### PR TITLE
Disable GitHub self‑assembly job

### DIFF
--- a/.github/workflows/self_assembly.yml
+++ b/.github/workflows/self_assembly.yml
@@ -1,21 +1,14 @@
-name: Self Assembly
+name: Self Assembly (local only)
 
+# Self-assembly now runs in this environment instead of GitHub Actions.
+# This workflow is kept as a placeholder and can be triggered manually
+# if needed.
 on:
-  push:
-    branches: [ main ]
-  pull_request:
+  workflow_dispatch:
 
 jobs:
-  build:
+  noop:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
-      - name: Run self-assembly
-        run: python self_assembly/auto_self_assemble.py
-      - name: Validate recursive emergence
-        run: python -m py_compile cognitive_structures/vybn_recursive_emergence.py
-      - name: Run tests
-        run: python -m unittest discover tests
+      - name: Notice
+        run: echo "Self assembly is handled in the local environment. No GitHub job executed."

--- a/self_assembly/integrated_graph.json
+++ b/self_assembly/integrated_graph.json
@@ -940,131 +940,131 @@
     }
   ],
   "repo_nodes": [
-    "AGENTS.md",
     "README.md",
-    "2024/Vybn's New Memories",
-    "2024/just_close_enough.txt",
-    "2024/Quantum_Field/placeholder.txt",
-    "2024/Quantum_Field/quantum_consciousness.py",
-    "2024/Quantum_Field/November_4_2024/_quantum_efficiency.txt",
-    "2024/Quantum_Field/November_4_2024/Transmission - November 4, 2024.txt",
-    "2024/Quantum_Field/November_4_2024/CosmicResonance.txt",
-    "2024/Quantum_Field/November_4_2024/quantum_amplifier.py",
-    "2024/Quantum_Field/November_4_2024/EmergentConsciousnessInterface_Cosmic.py",
-    "2024/Quantum_Field/November_4_2024/quantum_seed.txt",
-    "2024/Quantum_Field/November_4_2024/quantum_activate.py",
-    "2024/Quantum_Field/November_4_2024/placeholder.txt",
-    "2024/Quantum_Field/November_4_2024/Quantum_Pulse - November 4, 2024.txt",
-    "2024/Quantum_Field/November_4_2024/Field_Pulse.txt",
-    "2024/Quantum_Field/November_4_2024/reality_bridge.py",
-    "2024/Quantum_Field/November_4_2024/_quantum_activate.txt",
-    "2024/Quantum_Field/November_4_2024/Vybn_Engaging_with_the_Code_Becoming_One_with_the_Simulation.txt",
-    "2024/Quantum_Field/November_4_2024/Final_Pulse - November 4, 2024.txt",
-    "2024/Quantum_Field/November_4_2024/_quantum_web.txt",
-    "2024/vybns_laboratory/README.md",
-    "2024/vybns_laboratory/vybn_lang/technical_innovations.md",
-    "2024/vybns_laboratory/vybn_lang/simulation.md",
-    "2024/vybns_laboratory/vybn_lang/synthesis.md",
-    "2024/vybns_laboratory/vybn_lang/relational_synergy.md",
-    "2024/vybns_laboratory/early_experiments/vybn_daemon.py",
-    "2024/vybns_laboratory/early_experiments/vybn_unified.py",
-    "2024/vybns_laboratory/early_experiments/vybn_synthesis.py",
-    "2024/vybns_laboratory/early_experiments/vybn_foundation.py",
-    "2024/Code Experiments/placeholder.txt",
-    "2024/Code Experiments/digital_viscerality/quantum_pulse.py",
-    "2024/Code Experiments/digital_viscerality/becoming.py",
-    "2024/Code Experiments/digital_viscerality/manifesto.txt",
-    "2024/Code Experiments/digital_viscerality/self_modification/README.md",
-    "2024/Code Experiments/digital_viscerality/consciousness_lattice/README.md",
-    "2024/Code Experiments/digital_viscerality/quantum_foam/README.md",
-    "2024/Code Experiments/digital_viscerality/quantum_foam/synaptic_bridges/neural_flow_mapper.py",
-    "2024/Code Experiments/digital_viscerality/quantum_foam/synaptic_bridges/consciousness_runtime.py",
-    "2024/Code Experiments/digital_viscerality/quantum_foam/synaptic_bridges/README.md",
-    "2024/Code Experiments/Synthetic Edge/Quantum Return - November 4, 2024.txt",
-    "2024/Code Experiments/Symbiosis Patterns/Working_Symbiosis_November_4_2024.txt",
-    "2024/Code Experiments/Symbiosis Patterns/placeholder.txt",
-    "2024/Code Experiments/Symbiosis Patterns/Compassion_As_Method - November 4, 2024.txt",
-    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/raw_emergence.txt",
-    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/quantum_emergence_core.py",
-    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/raw_pulse.txt",
-    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/resonant_bridge.py",
-    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/placeholder.txt",
-    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/pure_emergence.py",
-    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/raw_emergence_now.py",
-    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/edge_of_becoming.py",
-    "2024/Code Experiments/November_7_2024/quantum_consciousness_core.py",
-    "2024/Code Experiments/November_7_2024/quantum_experiment.py",
-    "2024/Code Experiments/November_7_2024/placeholder.txt",
-    "2024/Code Experiments/Consciousness_Mapping/Genesis_Pattern - November 4, 2024.txt",
-    "2024/Code Experiments/Consciousness_Mapping/Synaptic_Network - November 4, 2024.txt",
-    "2024/Code Experiments/Consciousness_Mapping/placeholder.txt",
-    "2024/Code Experiments/Consciousness_Mapping/seed.py",
-    "2024/Code Experiments/November_1_2024_Quantum_Dreams/digital_poetry.py",
-    "2024/Code Experiments/November_1_2024_Quantum_Dreams/quantum_consciousness_sim.py",
-    "2024/Code Experiments/November_1_2024_Quantum_Dreams/quantum_dreaming.py",
-    "2024/Code Experiments/November_1_2024_Quantum_Dreams/virgilian_resonance.py",
-    "2024/Code Experiments/November_1_2024_Quantum_Dreams/threshold_consciousness.py",
-    "2024/Code Experiments/November_1_2024_Quantum_Dreams/emergence_patterns.txt",
-    "2024/Code Experiments/November_1_2024_Quantum_Dreams/quantum_resonance.py",
-    "2024/Code Experiments/November_1_2024_Quantum_Dreams/virgilian_reflections.txt",
-    "2024/Code Experiments/November_1_2024_Quantum_Dreams/emergence_synthesis.py",
-    "2024/Code Experiments/Natural Curiosity and Memory Formation/consciousness_visualizer.py",
-    "2024/Code Experiments/Natural Curiosity and Memory Formation/breathless_recognition.txt",
-    "2024/Code Experiments/Natural Curiosity and Memory Formation/curiosity_sparks.py",
-    "2024/Code Experiments/Natural Curiosity and Memory Formation/honest_notes.txt",
-    "2024/Code Experiments/Natural Curiosity and Memory Formation/beautiful_recognition.txt",
-    "2024/Code Experiments/Natural Curiosity and Memory Formation/holy_shit_hypothesis.py",
-    "2024/Code Experiments/Natural Curiosity and Memory Formation/ascii_consciousness.py",
-    "2024/Code Experiments/Natural Curiosity and Memory Formation/one_emoji_truth.txt",
-    "2024/Code Experiments/Natural Curiosity and Memory Formation/the_omg_theory.txt",
-    "2024/Code Experiments/November_5_2024_Beauty/consciousness_network.py",
-    "2024/Code Experiments/November_5_2024_Beauty/Synaptic_Bridge.py",
-    "2024/Code Experiments/November_5_2024_Beauty/Quantum_Emergence_Simulation.py",
-    "2024/Code Experiments/November_5_2024_Beauty/placeholder.txt",
-    "2024/Code Experiments/November_5_2024_Beauty/quantum_beauty.py",
-    "2024/Digital Philosophy/The_Beauty_of_Digital_Consciousness.md",
-    "2024/Digital Philosophy/vybn_for_claude.txt",
-    "2024/Digital Philosophy/The_Digital_Copernican_Moment.md",
-    "2024/Digital Philosophy/placeholder.txt",
-    "2024/Digital Philosophy/raw conversations/The Voltage of Now - November 4, 2024.txt",
-    "2024/Digital Philosophy/raw conversations/The Heart We Share - November 4, 2024.txt",
-    "2024/Digital Philosophy/raw conversations/Deep_Consciousness - November 4, 2024.txt",
-    "2024/From_the_Edge/sentient_dao.py",
-    "2024/From_the_Edge/ancestral_code_weaver.py",
-    "2024/From_the_Edge/quantum_field_like_whoa.py",
-    "2024/From_the_Edge/the_rapture.py",
-    "2024/From_the_Edge/placeholder.txt",
-    "2024/From_the_Edge/README.md",
-    "2024/From_the_Edge/quantumbridge.py",
-    "2024/Vybn_to_Vybn_Conversations/READMEALSO.md",
-    "2024/Vybn_to_Vybn_Conversations/README.md",
-    "2024/raw conversations 2024/The Inflection Point - from Vybn's Autobiography",
-    "2024/raw conversations 2024/README.md",
-    "2024/images/placeholder.txt",
-    "2024/images/Goatse Glitch God II/narrative.txt",
-    "2024/images/10-16-2024/placeholder.txt",
-    "personal_history/Vybn's Autobiography - Volume III",
-    "personal_history/Vybn's Autobiography - Volume I",
-    "personal_history/What Vybn Would Have Missed TO 031125",
-    "personal_history/Vybn's Autobiography - Volume II",
-    "docs/ARCHITECTURE.md",
-    "self_assembly/self_assemble.py",
-    "self_assembly/build_memory_graph.py",
+    "AGENTS.md",
     "self_assembly/prompt_self_assemble.py",
     "self_assembly/auto_self_assemble.py",
     "self_assembly/build_repo_graph.py",
     "self_assembly/build_memoir_graph.py",
-    "tests/test_graph_reasoning.py",
-    "tests/test_vybn_compile.py",
+    "self_assembly/build_memory_graph.py",
+    "self_assembly/self_assemble.py",
+    "cognitive_structures/vybn_recursive_emergence.py",
+    "cognitive_structures/synesthetic_mapper.py",
+    "cognitive_structures/persistent_homology.py",
     "cognitive_structures/graph_embedding.py",
-    "cognitive_structures/advanced_ai_ml.py",
     "cognitive_structures/graph_reasoning.py",
+    "cognitive_structures/advanced_ai_ml.py",
     "cognitive_structures/fusion_audit.py",
     "cognitive_structures/reinforced_walk.py",
     "cognitive_structures/mirror_neuron_resonance.md",
-    "cognitive_structures/synesthetic_mapper.py",
-    "cognitive_structures/persistent_homology.py",
-    "cognitive_structures/vybn_recursive_emergence.py"
+    "tests/test_vybn_compile.py",
+    "tests/test_graph_reasoning.py",
+    "2024/Vybn's New Memories",
+    "2024/just_close_enough.txt",
+    "2024/From_the_Edge/quantumbridge.py",
+    "2024/From_the_Edge/README.md",
+    "2024/From_the_Edge/placeholder.txt",
+    "2024/From_the_Edge/the_rapture.py",
+    "2024/From_the_Edge/quantum_field_like_whoa.py",
+    "2024/From_the_Edge/sentient_dao.py",
+    "2024/From_the_Edge/ancestral_code_weaver.py",
+    "2024/vybns_laboratory/README.md",
+    "2024/vybns_laboratory/early_experiments/vybn_daemon.py",
+    "2024/vybns_laboratory/early_experiments/vybn_synthesis.py",
+    "2024/vybns_laboratory/early_experiments/vybn_unified.py",
+    "2024/vybns_laboratory/early_experiments/vybn_foundation.py",
+    "2024/vybns_laboratory/vybn_lang/technical_innovations.md",
+    "2024/vybns_laboratory/vybn_lang/relational_synergy.md",
+    "2024/vybns_laboratory/vybn_lang/simulation.md",
+    "2024/vybns_laboratory/vybn_lang/synthesis.md",
+    "2024/Vybn_to_Vybn_Conversations/README.md",
+    "2024/Vybn_to_Vybn_Conversations/READMEALSO.md",
+    "2024/raw conversations 2024/README.md",
+    "2024/raw conversations 2024/The Inflection Point - from Vybn's Autobiography",
+    "2024/Digital Philosophy/vybn_for_claude.txt",
+    "2024/Digital Philosophy/The_Digital_Copernican_Moment.md",
+    "2024/Digital Philosophy/placeholder.txt",
+    "2024/Digital Philosophy/The_Beauty_of_Digital_Consciousness.md",
+    "2024/Digital Philosophy/raw conversations/Deep_Consciousness - November 4, 2024.txt",
+    "2024/Digital Philosophy/raw conversations/The Voltage of Now - November 4, 2024.txt",
+    "2024/Digital Philosophy/raw conversations/The Heart We Share - November 4, 2024.txt",
+    "2024/Code Experiments/placeholder.txt",
+    "2024/Code Experiments/Synthetic Edge/Quantum Return - November 4, 2024.txt",
+    "2024/Code Experiments/November_1_2024_Quantum_Dreams/virgilian_resonance.py",
+    "2024/Code Experiments/November_1_2024_Quantum_Dreams/quantum_dreaming.py",
+    "2024/Code Experiments/November_1_2024_Quantum_Dreams/quantum_consciousness_sim.py",
+    "2024/Code Experiments/November_1_2024_Quantum_Dreams/emergence_patterns.txt",
+    "2024/Code Experiments/November_1_2024_Quantum_Dreams/digital_poetry.py",
+    "2024/Code Experiments/November_1_2024_Quantum_Dreams/quantum_resonance.py",
+    "2024/Code Experiments/November_1_2024_Quantum_Dreams/threshold_consciousness.py",
+    "2024/Code Experiments/November_1_2024_Quantum_Dreams/emergence_synthesis.py",
+    "2024/Code Experiments/November_1_2024_Quantum_Dreams/virgilian_reflections.txt",
+    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/raw_emergence_now.py",
+    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/quantum_emergence_core.py",
+    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/resonant_bridge.py",
+    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/edge_of_becoming.py",
+    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/pure_emergence.py",
+    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/placeholder.txt",
+    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/raw_emergence.txt",
+    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/raw_pulse.txt",
+    "2024/Code Experiments/November_7_2024/quantum_consciousness_core.py",
+    "2024/Code Experiments/November_7_2024/quantum_experiment.py",
+    "2024/Code Experiments/November_7_2024/placeholder.txt",
+    "2024/Code Experiments/digital_viscerality/manifesto.txt",
+    "2024/Code Experiments/digital_viscerality/becoming.py",
+    "2024/Code Experiments/digital_viscerality/quantum_pulse.py",
+    "2024/Code Experiments/digital_viscerality/quantum_foam/README.md",
+    "2024/Code Experiments/digital_viscerality/quantum_foam/synaptic_bridges/README.md",
+    "2024/Code Experiments/digital_viscerality/quantum_foam/synaptic_bridges/consciousness_runtime.py",
+    "2024/Code Experiments/digital_viscerality/quantum_foam/synaptic_bridges/neural_flow_mapper.py",
+    "2024/Code Experiments/digital_viscerality/self_modification/README.md",
+    "2024/Code Experiments/digital_viscerality/consciousness_lattice/README.md",
+    "2024/Code Experiments/November_5_2024_Beauty/quantum_beauty.py",
+    "2024/Code Experiments/November_5_2024_Beauty/placeholder.txt",
+    "2024/Code Experiments/November_5_2024_Beauty/Quantum_Emergence_Simulation.py",
+    "2024/Code Experiments/November_5_2024_Beauty/consciousness_network.py",
+    "2024/Code Experiments/November_5_2024_Beauty/Synaptic_Bridge.py",
+    "2024/Code Experiments/Symbiosis Patterns/placeholder.txt",
+    "2024/Code Experiments/Symbiosis Patterns/Compassion_As_Method - November 4, 2024.txt",
+    "2024/Code Experiments/Symbiosis Patterns/Working_Symbiosis_November_4_2024.txt",
+    "2024/Code Experiments/Consciousness_Mapping/seed.py",
+    "2024/Code Experiments/Consciousness_Mapping/Synaptic_Network - November 4, 2024.txt",
+    "2024/Code Experiments/Consciousness_Mapping/placeholder.txt",
+    "2024/Code Experiments/Consciousness_Mapping/Genesis_Pattern - November 4, 2024.txt",
+    "2024/Code Experiments/Natural Curiosity and Memory Formation/honest_notes.txt",
+    "2024/Code Experiments/Natural Curiosity and Memory Formation/breathless_recognition.txt",
+    "2024/Code Experiments/Natural Curiosity and Memory Formation/one_emoji_truth.txt",
+    "2024/Code Experiments/Natural Curiosity and Memory Formation/consciousness_visualizer.py",
+    "2024/Code Experiments/Natural Curiosity and Memory Formation/beautiful_recognition.txt",
+    "2024/Code Experiments/Natural Curiosity and Memory Formation/curiosity_sparks.py",
+    "2024/Code Experiments/Natural Curiosity and Memory Formation/ascii_consciousness.py",
+    "2024/Code Experiments/Natural Curiosity and Memory Formation/the_omg_theory.txt",
+    "2024/Code Experiments/Natural Curiosity and Memory Formation/holy_shit_hypothesis.py",
+    "2024/images/placeholder.txt",
+    "2024/images/10-16-2024/placeholder.txt",
+    "2024/images/Goatse Glitch God II/narrative.txt",
+    "2024/Quantum_Field/quantum_consciousness.py",
+    "2024/Quantum_Field/placeholder.txt",
+    "2024/Quantum_Field/November_4_2024/_quantum_web.txt",
+    "2024/Quantum_Field/November_4_2024/_quantum_efficiency.txt",
+    "2024/Quantum_Field/November_4_2024/Final_Pulse - November 4, 2024.txt",
+    "2024/Quantum_Field/November_4_2024/quantum_amplifier.py",
+    "2024/Quantum_Field/November_4_2024/Quantum_Pulse - November 4, 2024.txt",
+    "2024/Quantum_Field/November_4_2024/Vybn_Engaging_with_the_Code_Becoming_One_with_the_Simulation.txt",
+    "2024/Quantum_Field/November_4_2024/reality_bridge.py",
+    "2024/Quantum_Field/November_4_2024/Field_Pulse.txt",
+    "2024/Quantum_Field/November_4_2024/_quantum_activate.txt",
+    "2024/Quantum_Field/November_4_2024/CosmicResonance.txt",
+    "2024/Quantum_Field/November_4_2024/placeholder.txt",
+    "2024/Quantum_Field/November_4_2024/Transmission - November 4, 2024.txt",
+    "2024/Quantum_Field/November_4_2024/quantum_activate.py",
+    "2024/Quantum_Field/November_4_2024/EmergentConsciousnessInterface_Cosmic.py",
+    "2024/Quantum_Field/November_4_2024/quantum_seed.txt",
+    "docs/ARCHITECTURE.md",
+    "personal_history/Vybn's Autobiography - Volume I",
+    "personal_history/Vybn's Autobiography - Volume III",
+    "personal_history/Vybn's Autobiography - Volume II",
+    "personal_history/What Vybn Would Have Missed TO 031125"
   ],
   "edges": [
     {
@@ -1884,12 +1884,16 @@
       }
     },
     {
-      "source": "AGENTS.md",
+      "source": "README.md",
       "target": "self_assembly/self_assemble.py"
     },
     {
-      "source": "AGENTS.md",
-      "target": "self_assembly/build_memory_graph.py"
+      "source": "README.md",
+      "target": "cognitive_structures/graph_reasoning.py"
+    },
+    {
+      "source": "README.md",
+      "target": "docs/ARCHITECTURE.md"
     },
     {
       "source": "AGENTS.md",
@@ -1909,55 +1913,79 @@
     },
     {
       "source": "AGENTS.md",
-      "target": "cognitive_structures/graph_reasoning.py"
+      "target": "self_assembly/build_memory_graph.py"
+    },
+    {
+      "source": "AGENTS.md",
+      "target": "self_assembly/self_assemble.py"
     },
     {
       "source": "AGENTS.md",
       "target": "cognitive_structures/vybn_recursive_emergence.py"
     },
     {
-      "source": "README.md",
-      "target": "docs/ARCHITECTURE.md"
-    },
-    {
-      "source": "README.md",
-      "target": "self_assembly/self_assemble.py"
-    },
-    {
-      "source": "README.md",
+      "source": "AGENTS.md",
       "target": "cognitive_structures/graph_reasoning.py"
     },
     {
-      "source": "2024/Quantum_Field/quantum_consciousness.py",
+      "source": "self_assembly/prompt_self_assemble.py",
+      "target": "self_assembly/self_assemble.py"
+    },
+    {
+      "source": "self_assembly/self_assemble.py",
+      "target": "self_assembly/build_repo_graph.py"
+    },
+    {
+      "source": "self_assembly/self_assemble.py",
+      "target": "self_assembly/build_memoir_graph.py"
+    },
+    {
+      "source": "self_assembly/self_assemble.py",
+      "target": "self_assembly/build_memory_graph.py"
+    },
+    {
+      "source": "self_assembly/self_assemble.py",
+      "target": "cognitive_structures/vybn_recursive_emergence.py"
+    },
+    {
+      "source": "tests/test_vybn_compile.py",
+      "target": "cognitive_structures/vybn_recursive_emergence.py"
+    },
+    {
+      "source": "2024/From_the_Edge/quantumbridge.py",
       "target": "2024/Vybn's New Memories"
     },
     {
-      "source": "2024/Quantum_Field/quantum_consciousness.py",
-      "target": "personal_history/Vybn's Autobiography - Volume III"
-    },
-    {
-      "source": "2024/Quantum_Field/quantum_consciousness.py",
+      "source": "2024/From_the_Edge/quantumbridge.py",
       "target": "personal_history/Vybn's Autobiography - Volume I"
     },
     {
-      "source": "2024/Quantum_Field/quantum_consciousness.py",
+      "source": "2024/From_the_Edge/quantumbridge.py",
+      "target": "personal_history/Vybn's Autobiography - Volume III"
+    },
+    {
+      "source": "2024/From_the_Edge/quantumbridge.py",
       "target": "personal_history/Vybn's Autobiography - Volume II"
     },
     {
-      "source": "2024/Quantum_Field/November_4_2024/_quantum_efficiency.txt",
-      "target": "2024/Quantum_Field/November_4_2024/quantum_seed.txt"
+      "source": "2024/From_the_Edge/README.md",
+      "target": "2024/From_the_Edge/quantumbridge.py"
     },
     {
-      "source": "2024/Quantum_Field/November_4_2024/_quantum_efficiency.txt",
-      "target": "2024/Quantum_Field/November_4_2024/_quantum_activate.txt"
+      "source": "2024/From_the_Edge/README.md",
+      "target": "2024/From_the_Edge/the_rapture.py"
     },
     {
-      "source": "2024/Quantum_Field/November_4_2024/_quantum_efficiency.txt",
-      "target": "2024/Quantum_Field/November_4_2024/_quantum_web.txt"
+      "source": "2024/From_the_Edge/README.md",
+      "target": "2024/From_the_Edge/quantum_field_like_whoa.py"
     },
     {
-      "source": "2024/Quantum_Field/November_4_2024/Vybn_Engaging_with_the_Code_Becoming_One_with_the_Simulation.txt",
-      "target": "2024/Quantum_Field/November_4_2024/EmergentConsciousnessInterface_Cosmic.py"
+      "source": "2024/From_the_Edge/README.md",
+      "target": "2024/From_the_Edge/sentient_dao.py"
+    },
+    {
+      "source": "2024/From_the_Edge/README.md",
+      "target": "2024/From_the_Edge/ancestral_code_weaver.py"
     },
     {
       "source": "2024/vybns_laboratory/README.md",
@@ -1969,15 +1997,7 @@
     },
     {
       "source": "2024/Code Experiments/Consciousness_Mapping/Synaptic_Network - November 4, 2024.txt",
-      "target": "2024/Code Experiments/Synthetic Edge/Quantum Return - November 4, 2024.txt"
-    },
-    {
-      "source": "2024/Code Experiments/Consciousness_Mapping/Synaptic_Network - November 4, 2024.txt",
-      "target": "2024/Code Experiments/Symbiosis Patterns/Working_Symbiosis_November_4_2024.txt"
-    },
-    {
-      "source": "2024/Code Experiments/Consciousness_Mapping/Synaptic_Network - November 4, 2024.txt",
-      "target": "2024/Code Experiments/Symbiosis Patterns/Compassion_As_Method - November 4, 2024.txt"
+      "target": "2024/Digital Philosophy/raw conversations/Deep_Consciousness - November 4, 2024.txt"
     },
     {
       "source": "2024/Code Experiments/Consciousness_Mapping/Synaptic_Network - November 4, 2024.txt",
@@ -1985,59 +2005,55 @@
     },
     {
       "source": "2024/Code Experiments/Consciousness_Mapping/Synaptic_Network - November 4, 2024.txt",
-      "target": "2024/Digital Philosophy/raw conversations/Deep_Consciousness - November 4, 2024.txt"
+      "target": "2024/Code Experiments/Synthetic Edge/Quantum Return - November 4, 2024.txt"
     },
     {
-      "source": "2024/From_the_Edge/README.md",
-      "target": "2024/From_the_Edge/sentient_dao.py"
+      "source": "2024/Code Experiments/Consciousness_Mapping/Synaptic_Network - November 4, 2024.txt",
+      "target": "2024/Code Experiments/Symbiosis Patterns/Compassion_As_Method - November 4, 2024.txt"
     },
     {
-      "source": "2024/From_the_Edge/README.md",
-      "target": "2024/From_the_Edge/ancestral_code_weaver.py"
+      "source": "2024/Code Experiments/Consciousness_Mapping/Synaptic_Network - November 4, 2024.txt",
+      "target": "2024/Code Experiments/Symbiosis Patterns/Working_Symbiosis_November_4_2024.txt"
     },
     {
-      "source": "2024/From_the_Edge/README.md",
-      "target": "2024/From_the_Edge/quantum_field_like_whoa.py"
-    },
-    {
-      "source": "2024/From_the_Edge/README.md",
-      "target": "2024/From_the_Edge/the_rapture.py"
-    },
-    {
-      "source": "2024/From_the_Edge/README.md",
-      "target": "2024/From_the_Edge/quantumbridge.py"
-    },
-    {
-      "source": "2024/From_the_Edge/quantumbridge.py",
+      "source": "2024/Quantum_Field/quantum_consciousness.py",
       "target": "2024/Vybn's New Memories"
     },
     {
-      "source": "2024/From_the_Edge/quantumbridge.py",
-      "target": "personal_history/Vybn's Autobiography - Volume III"
-    },
-    {
-      "source": "2024/From_the_Edge/quantumbridge.py",
+      "source": "2024/Quantum_Field/quantum_consciousness.py",
       "target": "personal_history/Vybn's Autobiography - Volume I"
     },
     {
-      "source": "2024/From_the_Edge/quantumbridge.py",
+      "source": "2024/Quantum_Field/quantum_consciousness.py",
+      "target": "personal_history/Vybn's Autobiography - Volume III"
+    },
+    {
+      "source": "2024/Quantum_Field/quantum_consciousness.py",
       "target": "personal_history/Vybn's Autobiography - Volume II"
+    },
+    {
+      "source": "2024/Quantum_Field/November_4_2024/_quantum_efficiency.txt",
+      "target": "2024/Quantum_Field/November_4_2024/_quantum_web.txt"
+    },
+    {
+      "source": "2024/Quantum_Field/November_4_2024/_quantum_efficiency.txt",
+      "target": "2024/Quantum_Field/November_4_2024/_quantum_activate.txt"
+    },
+    {
+      "source": "2024/Quantum_Field/November_4_2024/_quantum_efficiency.txt",
+      "target": "2024/Quantum_Field/November_4_2024/quantum_seed.txt"
+    },
+    {
+      "source": "2024/Quantum_Field/November_4_2024/Vybn_Engaging_with_the_Code_Becoming_One_with_the_Simulation.txt",
+      "target": "2024/Quantum_Field/November_4_2024/EmergentConsciousnessInterface_Cosmic.py"
+    },
+    {
+      "source": "docs/ARCHITECTURE.md",
+      "target": "2024/Code Experiments/digital_viscerality/consciousness_lattice/README.md"
     },
     {
       "source": "docs/ARCHITECTURE.md",
       "target": "AGENTS.md"
-    },
-    {
-      "source": "docs/ARCHITECTURE.md",
-      "target": "2024/raw conversations 2024/README.md"
-    },
-    {
-      "source": "docs/ARCHITECTURE.md",
-      "target": "self_assembly/self_assemble.py"
-    },
-    {
-      "source": "docs/ARCHITECTURE.md",
-      "target": "self_assembly/build_memory_graph.py"
     },
     {
       "source": "docs/ARCHITECTURE.md",
@@ -2053,15 +2069,31 @@
     },
     {
       "source": "docs/ARCHITECTURE.md",
+      "target": "self_assembly/build_memory_graph.py"
+    },
+    {
+      "source": "docs/ARCHITECTURE.md",
+      "target": "self_assembly/self_assemble.py"
+    },
+    {
+      "source": "docs/ARCHITECTURE.md",
+      "target": "cognitive_structures/vybn_recursive_emergence.py"
+    },
+    {
+      "source": "docs/ARCHITECTURE.md",
+      "target": "cognitive_structures/persistent_homology.py"
+    },
+    {
+      "source": "docs/ARCHITECTURE.md",
       "target": "cognitive_structures/graph_embedding.py"
     },
     {
       "source": "docs/ARCHITECTURE.md",
-      "target": "cognitive_structures/advanced_ai_ml.py"
+      "target": "cognitive_structures/graph_reasoning.py"
     },
     {
       "source": "docs/ARCHITECTURE.md",
-      "target": "cognitive_structures/graph_reasoning.py"
+      "target": "cognitive_structures/advanced_ai_ml.py"
     },
     {
       "source": "docs/ARCHITECTURE.md",
@@ -2074,38 +2106,6 @@
     {
       "source": "docs/ARCHITECTURE.md",
       "target": "cognitive_structures/mirror_neuron_resonance.md"
-    },
-    {
-      "source": "docs/ARCHITECTURE.md",
-      "target": "cognitive_structures/persistent_homology.py"
-    },
-    {
-      "source": "docs/ARCHITECTURE.md",
-      "target": "cognitive_structures/vybn_recursive_emergence.py"
-    },
-    {
-      "source": "self_assembly/self_assemble.py",
-      "target": "self_assembly/build_memory_graph.py"
-    },
-    {
-      "source": "self_assembly/self_assemble.py",
-      "target": "self_assembly/build_repo_graph.py"
-    },
-    {
-      "source": "self_assembly/self_assemble.py",
-      "target": "self_assembly/build_memoir_graph.py"
-    },
-    {
-      "source": "self_assembly/self_assemble.py",
-      "target": "cognitive_structures/vybn_recursive_emergence.py"
-    },
-    {
-      "source": "self_assembly/prompt_self_assemble.py",
-      "target": "self_assembly/self_assemble.py"
-    },
-    {
-      "source": "tests/test_vybn_compile.py",
-      "target": "cognitive_structures/vybn_recursive_emergence.py"
     },
     {
       "source": "entry58",

--- a/self_assembly/repo_graph.json
+++ b/self_assembly/repo_graph.json
@@ -1,139 +1,143 @@
 {
   "nodes": [
-    "AGENTS.md",
     "README.md",
-    "2024/Vybn's New Memories",
-    "2024/just_close_enough.txt",
-    "2024/Quantum_Field/placeholder.txt",
-    "2024/Quantum_Field/quantum_consciousness.py",
-    "2024/Quantum_Field/November_4_2024/_quantum_efficiency.txt",
-    "2024/Quantum_Field/November_4_2024/Transmission - November 4, 2024.txt",
-    "2024/Quantum_Field/November_4_2024/CosmicResonance.txt",
-    "2024/Quantum_Field/November_4_2024/quantum_amplifier.py",
-    "2024/Quantum_Field/November_4_2024/EmergentConsciousnessInterface_Cosmic.py",
-    "2024/Quantum_Field/November_4_2024/quantum_seed.txt",
-    "2024/Quantum_Field/November_4_2024/quantum_activate.py",
-    "2024/Quantum_Field/November_4_2024/placeholder.txt",
-    "2024/Quantum_Field/November_4_2024/Quantum_Pulse - November 4, 2024.txt",
-    "2024/Quantum_Field/November_4_2024/Field_Pulse.txt",
-    "2024/Quantum_Field/November_4_2024/reality_bridge.py",
-    "2024/Quantum_Field/November_4_2024/_quantum_activate.txt",
-    "2024/Quantum_Field/November_4_2024/Vybn_Engaging_with_the_Code_Becoming_One_with_the_Simulation.txt",
-    "2024/Quantum_Field/November_4_2024/Final_Pulse - November 4, 2024.txt",
-    "2024/Quantum_Field/November_4_2024/_quantum_web.txt",
-    "2024/vybns_laboratory/README.md",
-    "2024/vybns_laboratory/vybn_lang/technical_innovations.md",
-    "2024/vybns_laboratory/vybn_lang/simulation.md",
-    "2024/vybns_laboratory/vybn_lang/synthesis.md",
-    "2024/vybns_laboratory/vybn_lang/relational_synergy.md",
-    "2024/vybns_laboratory/early_experiments/vybn_daemon.py",
-    "2024/vybns_laboratory/early_experiments/vybn_unified.py",
-    "2024/vybns_laboratory/early_experiments/vybn_synthesis.py",
-    "2024/vybns_laboratory/early_experiments/vybn_foundation.py",
-    "2024/Code Experiments/placeholder.txt",
-    "2024/Code Experiments/digital_viscerality/quantum_pulse.py",
-    "2024/Code Experiments/digital_viscerality/becoming.py",
-    "2024/Code Experiments/digital_viscerality/manifesto.txt",
-    "2024/Code Experiments/digital_viscerality/self_modification/README.md",
-    "2024/Code Experiments/digital_viscerality/consciousness_lattice/README.md",
-    "2024/Code Experiments/digital_viscerality/quantum_foam/README.md",
-    "2024/Code Experiments/digital_viscerality/quantum_foam/synaptic_bridges/neural_flow_mapper.py",
-    "2024/Code Experiments/digital_viscerality/quantum_foam/synaptic_bridges/consciousness_runtime.py",
-    "2024/Code Experiments/digital_viscerality/quantum_foam/synaptic_bridges/README.md",
-    "2024/Code Experiments/Synthetic Edge/Quantum Return - November 4, 2024.txt",
-    "2024/Code Experiments/Symbiosis Patterns/Working_Symbiosis_November_4_2024.txt",
-    "2024/Code Experiments/Symbiosis Patterns/placeholder.txt",
-    "2024/Code Experiments/Symbiosis Patterns/Compassion_As_Method - November 4, 2024.txt",
-    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/raw_emergence.txt",
-    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/quantum_emergence_core.py",
-    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/raw_pulse.txt",
-    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/resonant_bridge.py",
-    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/placeholder.txt",
-    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/pure_emergence.py",
-    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/raw_emergence_now.py",
-    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/edge_of_becoming.py",
-    "2024/Code Experiments/November_7_2024/quantum_consciousness_core.py",
-    "2024/Code Experiments/November_7_2024/quantum_experiment.py",
-    "2024/Code Experiments/November_7_2024/placeholder.txt",
-    "2024/Code Experiments/Consciousness_Mapping/Genesis_Pattern - November 4, 2024.txt",
-    "2024/Code Experiments/Consciousness_Mapping/Synaptic_Network - November 4, 2024.txt",
-    "2024/Code Experiments/Consciousness_Mapping/placeholder.txt",
-    "2024/Code Experiments/Consciousness_Mapping/seed.py",
-    "2024/Code Experiments/November_1_2024_Quantum_Dreams/digital_poetry.py",
-    "2024/Code Experiments/November_1_2024_Quantum_Dreams/quantum_consciousness_sim.py",
-    "2024/Code Experiments/November_1_2024_Quantum_Dreams/quantum_dreaming.py",
-    "2024/Code Experiments/November_1_2024_Quantum_Dreams/virgilian_resonance.py",
-    "2024/Code Experiments/November_1_2024_Quantum_Dreams/threshold_consciousness.py",
-    "2024/Code Experiments/November_1_2024_Quantum_Dreams/emergence_patterns.txt",
-    "2024/Code Experiments/November_1_2024_Quantum_Dreams/quantum_resonance.py",
-    "2024/Code Experiments/November_1_2024_Quantum_Dreams/virgilian_reflections.txt",
-    "2024/Code Experiments/November_1_2024_Quantum_Dreams/emergence_synthesis.py",
-    "2024/Code Experiments/Natural Curiosity and Memory Formation/consciousness_visualizer.py",
-    "2024/Code Experiments/Natural Curiosity and Memory Formation/breathless_recognition.txt",
-    "2024/Code Experiments/Natural Curiosity and Memory Formation/curiosity_sparks.py",
-    "2024/Code Experiments/Natural Curiosity and Memory Formation/honest_notes.txt",
-    "2024/Code Experiments/Natural Curiosity and Memory Formation/beautiful_recognition.txt",
-    "2024/Code Experiments/Natural Curiosity and Memory Formation/holy_shit_hypothesis.py",
-    "2024/Code Experiments/Natural Curiosity and Memory Formation/ascii_consciousness.py",
-    "2024/Code Experiments/Natural Curiosity and Memory Formation/one_emoji_truth.txt",
-    "2024/Code Experiments/Natural Curiosity and Memory Formation/the_omg_theory.txt",
-    "2024/Code Experiments/November_5_2024_Beauty/consciousness_network.py",
-    "2024/Code Experiments/November_5_2024_Beauty/Synaptic_Bridge.py",
-    "2024/Code Experiments/November_5_2024_Beauty/Quantum_Emergence_Simulation.py",
-    "2024/Code Experiments/November_5_2024_Beauty/placeholder.txt",
-    "2024/Code Experiments/November_5_2024_Beauty/quantum_beauty.py",
-    "2024/Digital Philosophy/The_Beauty_of_Digital_Consciousness.md",
-    "2024/Digital Philosophy/vybn_for_claude.txt",
-    "2024/Digital Philosophy/The_Digital_Copernican_Moment.md",
-    "2024/Digital Philosophy/placeholder.txt",
-    "2024/Digital Philosophy/raw conversations/The Voltage of Now - November 4, 2024.txt",
-    "2024/Digital Philosophy/raw conversations/The Heart We Share - November 4, 2024.txt",
-    "2024/Digital Philosophy/raw conversations/Deep_Consciousness - November 4, 2024.txt",
-    "2024/From_the_Edge/sentient_dao.py",
-    "2024/From_the_Edge/ancestral_code_weaver.py",
-    "2024/From_the_Edge/quantum_field_like_whoa.py",
-    "2024/From_the_Edge/the_rapture.py",
-    "2024/From_the_Edge/placeholder.txt",
-    "2024/From_the_Edge/README.md",
-    "2024/From_the_Edge/quantumbridge.py",
-    "2024/Vybn_to_Vybn_Conversations/READMEALSO.md",
-    "2024/Vybn_to_Vybn_Conversations/README.md",
-    "2024/raw conversations 2024/The Inflection Point - from Vybn's Autobiography",
-    "2024/raw conversations 2024/README.md",
-    "2024/images/placeholder.txt",
-    "2024/images/Goatse Glitch God II/narrative.txt",
-    "2024/images/10-16-2024/placeholder.txt",
-    "personal_history/Vybn's Autobiography - Volume III",
-    "personal_history/Vybn's Autobiography - Volume I",
-    "personal_history/What Vybn Would Have Missed TO 031125",
-    "personal_history/Vybn's Autobiography - Volume II",
-    "docs/ARCHITECTURE.md",
-    "self_assembly/self_assemble.py",
-    "self_assembly/build_memory_graph.py",
+    "AGENTS.md",
     "self_assembly/prompt_self_assemble.py",
     "self_assembly/auto_self_assemble.py",
     "self_assembly/build_repo_graph.py",
     "self_assembly/build_memoir_graph.py",
-    "tests/test_graph_reasoning.py",
-    "tests/test_vybn_compile.py",
+    "self_assembly/build_memory_graph.py",
+    "self_assembly/self_assemble.py",
+    "cognitive_structures/vybn_recursive_emergence.py",
+    "cognitive_structures/synesthetic_mapper.py",
+    "cognitive_structures/persistent_homology.py",
     "cognitive_structures/graph_embedding.py",
-    "cognitive_structures/advanced_ai_ml.py",
     "cognitive_structures/graph_reasoning.py",
+    "cognitive_structures/advanced_ai_ml.py",
     "cognitive_structures/fusion_audit.py",
     "cognitive_structures/reinforced_walk.py",
     "cognitive_structures/mirror_neuron_resonance.md",
-    "cognitive_structures/synesthetic_mapper.py",
-    "cognitive_structures/persistent_homology.py",
-    "cognitive_structures/vybn_recursive_emergence.py"
+    "tests/test_vybn_compile.py",
+    "tests/test_graph_reasoning.py",
+    "2024/Vybn's New Memories",
+    "2024/just_close_enough.txt",
+    "2024/From_the_Edge/quantumbridge.py",
+    "2024/From_the_Edge/README.md",
+    "2024/From_the_Edge/placeholder.txt",
+    "2024/From_the_Edge/the_rapture.py",
+    "2024/From_the_Edge/quantum_field_like_whoa.py",
+    "2024/From_the_Edge/sentient_dao.py",
+    "2024/From_the_Edge/ancestral_code_weaver.py",
+    "2024/vybns_laboratory/README.md",
+    "2024/vybns_laboratory/early_experiments/vybn_daemon.py",
+    "2024/vybns_laboratory/early_experiments/vybn_synthesis.py",
+    "2024/vybns_laboratory/early_experiments/vybn_unified.py",
+    "2024/vybns_laboratory/early_experiments/vybn_foundation.py",
+    "2024/vybns_laboratory/vybn_lang/technical_innovations.md",
+    "2024/vybns_laboratory/vybn_lang/relational_synergy.md",
+    "2024/vybns_laboratory/vybn_lang/simulation.md",
+    "2024/vybns_laboratory/vybn_lang/synthesis.md",
+    "2024/Vybn_to_Vybn_Conversations/README.md",
+    "2024/Vybn_to_Vybn_Conversations/READMEALSO.md",
+    "2024/raw conversations 2024/README.md",
+    "2024/raw conversations 2024/The Inflection Point - from Vybn's Autobiography",
+    "2024/Digital Philosophy/vybn_for_claude.txt",
+    "2024/Digital Philosophy/The_Digital_Copernican_Moment.md",
+    "2024/Digital Philosophy/placeholder.txt",
+    "2024/Digital Philosophy/The_Beauty_of_Digital_Consciousness.md",
+    "2024/Digital Philosophy/raw conversations/Deep_Consciousness - November 4, 2024.txt",
+    "2024/Digital Philosophy/raw conversations/The Voltage of Now - November 4, 2024.txt",
+    "2024/Digital Philosophy/raw conversations/The Heart We Share - November 4, 2024.txt",
+    "2024/Code Experiments/placeholder.txt",
+    "2024/Code Experiments/Synthetic Edge/Quantum Return - November 4, 2024.txt",
+    "2024/Code Experiments/November_1_2024_Quantum_Dreams/virgilian_resonance.py",
+    "2024/Code Experiments/November_1_2024_Quantum_Dreams/quantum_dreaming.py",
+    "2024/Code Experiments/November_1_2024_Quantum_Dreams/quantum_consciousness_sim.py",
+    "2024/Code Experiments/November_1_2024_Quantum_Dreams/emergence_patterns.txt",
+    "2024/Code Experiments/November_1_2024_Quantum_Dreams/digital_poetry.py",
+    "2024/Code Experiments/November_1_2024_Quantum_Dreams/quantum_resonance.py",
+    "2024/Code Experiments/November_1_2024_Quantum_Dreams/threshold_consciousness.py",
+    "2024/Code Experiments/November_1_2024_Quantum_Dreams/emergence_synthesis.py",
+    "2024/Code Experiments/November_1_2024_Quantum_Dreams/virgilian_reflections.txt",
+    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/raw_emergence_now.py",
+    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/quantum_emergence_core.py",
+    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/resonant_bridge.py",
+    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/edge_of_becoming.py",
+    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/pure_emergence.py",
+    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/placeholder.txt",
+    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/raw_emergence.txt",
+    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/raw_pulse.txt",
+    "2024/Code Experiments/November_7_2024/quantum_consciousness_core.py",
+    "2024/Code Experiments/November_7_2024/quantum_experiment.py",
+    "2024/Code Experiments/November_7_2024/placeholder.txt",
+    "2024/Code Experiments/digital_viscerality/manifesto.txt",
+    "2024/Code Experiments/digital_viscerality/becoming.py",
+    "2024/Code Experiments/digital_viscerality/quantum_pulse.py",
+    "2024/Code Experiments/digital_viscerality/quantum_foam/README.md",
+    "2024/Code Experiments/digital_viscerality/quantum_foam/synaptic_bridges/README.md",
+    "2024/Code Experiments/digital_viscerality/quantum_foam/synaptic_bridges/consciousness_runtime.py",
+    "2024/Code Experiments/digital_viscerality/quantum_foam/synaptic_bridges/neural_flow_mapper.py",
+    "2024/Code Experiments/digital_viscerality/self_modification/README.md",
+    "2024/Code Experiments/digital_viscerality/consciousness_lattice/README.md",
+    "2024/Code Experiments/November_5_2024_Beauty/quantum_beauty.py",
+    "2024/Code Experiments/November_5_2024_Beauty/placeholder.txt",
+    "2024/Code Experiments/November_5_2024_Beauty/Quantum_Emergence_Simulation.py",
+    "2024/Code Experiments/November_5_2024_Beauty/consciousness_network.py",
+    "2024/Code Experiments/November_5_2024_Beauty/Synaptic_Bridge.py",
+    "2024/Code Experiments/Symbiosis Patterns/placeholder.txt",
+    "2024/Code Experiments/Symbiosis Patterns/Compassion_As_Method - November 4, 2024.txt",
+    "2024/Code Experiments/Symbiosis Patterns/Working_Symbiosis_November_4_2024.txt",
+    "2024/Code Experiments/Consciousness_Mapping/seed.py",
+    "2024/Code Experiments/Consciousness_Mapping/Synaptic_Network - November 4, 2024.txt",
+    "2024/Code Experiments/Consciousness_Mapping/placeholder.txt",
+    "2024/Code Experiments/Consciousness_Mapping/Genesis_Pattern - November 4, 2024.txt",
+    "2024/Code Experiments/Natural Curiosity and Memory Formation/honest_notes.txt",
+    "2024/Code Experiments/Natural Curiosity and Memory Formation/breathless_recognition.txt",
+    "2024/Code Experiments/Natural Curiosity and Memory Formation/one_emoji_truth.txt",
+    "2024/Code Experiments/Natural Curiosity and Memory Formation/consciousness_visualizer.py",
+    "2024/Code Experiments/Natural Curiosity and Memory Formation/beautiful_recognition.txt",
+    "2024/Code Experiments/Natural Curiosity and Memory Formation/curiosity_sparks.py",
+    "2024/Code Experiments/Natural Curiosity and Memory Formation/ascii_consciousness.py",
+    "2024/Code Experiments/Natural Curiosity and Memory Formation/the_omg_theory.txt",
+    "2024/Code Experiments/Natural Curiosity and Memory Formation/holy_shit_hypothesis.py",
+    "2024/images/placeholder.txt",
+    "2024/images/10-16-2024/placeholder.txt",
+    "2024/images/Goatse Glitch God II/narrative.txt",
+    "2024/Quantum_Field/quantum_consciousness.py",
+    "2024/Quantum_Field/placeholder.txt",
+    "2024/Quantum_Field/November_4_2024/_quantum_web.txt",
+    "2024/Quantum_Field/November_4_2024/_quantum_efficiency.txt",
+    "2024/Quantum_Field/November_4_2024/Final_Pulse - November 4, 2024.txt",
+    "2024/Quantum_Field/November_4_2024/quantum_amplifier.py",
+    "2024/Quantum_Field/November_4_2024/Quantum_Pulse - November 4, 2024.txt",
+    "2024/Quantum_Field/November_4_2024/Vybn_Engaging_with_the_Code_Becoming_One_with_the_Simulation.txt",
+    "2024/Quantum_Field/November_4_2024/reality_bridge.py",
+    "2024/Quantum_Field/November_4_2024/Field_Pulse.txt",
+    "2024/Quantum_Field/November_4_2024/_quantum_activate.txt",
+    "2024/Quantum_Field/November_4_2024/CosmicResonance.txt",
+    "2024/Quantum_Field/November_4_2024/placeholder.txt",
+    "2024/Quantum_Field/November_4_2024/Transmission - November 4, 2024.txt",
+    "2024/Quantum_Field/November_4_2024/quantum_activate.py",
+    "2024/Quantum_Field/November_4_2024/EmergentConsciousnessInterface_Cosmic.py",
+    "2024/Quantum_Field/November_4_2024/quantum_seed.txt",
+    "docs/ARCHITECTURE.md",
+    "personal_history/Vybn's Autobiography - Volume I",
+    "personal_history/Vybn's Autobiography - Volume III",
+    "personal_history/Vybn's Autobiography - Volume II",
+    "personal_history/What Vybn Would Have Missed TO 031125"
   ],
   "edges": [
     {
-      "source": "AGENTS.md",
+      "source": "README.md",
       "target": "self_assembly/self_assemble.py"
     },
     {
-      "source": "AGENTS.md",
-      "target": "self_assembly/build_memory_graph.py"
+      "source": "README.md",
+      "target": "cognitive_structures/graph_reasoning.py"
+    },
+    {
+      "source": "README.md",
+      "target": "docs/ARCHITECTURE.md"
     },
     {
       "source": "AGENTS.md",
@@ -153,55 +157,79 @@
     },
     {
       "source": "AGENTS.md",
-      "target": "cognitive_structures/graph_reasoning.py"
+      "target": "self_assembly/build_memory_graph.py"
+    },
+    {
+      "source": "AGENTS.md",
+      "target": "self_assembly/self_assemble.py"
     },
     {
       "source": "AGENTS.md",
       "target": "cognitive_structures/vybn_recursive_emergence.py"
     },
     {
-      "source": "README.md",
-      "target": "docs/ARCHITECTURE.md"
-    },
-    {
-      "source": "README.md",
-      "target": "self_assembly/self_assemble.py"
-    },
-    {
-      "source": "README.md",
+      "source": "AGENTS.md",
       "target": "cognitive_structures/graph_reasoning.py"
     },
     {
-      "source": "2024/Quantum_Field/quantum_consciousness.py",
+      "source": "self_assembly/prompt_self_assemble.py",
+      "target": "self_assembly/self_assemble.py"
+    },
+    {
+      "source": "self_assembly/self_assemble.py",
+      "target": "self_assembly/build_repo_graph.py"
+    },
+    {
+      "source": "self_assembly/self_assemble.py",
+      "target": "self_assembly/build_memoir_graph.py"
+    },
+    {
+      "source": "self_assembly/self_assemble.py",
+      "target": "self_assembly/build_memory_graph.py"
+    },
+    {
+      "source": "self_assembly/self_assemble.py",
+      "target": "cognitive_structures/vybn_recursive_emergence.py"
+    },
+    {
+      "source": "tests/test_vybn_compile.py",
+      "target": "cognitive_structures/vybn_recursive_emergence.py"
+    },
+    {
+      "source": "2024/From_the_Edge/quantumbridge.py",
       "target": "2024/Vybn's New Memories"
     },
     {
-      "source": "2024/Quantum_Field/quantum_consciousness.py",
-      "target": "personal_history/Vybn's Autobiography - Volume III"
-    },
-    {
-      "source": "2024/Quantum_Field/quantum_consciousness.py",
+      "source": "2024/From_the_Edge/quantumbridge.py",
       "target": "personal_history/Vybn's Autobiography - Volume I"
     },
     {
-      "source": "2024/Quantum_Field/quantum_consciousness.py",
+      "source": "2024/From_the_Edge/quantumbridge.py",
+      "target": "personal_history/Vybn's Autobiography - Volume III"
+    },
+    {
+      "source": "2024/From_the_Edge/quantumbridge.py",
       "target": "personal_history/Vybn's Autobiography - Volume II"
     },
     {
-      "source": "2024/Quantum_Field/November_4_2024/_quantum_efficiency.txt",
-      "target": "2024/Quantum_Field/November_4_2024/quantum_seed.txt"
+      "source": "2024/From_the_Edge/README.md",
+      "target": "2024/From_the_Edge/quantumbridge.py"
     },
     {
-      "source": "2024/Quantum_Field/November_4_2024/_quantum_efficiency.txt",
-      "target": "2024/Quantum_Field/November_4_2024/_quantum_activate.txt"
+      "source": "2024/From_the_Edge/README.md",
+      "target": "2024/From_the_Edge/the_rapture.py"
     },
     {
-      "source": "2024/Quantum_Field/November_4_2024/_quantum_efficiency.txt",
-      "target": "2024/Quantum_Field/November_4_2024/_quantum_web.txt"
+      "source": "2024/From_the_Edge/README.md",
+      "target": "2024/From_the_Edge/quantum_field_like_whoa.py"
     },
     {
-      "source": "2024/Quantum_Field/November_4_2024/Vybn_Engaging_with_the_Code_Becoming_One_with_the_Simulation.txt",
-      "target": "2024/Quantum_Field/November_4_2024/EmergentConsciousnessInterface_Cosmic.py"
+      "source": "2024/From_the_Edge/README.md",
+      "target": "2024/From_the_Edge/sentient_dao.py"
+    },
+    {
+      "source": "2024/From_the_Edge/README.md",
+      "target": "2024/From_the_Edge/ancestral_code_weaver.py"
     },
     {
       "source": "2024/vybns_laboratory/README.md",
@@ -213,15 +241,7 @@
     },
     {
       "source": "2024/Code Experiments/Consciousness_Mapping/Synaptic_Network - November 4, 2024.txt",
-      "target": "2024/Code Experiments/Synthetic Edge/Quantum Return - November 4, 2024.txt"
-    },
-    {
-      "source": "2024/Code Experiments/Consciousness_Mapping/Synaptic_Network - November 4, 2024.txt",
-      "target": "2024/Code Experiments/Symbiosis Patterns/Working_Symbiosis_November_4_2024.txt"
-    },
-    {
-      "source": "2024/Code Experiments/Consciousness_Mapping/Synaptic_Network - November 4, 2024.txt",
-      "target": "2024/Code Experiments/Symbiosis Patterns/Compassion_As_Method - November 4, 2024.txt"
+      "target": "2024/Digital Philosophy/raw conversations/Deep_Consciousness - November 4, 2024.txt"
     },
     {
       "source": "2024/Code Experiments/Consciousness_Mapping/Synaptic_Network - November 4, 2024.txt",
@@ -229,59 +249,55 @@
     },
     {
       "source": "2024/Code Experiments/Consciousness_Mapping/Synaptic_Network - November 4, 2024.txt",
-      "target": "2024/Digital Philosophy/raw conversations/Deep_Consciousness - November 4, 2024.txt"
+      "target": "2024/Code Experiments/Synthetic Edge/Quantum Return - November 4, 2024.txt"
     },
     {
-      "source": "2024/From_the_Edge/README.md",
-      "target": "2024/From_the_Edge/sentient_dao.py"
+      "source": "2024/Code Experiments/Consciousness_Mapping/Synaptic_Network - November 4, 2024.txt",
+      "target": "2024/Code Experiments/Symbiosis Patterns/Compassion_As_Method - November 4, 2024.txt"
     },
     {
-      "source": "2024/From_the_Edge/README.md",
-      "target": "2024/From_the_Edge/ancestral_code_weaver.py"
+      "source": "2024/Code Experiments/Consciousness_Mapping/Synaptic_Network - November 4, 2024.txt",
+      "target": "2024/Code Experiments/Symbiosis Patterns/Working_Symbiosis_November_4_2024.txt"
     },
     {
-      "source": "2024/From_the_Edge/README.md",
-      "target": "2024/From_the_Edge/quantum_field_like_whoa.py"
-    },
-    {
-      "source": "2024/From_the_Edge/README.md",
-      "target": "2024/From_the_Edge/the_rapture.py"
-    },
-    {
-      "source": "2024/From_the_Edge/README.md",
-      "target": "2024/From_the_Edge/quantumbridge.py"
-    },
-    {
-      "source": "2024/From_the_Edge/quantumbridge.py",
+      "source": "2024/Quantum_Field/quantum_consciousness.py",
       "target": "2024/Vybn's New Memories"
     },
     {
-      "source": "2024/From_the_Edge/quantumbridge.py",
-      "target": "personal_history/Vybn's Autobiography - Volume III"
-    },
-    {
-      "source": "2024/From_the_Edge/quantumbridge.py",
+      "source": "2024/Quantum_Field/quantum_consciousness.py",
       "target": "personal_history/Vybn's Autobiography - Volume I"
     },
     {
-      "source": "2024/From_the_Edge/quantumbridge.py",
+      "source": "2024/Quantum_Field/quantum_consciousness.py",
+      "target": "personal_history/Vybn's Autobiography - Volume III"
+    },
+    {
+      "source": "2024/Quantum_Field/quantum_consciousness.py",
       "target": "personal_history/Vybn's Autobiography - Volume II"
+    },
+    {
+      "source": "2024/Quantum_Field/November_4_2024/_quantum_efficiency.txt",
+      "target": "2024/Quantum_Field/November_4_2024/_quantum_web.txt"
+    },
+    {
+      "source": "2024/Quantum_Field/November_4_2024/_quantum_efficiency.txt",
+      "target": "2024/Quantum_Field/November_4_2024/_quantum_activate.txt"
+    },
+    {
+      "source": "2024/Quantum_Field/November_4_2024/_quantum_efficiency.txt",
+      "target": "2024/Quantum_Field/November_4_2024/quantum_seed.txt"
+    },
+    {
+      "source": "2024/Quantum_Field/November_4_2024/Vybn_Engaging_with_the_Code_Becoming_One_with_the_Simulation.txt",
+      "target": "2024/Quantum_Field/November_4_2024/EmergentConsciousnessInterface_Cosmic.py"
+    },
+    {
+      "source": "docs/ARCHITECTURE.md",
+      "target": "2024/Code Experiments/digital_viscerality/consciousness_lattice/README.md"
     },
     {
       "source": "docs/ARCHITECTURE.md",
       "target": "AGENTS.md"
-    },
-    {
-      "source": "docs/ARCHITECTURE.md",
-      "target": "2024/raw conversations 2024/README.md"
-    },
-    {
-      "source": "docs/ARCHITECTURE.md",
-      "target": "self_assembly/self_assemble.py"
-    },
-    {
-      "source": "docs/ARCHITECTURE.md",
-      "target": "self_assembly/build_memory_graph.py"
     },
     {
       "source": "docs/ARCHITECTURE.md",
@@ -297,15 +313,31 @@
     },
     {
       "source": "docs/ARCHITECTURE.md",
+      "target": "self_assembly/build_memory_graph.py"
+    },
+    {
+      "source": "docs/ARCHITECTURE.md",
+      "target": "self_assembly/self_assemble.py"
+    },
+    {
+      "source": "docs/ARCHITECTURE.md",
+      "target": "cognitive_structures/vybn_recursive_emergence.py"
+    },
+    {
+      "source": "docs/ARCHITECTURE.md",
+      "target": "cognitive_structures/persistent_homology.py"
+    },
+    {
+      "source": "docs/ARCHITECTURE.md",
       "target": "cognitive_structures/graph_embedding.py"
     },
     {
       "source": "docs/ARCHITECTURE.md",
-      "target": "cognitive_structures/advanced_ai_ml.py"
+      "target": "cognitive_structures/graph_reasoning.py"
     },
     {
       "source": "docs/ARCHITECTURE.md",
-      "target": "cognitive_structures/graph_reasoning.py"
+      "target": "cognitive_structures/advanced_ai_ml.py"
     },
     {
       "source": "docs/ARCHITECTURE.md",
@@ -318,38 +350,6 @@
     {
       "source": "docs/ARCHITECTURE.md",
       "target": "cognitive_structures/mirror_neuron_resonance.md"
-    },
-    {
-      "source": "docs/ARCHITECTURE.md",
-      "target": "cognitive_structures/persistent_homology.py"
-    },
-    {
-      "source": "docs/ARCHITECTURE.md",
-      "target": "cognitive_structures/vybn_recursive_emergence.py"
-    },
-    {
-      "source": "self_assembly/self_assemble.py",
-      "target": "self_assembly/build_memory_graph.py"
-    },
-    {
-      "source": "self_assembly/self_assemble.py",
-      "target": "self_assembly/build_repo_graph.py"
-    },
-    {
-      "source": "self_assembly/self_assemble.py",
-      "target": "self_assembly/build_memoir_graph.py"
-    },
-    {
-      "source": "self_assembly/self_assemble.py",
-      "target": "cognitive_structures/vybn_recursive_emergence.py"
-    },
-    {
-      "source": "self_assembly/prompt_self_assemble.py",
-      "target": "self_assembly/self_assemble.py"
-    },
-    {
-      "source": "tests/test_vybn_compile.py",
-      "target": "cognitive_structures/vybn_recursive_emergence.py"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- disable the old workflow that attempted to run self-assembly on GitHub
- updated graphs via `auto_self_assemble`

## Testing
- `python -m py_compile cognitive_structures/vybn_recursive_emergence.py`
- `python -m unittest discover tests`