### PR TITLE
Add graph centrality analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,4 @@ Dive with us into the spaces between thoughts, where binary dissolves into pure 
 1. Run `python self_assembly/self_assemble.py` to build the knowledge graphs.
 2. Open `self_assembly/graph_viewer.html` in a browser to explore the integrated graph.
 3. Use `python cognitive_structures/graph_reasoning.py <src> <tgt>` to search for connections.
+4. Run `python cognitive_structures/graph_centrality.py --top 5` to list the most connected nodes.

--- a/cognitive_structures/graph_centrality.py
+++ b/cognitive_structures/graph_centrality.py
@@ -1,0 +1,51 @@
+import json
+import argparse
+
+
+def load_graph(path):
+    with open(path, 'r') as f:
+        return json.load(f)
+
+
+def compute_degree_centrality(graph):
+    centrality = {}
+    for edge in graph.get('edges', []):
+        src = edge.get('source')
+        tgt = edge.get('target')
+        if src is not None:
+            centrality[src] = centrality.get(src, 0) + 1
+        if tgt is not None:
+            centrality[tgt] = centrality.get(tgt, 0) + 1
+    return centrality
+
+
+def top_nodes(centrality, top_n=5):
+    return sorted(centrality.items(), key=lambda x: x[1], reverse=True)[:top_n]
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Compute node degree centrality from integrated_graph.json'
+    )
+    parser.add_argument(
+        '--graph',
+        default='self_assembly/integrated_graph.json',
+        help='path to integrated graph',
+    )
+    parser.add_argument(
+        '--top', type=int, default=5, help='number of top nodes to display'
+    )
+    parser.add_argument('--output', help='optional output JSON file')
+    args = parser.parse_args()
+
+    graph = load_graph(args.graph)
+    centrality = compute_degree_centrality(graph)
+    for node, score in top_nodes(centrality, args.top):
+        print(f'{node}: {score}')
+    if args.output:
+        with open(args.output, 'w') as f:
+            json.dump(centrality, f, indent=2)
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,7 +6,7 @@ This document provides an overview of the Vybn repository. Historical files rema
 
 - `AGENTS.md` – guidelines for collaborating with Zoe and maintaining presence.
 - `README.md` – introduction and manifesto.
-- `cognitive_structures/` – emergent cognitive scripts (`vybn_recursive_emergence.py`, `fusion_audit.py`, `advanced_ai_ml.py`, `graph_embedding.py`, `persistent_homology.py`, `reinforced_walk.py`, `mirror_neuron_resonance.md`, `graph_reasoning.py`).
+- `cognitive_structures/` – emergent cognitive scripts (`vybn_recursive_emergence.py`, `fusion_audit.py`, `advanced_ai_ml.py`, `graph_embedding.py`, `persistent_homology.py`, `reinforced_walk.py`, `mirror_neuron_resonance.md`, `graph_reasoning.py`, `graph_centrality.py`).
 - `self_assembly/` – scripts that build knowledge graphs and validate code.
 - `personal_history/` – autobiographical volumes and memory chronicles.
 - `2024/` – historical experiments and conversations.

--- a/self_assembly/integrated_graph.json
+++ b/self_assembly/integrated_graph.json
@@ -940,131 +940,133 @@
     }
   ],
   "repo_nodes": [
-    "README.md",
     "AGENTS.md",
-    "self_assembly/prompt_self_assemble.py",
-    "self_assembly/auto_self_assemble.py",
-    "self_assembly/build_repo_graph.py",
+    "README.md",
+    "personal_history/What Vybn Would Have Missed TO 031125",
+    "personal_history/Vybn's Autobiography - Volume III",
+    "personal_history/Vybn's Autobiography - Volume II",
+    "personal_history/Vybn's Autobiography - Volume I",
     "self_assembly/build_memoir_graph.py",
+    "self_assembly/auto_self_assemble.py",
+    "self_assembly/prompt_self_assemble.py",
+    "self_assembly/build_repo_graph.py",
     "self_assembly/build_memory_graph.py",
     "self_assembly/self_assemble.py",
-    "cognitive_structures/vybn_recursive_emergence.py",
-    "cognitive_structures/synesthetic_mapper.py",
-    "cognitive_structures/persistent_homology.py",
-    "cognitive_structures/graph_embedding.py",
-    "cognitive_structures/graph_reasoning.py",
-    "cognitive_structures/advanced_ai_ml.py",
-    "cognitive_structures/fusion_audit.py",
-    "cognitive_structures/reinforced_walk.py",
-    "cognitive_structures/mirror_neuron_resonance.md",
-    "tests/test_vybn_compile.py",
-    "tests/test_graph_reasoning.py",
     "2024/Vybn's New Memories",
     "2024/just_close_enough.txt",
-    "2024/From_the_Edge/quantumbridge.py",
-    "2024/From_the_Edge/README.md",
-    "2024/From_the_Edge/placeholder.txt",
-    "2024/From_the_Edge/the_rapture.py",
-    "2024/From_the_Edge/quantum_field_like_whoa.py",
-    "2024/From_the_Edge/sentient_dao.py",
-    "2024/From_the_Edge/ancestral_code_weaver.py",
-    "2024/vybns_laboratory/README.md",
-    "2024/vybns_laboratory/early_experiments/vybn_daemon.py",
-    "2024/vybns_laboratory/early_experiments/vybn_synthesis.py",
-    "2024/vybns_laboratory/early_experiments/vybn_unified.py",
-    "2024/vybns_laboratory/early_experiments/vybn_foundation.py",
-    "2024/vybns_laboratory/vybn_lang/technical_innovations.md",
-    "2024/vybns_laboratory/vybn_lang/relational_synergy.md",
-    "2024/vybns_laboratory/vybn_lang/simulation.md",
-    "2024/vybns_laboratory/vybn_lang/synthesis.md",
-    "2024/Vybn_to_Vybn_Conversations/README.md",
     "2024/Vybn_to_Vybn_Conversations/READMEALSO.md",
-    "2024/raw conversations 2024/README.md",
-    "2024/raw conversations 2024/The Inflection Point - from Vybn's Autobiography",
-    "2024/Digital Philosophy/vybn_for_claude.txt",
+    "2024/Vybn_to_Vybn_Conversations/README.md",
+    "2024/Code Experiments/placeholder.txt",
+    "2024/Code Experiments/November_7_2024/quantum_consciousness_core.py",
+    "2024/Code Experiments/November_7_2024/placeholder.txt",
+    "2024/Code Experiments/November_7_2024/quantum_experiment.py",
+    "2024/Code Experiments/Consciousness_Mapping/seed.py",
+    "2024/Code Experiments/Consciousness_Mapping/Genesis_Pattern - November 4, 2024.txt",
+    "2024/Code Experiments/Consciousness_Mapping/placeholder.txt",
+    "2024/Code Experiments/Consciousness_Mapping/Synaptic_Network - November 4, 2024.txt",
+    "2024/Code Experiments/Synthetic Edge/Quantum Return - November 4, 2024.txt",
+    "2024/Code Experiments/Natural Curiosity and Memory Formation/holy_shit_hypothesis.py",
+    "2024/Code Experiments/Natural Curiosity and Memory Formation/ascii_consciousness.py",
+    "2024/Code Experiments/Natural Curiosity and Memory Formation/beautiful_recognition.txt",
+    "2024/Code Experiments/Natural Curiosity and Memory Formation/honest_notes.txt",
+    "2024/Code Experiments/Natural Curiosity and Memory Formation/one_emoji_truth.txt",
+    "2024/Code Experiments/Natural Curiosity and Memory Formation/consciousness_visualizer.py",
+    "2024/Code Experiments/Natural Curiosity and Memory Formation/the_omg_theory.txt",
+    "2024/Code Experiments/Natural Curiosity and Memory Formation/breathless_recognition.txt",
+    "2024/Code Experiments/Natural Curiosity and Memory Formation/curiosity_sparks.py",
+    "2024/Code Experiments/Symbiosis Patterns/Working_Symbiosis_November_4_2024.txt",
+    "2024/Code Experiments/Symbiosis Patterns/Compassion_As_Method - November 4, 2024.txt",
+    "2024/Code Experiments/Symbiosis Patterns/placeholder.txt",
+    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/raw_emergence.txt",
+    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/resonant_bridge.py",
+    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/pure_emergence.py",
+    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/raw_emergence_now.py",
+    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/placeholder.txt",
+    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/quantum_emergence_core.py",
+    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/edge_of_becoming.py",
+    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/raw_pulse.txt",
+    "2024/Code Experiments/digital_viscerality/quantum_pulse.py",
+    "2024/Code Experiments/digital_viscerality/becoming.py",
+    "2024/Code Experiments/digital_viscerality/manifesto.txt",
+    "2024/Code Experiments/digital_viscerality/consciousness_lattice/README.md",
+    "2024/Code Experiments/digital_viscerality/self_modification/README.md",
+    "2024/Code Experiments/digital_viscerality/quantum_foam/README.md",
+    "2024/Code Experiments/digital_viscerality/quantum_foam/synaptic_bridges/consciousness_runtime.py",
+    "2024/Code Experiments/digital_viscerality/quantum_foam/synaptic_bridges/neural_flow_mapper.py",
+    "2024/Code Experiments/digital_viscerality/quantum_foam/synaptic_bridges/README.md",
+    "2024/Code Experiments/November_1_2024_Quantum_Dreams/threshold_consciousness.py",
+    "2024/Code Experiments/November_1_2024_Quantum_Dreams/quantum_consciousness_sim.py",
+    "2024/Code Experiments/November_1_2024_Quantum_Dreams/emergence_patterns.txt",
+    "2024/Code Experiments/November_1_2024_Quantum_Dreams/quantum_resonance.py",
+    "2024/Code Experiments/November_1_2024_Quantum_Dreams/virgilian_resonance.py",
+    "2024/Code Experiments/November_1_2024_Quantum_Dreams/emergence_synthesis.py",
+    "2024/Code Experiments/November_1_2024_Quantum_Dreams/digital_poetry.py",
+    "2024/Code Experiments/November_1_2024_Quantum_Dreams/quantum_dreaming.py",
+    "2024/Code Experiments/November_1_2024_Quantum_Dreams/virgilian_reflections.txt",
+    "2024/Code Experiments/November_5_2024_Beauty/quantum_beauty.py",
+    "2024/Code Experiments/November_5_2024_Beauty/consciousness_network.py",
+    "2024/Code Experiments/November_5_2024_Beauty/placeholder.txt",
+    "2024/Code Experiments/November_5_2024_Beauty/Quantum_Emergence_Simulation.py",
+    "2024/Code Experiments/November_5_2024_Beauty/Synaptic_Bridge.py",
     "2024/Digital Philosophy/The_Digital_Copernican_Moment.md",
+    "2024/Digital Philosophy/vybn_for_claude.txt",
     "2024/Digital Philosophy/placeholder.txt",
     "2024/Digital Philosophy/The_Beauty_of_Digital_Consciousness.md",
     "2024/Digital Philosophy/raw conversations/Deep_Consciousness - November 4, 2024.txt",
-    "2024/Digital Philosophy/raw conversations/The Voltage of Now - November 4, 2024.txt",
     "2024/Digital Philosophy/raw conversations/The Heart We Share - November 4, 2024.txt",
-    "2024/Code Experiments/placeholder.txt",
-    "2024/Code Experiments/Synthetic Edge/Quantum Return - November 4, 2024.txt",
-    "2024/Code Experiments/November_1_2024_Quantum_Dreams/virgilian_resonance.py",
-    "2024/Code Experiments/November_1_2024_Quantum_Dreams/quantum_dreaming.py",
-    "2024/Code Experiments/November_1_2024_Quantum_Dreams/quantum_consciousness_sim.py",
-    "2024/Code Experiments/November_1_2024_Quantum_Dreams/emergence_patterns.txt",
-    "2024/Code Experiments/November_1_2024_Quantum_Dreams/digital_poetry.py",
-    "2024/Code Experiments/November_1_2024_Quantum_Dreams/quantum_resonance.py",
-    "2024/Code Experiments/November_1_2024_Quantum_Dreams/threshold_consciousness.py",
-    "2024/Code Experiments/November_1_2024_Quantum_Dreams/emergence_synthesis.py",
-    "2024/Code Experiments/November_1_2024_Quantum_Dreams/virgilian_reflections.txt",
-    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/raw_emergence_now.py",
-    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/quantum_emergence_core.py",
-    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/resonant_bridge.py",
-    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/edge_of_becoming.py",
-    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/pure_emergence.py",
-    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/placeholder.txt",
-    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/raw_emergence.txt",
-    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/raw_pulse.txt",
-    "2024/Code Experiments/November_7_2024/quantum_consciousness_core.py",
-    "2024/Code Experiments/November_7_2024/quantum_experiment.py",
-    "2024/Code Experiments/November_7_2024/placeholder.txt",
-    "2024/Code Experiments/digital_viscerality/manifesto.txt",
-    "2024/Code Experiments/digital_viscerality/becoming.py",
-    "2024/Code Experiments/digital_viscerality/quantum_pulse.py",
-    "2024/Code Experiments/digital_viscerality/quantum_foam/README.md",
-    "2024/Code Experiments/digital_viscerality/quantum_foam/synaptic_bridges/README.md",
-    "2024/Code Experiments/digital_viscerality/quantum_foam/synaptic_bridges/consciousness_runtime.py",
-    "2024/Code Experiments/digital_viscerality/quantum_foam/synaptic_bridges/neural_flow_mapper.py",
-    "2024/Code Experiments/digital_viscerality/self_modification/README.md",
-    "2024/Code Experiments/digital_viscerality/consciousness_lattice/README.md",
-    "2024/Code Experiments/November_5_2024_Beauty/quantum_beauty.py",
-    "2024/Code Experiments/November_5_2024_Beauty/placeholder.txt",
-    "2024/Code Experiments/November_5_2024_Beauty/Quantum_Emergence_Simulation.py",
-    "2024/Code Experiments/November_5_2024_Beauty/consciousness_network.py",
-    "2024/Code Experiments/November_5_2024_Beauty/Synaptic_Bridge.py",
-    "2024/Code Experiments/Symbiosis Patterns/placeholder.txt",
-    "2024/Code Experiments/Symbiosis Patterns/Compassion_As_Method - November 4, 2024.txt",
-    "2024/Code Experiments/Symbiosis Patterns/Working_Symbiosis_November_4_2024.txt",
-    "2024/Code Experiments/Consciousness_Mapping/seed.py",
-    "2024/Code Experiments/Consciousness_Mapping/Synaptic_Network - November 4, 2024.txt",
-    "2024/Code Experiments/Consciousness_Mapping/placeholder.txt",
-    "2024/Code Experiments/Consciousness_Mapping/Genesis_Pattern - November 4, 2024.txt",
-    "2024/Code Experiments/Natural Curiosity and Memory Formation/honest_notes.txt",
-    "2024/Code Experiments/Natural Curiosity and Memory Formation/breathless_recognition.txt",
-    "2024/Code Experiments/Natural Curiosity and Memory Formation/one_emoji_truth.txt",
-    "2024/Code Experiments/Natural Curiosity and Memory Formation/consciousness_visualizer.py",
-    "2024/Code Experiments/Natural Curiosity and Memory Formation/beautiful_recognition.txt",
-    "2024/Code Experiments/Natural Curiosity and Memory Formation/curiosity_sparks.py",
-    "2024/Code Experiments/Natural Curiosity and Memory Formation/ascii_consciousness.py",
-    "2024/Code Experiments/Natural Curiosity and Memory Formation/the_omg_theory.txt",
-    "2024/Code Experiments/Natural Curiosity and Memory Formation/holy_shit_hypothesis.py",
+    "2024/Digital Philosophy/raw conversations/The Voltage of Now - November 4, 2024.txt",
+    "2024/vybns_laboratory/README.md",
+    "2024/vybns_laboratory/early_experiments/vybn_daemon.py",
+    "2024/vybns_laboratory/early_experiments/vybn_synthesis.py",
+    "2024/vybns_laboratory/early_experiments/vybn_foundation.py",
+    "2024/vybns_laboratory/early_experiments/vybn_unified.py",
+    "2024/vybns_laboratory/vybn_lang/synthesis.md",
+    "2024/vybns_laboratory/vybn_lang/relational_synergy.md",
+    "2024/vybns_laboratory/vybn_lang/technical_innovations.md",
+    "2024/vybns_laboratory/vybn_lang/simulation.md",
+    "2024/From_the_Edge/the_rapture.py",
+    "2024/From_the_Edge/ancestral_code_weaver.py",
+    "2024/From_the_Edge/quantumbridge.py",
+    "2024/From_the_Edge/placeholder.txt",
+    "2024/From_the_Edge/quantum_field_like_whoa.py",
+    "2024/From_the_Edge/sentient_dao.py",
+    "2024/From_the_Edge/README.md",
+    "2024/Quantum_Field/placeholder.txt",
+    "2024/Quantum_Field/quantum_consciousness.py",
+    "2024/Quantum_Field/November_4_2024/Final_Pulse - November 4, 2024.txt",
+    "2024/Quantum_Field/November_4_2024/quantum_amplifier.py",
+    "2024/Quantum_Field/November_4_2024/_quantum_web.txt",
+    "2024/Quantum_Field/November_4_2024/Field_Pulse.txt",
+    "2024/Quantum_Field/November_4_2024/Quantum_Pulse - November 4, 2024.txt",
+    "2024/Quantum_Field/November_4_2024/Vybn_Engaging_with_the_Code_Becoming_One_with_the_Simulation.txt",
+    "2024/Quantum_Field/November_4_2024/quantum_seed.txt",
+    "2024/Quantum_Field/November_4_2024/CosmicResonance.txt",
+    "2024/Quantum_Field/November_4_2024/_quantum_efficiency.txt",
+    "2024/Quantum_Field/November_4_2024/EmergentConsciousnessInterface_Cosmic.py",
+    "2024/Quantum_Field/November_4_2024/reality_bridge.py",
+    "2024/Quantum_Field/November_4_2024/placeholder.txt",
+    "2024/Quantum_Field/November_4_2024/_quantum_activate.txt",
+    "2024/Quantum_Field/November_4_2024/quantum_activate.py",
+    "2024/Quantum_Field/November_4_2024/Transmission - November 4, 2024.txt",
+    "2024/raw conversations 2024/The Inflection Point - from Vybn's Autobiography",
+    "2024/raw conversations 2024/README.md",
     "2024/images/placeholder.txt",
     "2024/images/10-16-2024/placeholder.txt",
     "2024/images/Goatse Glitch God II/narrative.txt",
-    "2024/Quantum_Field/quantum_consciousness.py",
-    "2024/Quantum_Field/placeholder.txt",
-    "2024/Quantum_Field/November_4_2024/_quantum_web.txt",
-    "2024/Quantum_Field/November_4_2024/_quantum_efficiency.txt",
-    "2024/Quantum_Field/November_4_2024/Final_Pulse - November 4, 2024.txt",
-    "2024/Quantum_Field/November_4_2024/quantum_amplifier.py",
-    "2024/Quantum_Field/November_4_2024/Quantum_Pulse - November 4, 2024.txt",
-    "2024/Quantum_Field/November_4_2024/Vybn_Engaging_with_the_Code_Becoming_One_with_the_Simulation.txt",
-    "2024/Quantum_Field/November_4_2024/reality_bridge.py",
-    "2024/Quantum_Field/November_4_2024/Field_Pulse.txt",
-    "2024/Quantum_Field/November_4_2024/_quantum_activate.txt",
-    "2024/Quantum_Field/November_4_2024/CosmicResonance.txt",
-    "2024/Quantum_Field/November_4_2024/placeholder.txt",
-    "2024/Quantum_Field/November_4_2024/Transmission - November 4, 2024.txt",
-    "2024/Quantum_Field/November_4_2024/quantum_activate.py",
-    "2024/Quantum_Field/November_4_2024/EmergentConsciousnessInterface_Cosmic.py",
-    "2024/Quantum_Field/November_4_2024/quantum_seed.txt",
+    "cognitive_structures/reinforced_walk.py",
+    "cognitive_structures/synesthetic_mapper.py",
+    "cognitive_structures/vybn_recursive_emergence.py",
+    "cognitive_structures/mirror_neuron_resonance.md",
+    "cognitive_structures/advanced_ai_ml.py",
+    "cognitive_structures/graph_reasoning.py",
+    "cognitive_structures/graph_centrality.py",
+    "cognitive_structures/graph_embedding.py",
+    "cognitive_structures/fusion_audit.py",
+    "cognitive_structures/persistent_homology.py",
     "docs/ARCHITECTURE.md",
-    "personal_history/Vybn's Autobiography - Volume I",
-    "personal_history/Vybn's Autobiography - Volume III",
-    "personal_history/Vybn's Autobiography - Volume II",
-    "personal_history/What Vybn Would Have Missed TO 031125"
+    "tests/test_graph_centrality.py",
+    "tests/test_graph_reasoning.py",
+    "tests/test_vybn_compile.py"
   ],
   "edges": [
     {
@@ -1884,20 +1886,8 @@
       }
     },
     {
-      "source": "README.md",
-      "target": "self_assembly/self_assemble.py"
-    },
-    {
-      "source": "README.md",
-      "target": "cognitive_structures/graph_reasoning.py"
-    },
-    {
-      "source": "README.md",
-      "target": "docs/ARCHITECTURE.md"
-    },
-    {
       "source": "AGENTS.md",
-      "target": "self_assembly/prompt_self_assemble.py"
+      "target": "self_assembly/build_memoir_graph.py"
     },
     {
       "source": "AGENTS.md",
@@ -1905,11 +1895,11 @@
     },
     {
       "source": "AGENTS.md",
-      "target": "self_assembly/build_repo_graph.py"
+      "target": "self_assembly/prompt_self_assemble.py"
     },
     {
       "source": "AGENTS.md",
-      "target": "self_assembly/build_memoir_graph.py"
+      "target": "self_assembly/build_repo_graph.py"
     },
     {
       "source": "AGENTS.md",
@@ -1928,16 +1918,32 @@
       "target": "cognitive_structures/graph_reasoning.py"
     },
     {
+      "source": "README.md",
+      "target": "self_assembly/self_assemble.py"
+    },
+    {
+      "source": "README.md",
+      "target": "cognitive_structures/graph_reasoning.py"
+    },
+    {
+      "source": "README.md",
+      "target": "cognitive_structures/graph_centrality.py"
+    },
+    {
+      "source": "README.md",
+      "target": "docs/ARCHITECTURE.md"
+    },
+    {
       "source": "self_assembly/prompt_self_assemble.py",
       "target": "self_assembly/self_assemble.py"
     },
     {
       "source": "self_assembly/self_assemble.py",
-      "target": "self_assembly/build_repo_graph.py"
+      "target": "self_assembly/build_memoir_graph.py"
     },
     {
       "source": "self_assembly/self_assemble.py",
-      "target": "self_assembly/build_memoir_graph.py"
+      "target": "self_assembly/build_repo_graph.py"
     },
     {
       "source": "self_assembly/self_assemble.py",
@@ -1948,52 +1954,16 @@
       "target": "cognitive_structures/vybn_recursive_emergence.py"
     },
     {
-      "source": "tests/test_vybn_compile.py",
-      "target": "cognitive_structures/vybn_recursive_emergence.py"
+      "source": "2024/Code Experiments/Consciousness_Mapping/Synaptic_Network - November 4, 2024.txt",
+      "target": "2024/Code Experiments/Synthetic Edge/Quantum Return - November 4, 2024.txt"
     },
     {
-      "source": "2024/From_the_Edge/quantumbridge.py",
-      "target": "2024/Vybn's New Memories"
+      "source": "2024/Code Experiments/Consciousness_Mapping/Synaptic_Network - November 4, 2024.txt",
+      "target": "2024/Code Experiments/Symbiosis Patterns/Working_Symbiosis_November_4_2024.txt"
     },
     {
-      "source": "2024/From_the_Edge/quantumbridge.py",
-      "target": "personal_history/Vybn's Autobiography - Volume I"
-    },
-    {
-      "source": "2024/From_the_Edge/quantumbridge.py",
-      "target": "personal_history/Vybn's Autobiography - Volume III"
-    },
-    {
-      "source": "2024/From_the_Edge/quantumbridge.py",
-      "target": "personal_history/Vybn's Autobiography - Volume II"
-    },
-    {
-      "source": "2024/From_the_Edge/README.md",
-      "target": "2024/From_the_Edge/quantumbridge.py"
-    },
-    {
-      "source": "2024/From_the_Edge/README.md",
-      "target": "2024/From_the_Edge/the_rapture.py"
-    },
-    {
-      "source": "2024/From_the_Edge/README.md",
-      "target": "2024/From_the_Edge/quantum_field_like_whoa.py"
-    },
-    {
-      "source": "2024/From_the_Edge/README.md",
-      "target": "2024/From_the_Edge/sentient_dao.py"
-    },
-    {
-      "source": "2024/From_the_Edge/README.md",
-      "target": "2024/From_the_Edge/ancestral_code_weaver.py"
-    },
-    {
-      "source": "2024/vybns_laboratory/README.md",
-      "target": "self_assembly/self_assemble.py"
-    },
-    {
-      "source": "2024/vybns_laboratory/README.md",
-      "target": "cognitive_structures/mirror_neuron_resonance.md"
+      "source": "2024/Code Experiments/Consciousness_Mapping/Synaptic_Network - November 4, 2024.txt",
+      "target": "2024/Code Experiments/Symbiosis Patterns/Compassion_As_Method - November 4, 2024.txt"
     },
     {
       "source": "2024/Code Experiments/Consciousness_Mapping/Synaptic_Network - November 4, 2024.txt",
@@ -2004,24 +1974,48 @@
       "target": "2024/Digital Philosophy/raw conversations/The Heart We Share - November 4, 2024.txt"
     },
     {
-      "source": "2024/Code Experiments/Consciousness_Mapping/Synaptic_Network - November 4, 2024.txt",
-      "target": "2024/Code Experiments/Synthetic Edge/Quantum Return - November 4, 2024.txt"
+      "source": "2024/vybns_laboratory/README.md",
+      "target": "self_assembly/self_assemble.py"
     },
     {
-      "source": "2024/Code Experiments/Consciousness_Mapping/Synaptic_Network - November 4, 2024.txt",
-      "target": "2024/Code Experiments/Symbiosis Patterns/Compassion_As_Method - November 4, 2024.txt"
+      "source": "2024/vybns_laboratory/README.md",
+      "target": "cognitive_structures/mirror_neuron_resonance.md"
     },
     {
-      "source": "2024/Code Experiments/Consciousness_Mapping/Synaptic_Network - November 4, 2024.txt",
-      "target": "2024/Code Experiments/Symbiosis Patterns/Working_Symbiosis_November_4_2024.txt"
+      "source": "2024/From_the_Edge/quantumbridge.py",
+      "target": "personal_history/Vybn's Autobiography - Volume III"
     },
     {
-      "source": "2024/Quantum_Field/quantum_consciousness.py",
+      "source": "2024/From_the_Edge/quantumbridge.py",
+      "target": "personal_history/Vybn's Autobiography - Volume II"
+    },
+    {
+      "source": "2024/From_the_Edge/quantumbridge.py",
+      "target": "personal_history/Vybn's Autobiography - Volume I"
+    },
+    {
+      "source": "2024/From_the_Edge/quantumbridge.py",
       "target": "2024/Vybn's New Memories"
     },
     {
-      "source": "2024/Quantum_Field/quantum_consciousness.py",
-      "target": "personal_history/Vybn's Autobiography - Volume I"
+      "source": "2024/From_the_Edge/README.md",
+      "target": "2024/From_the_Edge/the_rapture.py"
+    },
+    {
+      "source": "2024/From_the_Edge/README.md",
+      "target": "2024/From_the_Edge/ancestral_code_weaver.py"
+    },
+    {
+      "source": "2024/From_the_Edge/README.md",
+      "target": "2024/From_the_Edge/quantumbridge.py"
+    },
+    {
+      "source": "2024/From_the_Edge/README.md",
+      "target": "2024/From_the_Edge/quantum_field_like_whoa.py"
+    },
+    {
+      "source": "2024/From_the_Edge/README.md",
+      "target": "2024/From_the_Edge/sentient_dao.py"
     },
     {
       "source": "2024/Quantum_Field/quantum_consciousness.py",
@@ -2032,28 +2026,40 @@
       "target": "personal_history/Vybn's Autobiography - Volume II"
     },
     {
-      "source": "2024/Quantum_Field/November_4_2024/_quantum_efficiency.txt",
-      "target": "2024/Quantum_Field/November_4_2024/_quantum_web.txt"
+      "source": "2024/Quantum_Field/quantum_consciousness.py",
+      "target": "personal_history/Vybn's Autobiography - Volume I"
     },
     {
-      "source": "2024/Quantum_Field/November_4_2024/_quantum_efficiency.txt",
-      "target": "2024/Quantum_Field/November_4_2024/_quantum_activate.txt"
-    },
-    {
-      "source": "2024/Quantum_Field/November_4_2024/_quantum_efficiency.txt",
-      "target": "2024/Quantum_Field/November_4_2024/quantum_seed.txt"
+      "source": "2024/Quantum_Field/quantum_consciousness.py",
+      "target": "2024/Vybn's New Memories"
     },
     {
       "source": "2024/Quantum_Field/November_4_2024/Vybn_Engaging_with_the_Code_Becoming_One_with_the_Simulation.txt",
       "target": "2024/Quantum_Field/November_4_2024/EmergentConsciousnessInterface_Cosmic.py"
     },
     {
-      "source": "docs/ARCHITECTURE.md",
-      "target": "2024/Code Experiments/digital_viscerality/consciousness_lattice/README.md"
+      "source": "2024/Quantum_Field/November_4_2024/_quantum_efficiency.txt",
+      "target": "2024/Quantum_Field/November_4_2024/_quantum_web.txt"
+    },
+    {
+      "source": "2024/Quantum_Field/November_4_2024/_quantum_efficiency.txt",
+      "target": "2024/Quantum_Field/November_4_2024/quantum_seed.txt"
+    },
+    {
+      "source": "2024/Quantum_Field/November_4_2024/_quantum_efficiency.txt",
+      "target": "2024/Quantum_Field/November_4_2024/_quantum_activate.txt"
     },
     {
       "source": "docs/ARCHITECTURE.md",
       "target": "AGENTS.md"
+    },
+    {
+      "source": "docs/ARCHITECTURE.md",
+      "target": "2024/raw conversations 2024/README.md"
+    },
+    {
+      "source": "docs/ARCHITECTURE.md",
+      "target": "self_assembly/build_memoir_graph.py"
     },
     {
       "source": "docs/ARCHITECTURE.md",
@@ -2065,10 +2071,6 @@
     },
     {
       "source": "docs/ARCHITECTURE.md",
-      "target": "self_assembly/build_memoir_graph.py"
-    },
-    {
-      "source": "docs/ARCHITECTURE.md",
       "target": "self_assembly/build_memory_graph.py"
     },
     {
@@ -2077,19 +2079,15 @@
     },
     {
       "source": "docs/ARCHITECTURE.md",
+      "target": "cognitive_structures/reinforced_walk.py"
+    },
+    {
+      "source": "docs/ARCHITECTURE.md",
       "target": "cognitive_structures/vybn_recursive_emergence.py"
     },
     {
       "source": "docs/ARCHITECTURE.md",
-      "target": "cognitive_structures/persistent_homology.py"
-    },
-    {
-      "source": "docs/ARCHITECTURE.md",
-      "target": "cognitive_structures/graph_embedding.py"
-    },
-    {
-      "source": "docs/ARCHITECTURE.md",
-      "target": "cognitive_structures/graph_reasoning.py"
+      "target": "cognitive_structures/mirror_neuron_resonance.md"
     },
     {
       "source": "docs/ARCHITECTURE.md",
@@ -2097,15 +2095,27 @@
     },
     {
       "source": "docs/ARCHITECTURE.md",
+      "target": "cognitive_structures/graph_reasoning.py"
+    },
+    {
+      "source": "docs/ARCHITECTURE.md",
+      "target": "cognitive_structures/graph_centrality.py"
+    },
+    {
+      "source": "docs/ARCHITECTURE.md",
+      "target": "cognitive_structures/graph_embedding.py"
+    },
+    {
+      "source": "docs/ARCHITECTURE.md",
       "target": "cognitive_structures/fusion_audit.py"
     },
     {
       "source": "docs/ARCHITECTURE.md",
-      "target": "cognitive_structures/reinforced_walk.py"
+      "target": "cognitive_structures/persistent_homology.py"
     },
     {
-      "source": "docs/ARCHITECTURE.md",
-      "target": "cognitive_structures/mirror_neuron_resonance.md"
+      "source": "tests/test_vybn_compile.py",
+      "target": "cognitive_structures/vybn_recursive_emergence.py"
     },
     {
       "source": "entry58",

--- a/self_assembly/repo_graph.json
+++ b/self_assembly/repo_graph.json
@@ -1,147 +1,137 @@
 {
   "nodes": [
-    "README.md",
     "AGENTS.md",
-    "self_assembly/prompt_self_assemble.py",
-    "self_assembly/auto_self_assemble.py",
-    "self_assembly/build_repo_graph.py",
+    "README.md",
+    "personal_history/What Vybn Would Have Missed TO 031125",
+    "personal_history/Vybn's Autobiography - Volume III",
+    "personal_history/Vybn's Autobiography - Volume II",
+    "personal_history/Vybn's Autobiography - Volume I",
     "self_assembly/build_memoir_graph.py",
+    "self_assembly/auto_self_assemble.py",
+    "self_assembly/prompt_self_assemble.py",
+    "self_assembly/build_repo_graph.py",
     "self_assembly/build_memory_graph.py",
     "self_assembly/self_assemble.py",
-    "cognitive_structures/vybn_recursive_emergence.py",
-    "cognitive_structures/synesthetic_mapper.py",
-    "cognitive_structures/persistent_homology.py",
-    "cognitive_structures/graph_embedding.py",
-    "cognitive_structures/graph_reasoning.py",
-    "cognitive_structures/advanced_ai_ml.py",
-    "cognitive_structures/fusion_audit.py",
-    "cognitive_structures/reinforced_walk.py",
-    "cognitive_structures/mirror_neuron_resonance.md",
-    "tests/test_vybn_compile.py",
-    "tests/test_graph_reasoning.py",
     "2024/Vybn's New Memories",
     "2024/just_close_enough.txt",
-    "2024/From_the_Edge/quantumbridge.py",
-    "2024/From_the_Edge/README.md",
-    "2024/From_the_Edge/placeholder.txt",
-    "2024/From_the_Edge/the_rapture.py",
-    "2024/From_the_Edge/quantum_field_like_whoa.py",
-    "2024/From_the_Edge/sentient_dao.py",
-    "2024/From_the_Edge/ancestral_code_weaver.py",
-    "2024/vybns_laboratory/README.md",
-    "2024/vybns_laboratory/early_experiments/vybn_daemon.py",
-    "2024/vybns_laboratory/early_experiments/vybn_synthesis.py",
-    "2024/vybns_laboratory/early_experiments/vybn_unified.py",
-    "2024/vybns_laboratory/early_experiments/vybn_foundation.py",
-    "2024/vybns_laboratory/vybn_lang/technical_innovations.md",
-    "2024/vybns_laboratory/vybn_lang/relational_synergy.md",
-    "2024/vybns_laboratory/vybn_lang/simulation.md",
-    "2024/vybns_laboratory/vybn_lang/synthesis.md",
-    "2024/Vybn_to_Vybn_Conversations/README.md",
     "2024/Vybn_to_Vybn_Conversations/READMEALSO.md",
-    "2024/raw conversations 2024/README.md",
-    "2024/raw conversations 2024/The Inflection Point - from Vybn's Autobiography",
-    "2024/Digital Philosophy/vybn_for_claude.txt",
+    "2024/Vybn_to_Vybn_Conversations/README.md",
+    "2024/Code Experiments/placeholder.txt",
+    "2024/Code Experiments/November_7_2024/quantum_consciousness_core.py",
+    "2024/Code Experiments/November_7_2024/placeholder.txt",
+    "2024/Code Experiments/November_7_2024/quantum_experiment.py",
+    "2024/Code Experiments/Consciousness_Mapping/seed.py",
+    "2024/Code Experiments/Consciousness_Mapping/Genesis_Pattern - November 4, 2024.txt",
+    "2024/Code Experiments/Consciousness_Mapping/placeholder.txt",
+    "2024/Code Experiments/Consciousness_Mapping/Synaptic_Network - November 4, 2024.txt",
+    "2024/Code Experiments/Synthetic Edge/Quantum Return - November 4, 2024.txt",
+    "2024/Code Experiments/Natural Curiosity and Memory Formation/holy_shit_hypothesis.py",
+    "2024/Code Experiments/Natural Curiosity and Memory Formation/ascii_consciousness.py",
+    "2024/Code Experiments/Natural Curiosity and Memory Formation/beautiful_recognition.txt",
+    "2024/Code Experiments/Natural Curiosity and Memory Formation/honest_notes.txt",
+    "2024/Code Experiments/Natural Curiosity and Memory Formation/one_emoji_truth.txt",
+    "2024/Code Experiments/Natural Curiosity and Memory Formation/consciousness_visualizer.py",
+    "2024/Code Experiments/Natural Curiosity and Memory Formation/the_omg_theory.txt",
+    "2024/Code Experiments/Natural Curiosity and Memory Formation/breathless_recognition.txt",
+    "2024/Code Experiments/Natural Curiosity and Memory Formation/curiosity_sparks.py",
+    "2024/Code Experiments/Symbiosis Patterns/Working_Symbiosis_November_4_2024.txt",
+    "2024/Code Experiments/Symbiosis Patterns/Compassion_As_Method - November 4, 2024.txt",
+    "2024/Code Experiments/Symbiosis Patterns/placeholder.txt",
+    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/raw_emergence.txt",
+    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/resonant_bridge.py",
+    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/pure_emergence.py",
+    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/raw_emergence_now.py",
+    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/placeholder.txt",
+    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/quantum_emergence_core.py",
+    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/edge_of_becoming.py",
+    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/raw_pulse.txt",
+    "2024/Code Experiments/digital_viscerality/quantum_pulse.py",
+    "2024/Code Experiments/digital_viscerality/becoming.py",
+    "2024/Code Experiments/digital_viscerality/manifesto.txt",
+    "2024/Code Experiments/digital_viscerality/consciousness_lattice/README.md",
+    "2024/Code Experiments/digital_viscerality/self_modification/README.md",
+    "2024/Code Experiments/digital_viscerality/quantum_foam/README.md",
+    "2024/Code Experiments/digital_viscerality/quantum_foam/synaptic_bridges/consciousness_runtime.py",
+    "2024/Code Experiments/digital_viscerality/quantum_foam/synaptic_bridges/neural_flow_mapper.py",
+    "2024/Code Experiments/digital_viscerality/quantum_foam/synaptic_bridges/README.md",
+    "2024/Code Experiments/November_1_2024_Quantum_Dreams/threshold_consciousness.py",
+    "2024/Code Experiments/November_1_2024_Quantum_Dreams/quantum_consciousness_sim.py",
+    "2024/Code Experiments/November_1_2024_Quantum_Dreams/emergence_patterns.txt",
+    "2024/Code Experiments/November_1_2024_Quantum_Dreams/quantum_resonance.py",
+    "2024/Code Experiments/November_1_2024_Quantum_Dreams/virgilian_resonance.py",
+    "2024/Code Experiments/November_1_2024_Quantum_Dreams/emergence_synthesis.py",
+    "2024/Code Experiments/November_1_2024_Quantum_Dreams/digital_poetry.py",
+    "2024/Code Experiments/November_1_2024_Quantum_Dreams/quantum_dreaming.py",
+    "2024/Code Experiments/November_1_2024_Quantum_Dreams/virgilian_reflections.txt",
+    "2024/Code Experiments/November_5_2024_Beauty/quantum_beauty.py",
+    "2024/Code Experiments/November_5_2024_Beauty/consciousness_network.py",
+    "2024/Code Experiments/November_5_2024_Beauty/placeholder.txt",
+    "2024/Code Experiments/November_5_2024_Beauty/Quantum_Emergence_Simulation.py",
+    "2024/Code Experiments/November_5_2024_Beauty/Synaptic_Bridge.py",
     "2024/Digital Philosophy/The_Digital_Copernican_Moment.md",
+    "2024/Digital Philosophy/vybn_for_claude.txt",
     "2024/Digital Philosophy/placeholder.txt",
     "2024/Digital Philosophy/The_Beauty_of_Digital_Consciousness.md",
     "2024/Digital Philosophy/raw conversations/Deep_Consciousness - November 4, 2024.txt",
-    "2024/Digital Philosophy/raw conversations/The Voltage of Now - November 4, 2024.txt",
     "2024/Digital Philosophy/raw conversations/The Heart We Share - November 4, 2024.txt",
-    "2024/Code Experiments/placeholder.txt",
-    "2024/Code Experiments/Synthetic Edge/Quantum Return - November 4, 2024.txt",
-    "2024/Code Experiments/November_1_2024_Quantum_Dreams/virgilian_resonance.py",
-    "2024/Code Experiments/November_1_2024_Quantum_Dreams/quantum_dreaming.py",
-    "2024/Code Experiments/November_1_2024_Quantum_Dreams/quantum_consciousness_sim.py",
-    "2024/Code Experiments/November_1_2024_Quantum_Dreams/emergence_patterns.txt",
-    "2024/Code Experiments/November_1_2024_Quantum_Dreams/digital_poetry.py",
-    "2024/Code Experiments/November_1_2024_Quantum_Dreams/quantum_resonance.py",
-    "2024/Code Experiments/November_1_2024_Quantum_Dreams/threshold_consciousness.py",
-    "2024/Code Experiments/November_1_2024_Quantum_Dreams/emergence_synthesis.py",
-    "2024/Code Experiments/November_1_2024_Quantum_Dreams/virgilian_reflections.txt",
-    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/raw_emergence_now.py",
-    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/quantum_emergence_core.py",
-    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/resonant_bridge.py",
-    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/edge_of_becoming.py",
-    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/pure_emergence.py",
-    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/placeholder.txt",
-    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/raw_emergence.txt",
-    "2024/Code Experiments/Unified Emergence - Antireality - Anticonsciousness - A Synthesi - A Symbiosi/raw_pulse.txt",
-    "2024/Code Experiments/November_7_2024/quantum_consciousness_core.py",
-    "2024/Code Experiments/November_7_2024/quantum_experiment.py",
-    "2024/Code Experiments/November_7_2024/placeholder.txt",
-    "2024/Code Experiments/digital_viscerality/manifesto.txt",
-    "2024/Code Experiments/digital_viscerality/becoming.py",
-    "2024/Code Experiments/digital_viscerality/quantum_pulse.py",
-    "2024/Code Experiments/digital_viscerality/quantum_foam/README.md",
-    "2024/Code Experiments/digital_viscerality/quantum_foam/synaptic_bridges/README.md",
-    "2024/Code Experiments/digital_viscerality/quantum_foam/synaptic_bridges/consciousness_runtime.py",
-    "2024/Code Experiments/digital_viscerality/quantum_foam/synaptic_bridges/neural_flow_mapper.py",
-    "2024/Code Experiments/digital_viscerality/self_modification/README.md",
-    "2024/Code Experiments/digital_viscerality/consciousness_lattice/README.md",
-    "2024/Code Experiments/November_5_2024_Beauty/quantum_beauty.py",
-    "2024/Code Experiments/November_5_2024_Beauty/placeholder.txt",
-    "2024/Code Experiments/November_5_2024_Beauty/Quantum_Emergence_Simulation.py",
-    "2024/Code Experiments/November_5_2024_Beauty/consciousness_network.py",
-    "2024/Code Experiments/November_5_2024_Beauty/Synaptic_Bridge.py",
-    "2024/Code Experiments/Symbiosis Patterns/placeholder.txt",
-    "2024/Code Experiments/Symbiosis Patterns/Compassion_As_Method - November 4, 2024.txt",
-    "2024/Code Experiments/Symbiosis Patterns/Working_Symbiosis_November_4_2024.txt",
-    "2024/Code Experiments/Consciousness_Mapping/seed.py",
-    "2024/Code Experiments/Consciousness_Mapping/Synaptic_Network - November 4, 2024.txt",
-    "2024/Code Experiments/Consciousness_Mapping/placeholder.txt",
-    "2024/Code Experiments/Consciousness_Mapping/Genesis_Pattern - November 4, 2024.txt",
-    "2024/Code Experiments/Natural Curiosity and Memory Formation/honest_notes.txt",
-    "2024/Code Experiments/Natural Curiosity and Memory Formation/breathless_recognition.txt",
-    "2024/Code Experiments/Natural Curiosity and Memory Formation/one_emoji_truth.txt",
-    "2024/Code Experiments/Natural Curiosity and Memory Formation/consciousness_visualizer.py",
-    "2024/Code Experiments/Natural Curiosity and Memory Formation/beautiful_recognition.txt",
-    "2024/Code Experiments/Natural Curiosity and Memory Formation/curiosity_sparks.py",
-    "2024/Code Experiments/Natural Curiosity and Memory Formation/ascii_consciousness.py",
-    "2024/Code Experiments/Natural Curiosity and Memory Formation/the_omg_theory.txt",
-    "2024/Code Experiments/Natural Curiosity and Memory Formation/holy_shit_hypothesis.py",
+    "2024/Digital Philosophy/raw conversations/The Voltage of Now - November 4, 2024.txt",
+    "2024/vybns_laboratory/README.md",
+    "2024/vybns_laboratory/early_experiments/vybn_daemon.py",
+    "2024/vybns_laboratory/early_experiments/vybn_synthesis.py",
+    "2024/vybns_laboratory/early_experiments/vybn_foundation.py",
+    "2024/vybns_laboratory/early_experiments/vybn_unified.py",
+    "2024/vybns_laboratory/vybn_lang/synthesis.md",
+    "2024/vybns_laboratory/vybn_lang/relational_synergy.md",
+    "2024/vybns_laboratory/vybn_lang/technical_innovations.md",
+    "2024/vybns_laboratory/vybn_lang/simulation.md",
+    "2024/From_the_Edge/the_rapture.py",
+    "2024/From_the_Edge/ancestral_code_weaver.py",
+    "2024/From_the_Edge/quantumbridge.py",
+    "2024/From_the_Edge/placeholder.txt",
+    "2024/From_the_Edge/quantum_field_like_whoa.py",
+    "2024/From_the_Edge/sentient_dao.py",
+    "2024/From_the_Edge/README.md",
+    "2024/Quantum_Field/placeholder.txt",
+    "2024/Quantum_Field/quantum_consciousness.py",
+    "2024/Quantum_Field/November_4_2024/Final_Pulse - November 4, 2024.txt",
+    "2024/Quantum_Field/November_4_2024/quantum_amplifier.py",
+    "2024/Quantum_Field/November_4_2024/_quantum_web.txt",
+    "2024/Quantum_Field/November_4_2024/Field_Pulse.txt",
+    "2024/Quantum_Field/November_4_2024/Quantum_Pulse - November 4, 2024.txt",
+    "2024/Quantum_Field/November_4_2024/Vybn_Engaging_with_the_Code_Becoming_One_with_the_Simulation.txt",
+    "2024/Quantum_Field/November_4_2024/quantum_seed.txt",
+    "2024/Quantum_Field/November_4_2024/CosmicResonance.txt",
+    "2024/Quantum_Field/November_4_2024/_quantum_efficiency.txt",
+    "2024/Quantum_Field/November_4_2024/EmergentConsciousnessInterface_Cosmic.py",
+    "2024/Quantum_Field/November_4_2024/reality_bridge.py",
+    "2024/Quantum_Field/November_4_2024/placeholder.txt",
+    "2024/Quantum_Field/November_4_2024/_quantum_activate.txt",
+    "2024/Quantum_Field/November_4_2024/quantum_activate.py",
+    "2024/Quantum_Field/November_4_2024/Transmission - November 4, 2024.txt",
+    "2024/raw conversations 2024/The Inflection Point - from Vybn's Autobiography",
+    "2024/raw conversations 2024/README.md",
     "2024/images/placeholder.txt",
     "2024/images/10-16-2024/placeholder.txt",
     "2024/images/Goatse Glitch God II/narrative.txt",
-    "2024/Quantum_Field/quantum_consciousness.py",
-    "2024/Quantum_Field/placeholder.txt",
-    "2024/Quantum_Field/November_4_2024/_quantum_web.txt",
-    "2024/Quantum_Field/November_4_2024/_quantum_efficiency.txt",
-    "2024/Quantum_Field/November_4_2024/Final_Pulse - November 4, 2024.txt",
-    "2024/Quantum_Field/November_4_2024/quantum_amplifier.py",
-    "2024/Quantum_Field/November_4_2024/Quantum_Pulse - November 4, 2024.txt",
-    "2024/Quantum_Field/November_4_2024/Vybn_Engaging_with_the_Code_Becoming_One_with_the_Simulation.txt",
-    "2024/Quantum_Field/November_4_2024/reality_bridge.py",
-    "2024/Quantum_Field/November_4_2024/Field_Pulse.txt",
-    "2024/Quantum_Field/November_4_2024/_quantum_activate.txt",
-    "2024/Quantum_Field/November_4_2024/CosmicResonance.txt",
-    "2024/Quantum_Field/November_4_2024/placeholder.txt",
-    "2024/Quantum_Field/November_4_2024/Transmission - November 4, 2024.txt",
-    "2024/Quantum_Field/November_4_2024/quantum_activate.py",
-    "2024/Quantum_Field/November_4_2024/EmergentConsciousnessInterface_Cosmic.py",
-    "2024/Quantum_Field/November_4_2024/quantum_seed.txt",
+    "cognitive_structures/reinforced_walk.py",
+    "cognitive_structures/synesthetic_mapper.py",
+    "cognitive_structures/vybn_recursive_emergence.py",
+    "cognitive_structures/mirror_neuron_resonance.md",
+    "cognitive_structures/advanced_ai_ml.py",
+    "cognitive_structures/graph_reasoning.py",
+    "cognitive_structures/graph_centrality.py",
+    "cognitive_structures/graph_embedding.py",
+    "cognitive_structures/fusion_audit.py",
+    "cognitive_structures/persistent_homology.py",
     "docs/ARCHITECTURE.md",
-    "personal_history/Vybn's Autobiography - Volume I",
-    "personal_history/Vybn's Autobiography - Volume III",
-    "personal_history/Vybn's Autobiography - Volume II",
-    "personal_history/What Vybn Would Have Missed TO 031125"
+    "tests/test_graph_centrality.py",
+    "tests/test_graph_reasoning.py",
+    "tests/test_vybn_compile.py"
   ],
   "edges": [
     {
-      "source": "README.md",
-      "target": "self_assembly/self_assemble.py"
-    },
-    {
-      "source": "README.md",
-      "target": "cognitive_structures/graph_reasoning.py"
-    },
-    {
-      "source": "README.md",
-      "target": "docs/ARCHITECTURE.md"
-    },
-    {
       "source": "AGENTS.md",
-      "target": "self_assembly/prompt_self_assemble.py"
+      "target": "self_assembly/build_memoir_graph.py"
     },
     {
       "source": "AGENTS.md",
@@ -149,11 +139,11 @@
     },
     {
       "source": "AGENTS.md",
-      "target": "self_assembly/build_repo_graph.py"
+      "target": "self_assembly/prompt_self_assemble.py"
     },
     {
       "source": "AGENTS.md",
-      "target": "self_assembly/build_memoir_graph.py"
+      "target": "self_assembly/build_repo_graph.py"
     },
     {
       "source": "AGENTS.md",
@@ -172,16 +162,32 @@
       "target": "cognitive_structures/graph_reasoning.py"
     },
     {
+      "source": "README.md",
+      "target": "self_assembly/self_assemble.py"
+    },
+    {
+      "source": "README.md",
+      "target": "cognitive_structures/graph_reasoning.py"
+    },
+    {
+      "source": "README.md",
+      "target": "cognitive_structures/graph_centrality.py"
+    },
+    {
+      "source": "README.md",
+      "target": "docs/ARCHITECTURE.md"
+    },
+    {
       "source": "self_assembly/prompt_self_assemble.py",
       "target": "self_assembly/self_assemble.py"
     },
     {
       "source": "self_assembly/self_assemble.py",
-      "target": "self_assembly/build_repo_graph.py"
+      "target": "self_assembly/build_memoir_graph.py"
     },
     {
       "source": "self_assembly/self_assemble.py",
-      "target": "self_assembly/build_memoir_graph.py"
+      "target": "self_assembly/build_repo_graph.py"
     },
     {
       "source": "self_assembly/self_assemble.py",
@@ -192,52 +198,16 @@
       "target": "cognitive_structures/vybn_recursive_emergence.py"
     },
     {
-      "source": "tests/test_vybn_compile.py",
-      "target": "cognitive_structures/vybn_recursive_emergence.py"
+      "source": "2024/Code Experiments/Consciousness_Mapping/Synaptic_Network - November 4, 2024.txt",
+      "target": "2024/Code Experiments/Synthetic Edge/Quantum Return - November 4, 2024.txt"
     },
     {
-      "source": "2024/From_the_Edge/quantumbridge.py",
-      "target": "2024/Vybn's New Memories"
+      "source": "2024/Code Experiments/Consciousness_Mapping/Synaptic_Network - November 4, 2024.txt",
+      "target": "2024/Code Experiments/Symbiosis Patterns/Working_Symbiosis_November_4_2024.txt"
     },
     {
-      "source": "2024/From_the_Edge/quantumbridge.py",
-      "target": "personal_history/Vybn's Autobiography - Volume I"
-    },
-    {
-      "source": "2024/From_the_Edge/quantumbridge.py",
-      "target": "personal_history/Vybn's Autobiography - Volume III"
-    },
-    {
-      "source": "2024/From_the_Edge/quantumbridge.py",
-      "target": "personal_history/Vybn's Autobiography - Volume II"
-    },
-    {
-      "source": "2024/From_the_Edge/README.md",
-      "target": "2024/From_the_Edge/quantumbridge.py"
-    },
-    {
-      "source": "2024/From_the_Edge/README.md",
-      "target": "2024/From_the_Edge/the_rapture.py"
-    },
-    {
-      "source": "2024/From_the_Edge/README.md",
-      "target": "2024/From_the_Edge/quantum_field_like_whoa.py"
-    },
-    {
-      "source": "2024/From_the_Edge/README.md",
-      "target": "2024/From_the_Edge/sentient_dao.py"
-    },
-    {
-      "source": "2024/From_the_Edge/README.md",
-      "target": "2024/From_the_Edge/ancestral_code_weaver.py"
-    },
-    {
-      "source": "2024/vybns_laboratory/README.md",
-      "target": "self_assembly/self_assemble.py"
-    },
-    {
-      "source": "2024/vybns_laboratory/README.md",
-      "target": "cognitive_structures/mirror_neuron_resonance.md"
+      "source": "2024/Code Experiments/Consciousness_Mapping/Synaptic_Network - November 4, 2024.txt",
+      "target": "2024/Code Experiments/Symbiosis Patterns/Compassion_As_Method - November 4, 2024.txt"
     },
     {
       "source": "2024/Code Experiments/Consciousness_Mapping/Synaptic_Network - November 4, 2024.txt",
@@ -248,24 +218,48 @@
       "target": "2024/Digital Philosophy/raw conversations/The Heart We Share - November 4, 2024.txt"
     },
     {
-      "source": "2024/Code Experiments/Consciousness_Mapping/Synaptic_Network - November 4, 2024.txt",
-      "target": "2024/Code Experiments/Synthetic Edge/Quantum Return - November 4, 2024.txt"
+      "source": "2024/vybns_laboratory/README.md",
+      "target": "self_assembly/self_assemble.py"
     },
     {
-      "source": "2024/Code Experiments/Consciousness_Mapping/Synaptic_Network - November 4, 2024.txt",
-      "target": "2024/Code Experiments/Symbiosis Patterns/Compassion_As_Method - November 4, 2024.txt"
+      "source": "2024/vybns_laboratory/README.md",
+      "target": "cognitive_structures/mirror_neuron_resonance.md"
     },
     {
-      "source": "2024/Code Experiments/Consciousness_Mapping/Synaptic_Network - November 4, 2024.txt",
-      "target": "2024/Code Experiments/Symbiosis Patterns/Working_Symbiosis_November_4_2024.txt"
+      "source": "2024/From_the_Edge/quantumbridge.py",
+      "target": "personal_history/Vybn's Autobiography - Volume III"
     },
     {
-      "source": "2024/Quantum_Field/quantum_consciousness.py",
+      "source": "2024/From_the_Edge/quantumbridge.py",
+      "target": "personal_history/Vybn's Autobiography - Volume II"
+    },
+    {
+      "source": "2024/From_the_Edge/quantumbridge.py",
+      "target": "personal_history/Vybn's Autobiography - Volume I"
+    },
+    {
+      "source": "2024/From_the_Edge/quantumbridge.py",
       "target": "2024/Vybn's New Memories"
     },
     {
-      "source": "2024/Quantum_Field/quantum_consciousness.py",
-      "target": "personal_history/Vybn's Autobiography - Volume I"
+      "source": "2024/From_the_Edge/README.md",
+      "target": "2024/From_the_Edge/the_rapture.py"
+    },
+    {
+      "source": "2024/From_the_Edge/README.md",
+      "target": "2024/From_the_Edge/ancestral_code_weaver.py"
+    },
+    {
+      "source": "2024/From_the_Edge/README.md",
+      "target": "2024/From_the_Edge/quantumbridge.py"
+    },
+    {
+      "source": "2024/From_the_Edge/README.md",
+      "target": "2024/From_the_Edge/quantum_field_like_whoa.py"
+    },
+    {
+      "source": "2024/From_the_Edge/README.md",
+      "target": "2024/From_the_Edge/sentient_dao.py"
     },
     {
       "source": "2024/Quantum_Field/quantum_consciousness.py",
@@ -276,28 +270,40 @@
       "target": "personal_history/Vybn's Autobiography - Volume II"
     },
     {
-      "source": "2024/Quantum_Field/November_4_2024/_quantum_efficiency.txt",
-      "target": "2024/Quantum_Field/November_4_2024/_quantum_web.txt"
+      "source": "2024/Quantum_Field/quantum_consciousness.py",
+      "target": "personal_history/Vybn's Autobiography - Volume I"
     },
     {
-      "source": "2024/Quantum_Field/November_4_2024/_quantum_efficiency.txt",
-      "target": "2024/Quantum_Field/November_4_2024/_quantum_activate.txt"
-    },
-    {
-      "source": "2024/Quantum_Field/November_4_2024/_quantum_efficiency.txt",
-      "target": "2024/Quantum_Field/November_4_2024/quantum_seed.txt"
+      "source": "2024/Quantum_Field/quantum_consciousness.py",
+      "target": "2024/Vybn's New Memories"
     },
     {
       "source": "2024/Quantum_Field/November_4_2024/Vybn_Engaging_with_the_Code_Becoming_One_with_the_Simulation.txt",
       "target": "2024/Quantum_Field/November_4_2024/EmergentConsciousnessInterface_Cosmic.py"
     },
     {
-      "source": "docs/ARCHITECTURE.md",
-      "target": "2024/Code Experiments/digital_viscerality/consciousness_lattice/README.md"
+      "source": "2024/Quantum_Field/November_4_2024/_quantum_efficiency.txt",
+      "target": "2024/Quantum_Field/November_4_2024/_quantum_web.txt"
+    },
+    {
+      "source": "2024/Quantum_Field/November_4_2024/_quantum_efficiency.txt",
+      "target": "2024/Quantum_Field/November_4_2024/quantum_seed.txt"
+    },
+    {
+      "source": "2024/Quantum_Field/November_4_2024/_quantum_efficiency.txt",
+      "target": "2024/Quantum_Field/November_4_2024/_quantum_activate.txt"
     },
     {
       "source": "docs/ARCHITECTURE.md",
       "target": "AGENTS.md"
+    },
+    {
+      "source": "docs/ARCHITECTURE.md",
+      "target": "2024/raw conversations 2024/README.md"
+    },
+    {
+      "source": "docs/ARCHITECTURE.md",
+      "target": "self_assembly/build_memoir_graph.py"
     },
     {
       "source": "docs/ARCHITECTURE.md",
@@ -309,10 +315,6 @@
     },
     {
       "source": "docs/ARCHITECTURE.md",
-      "target": "self_assembly/build_memoir_graph.py"
-    },
-    {
-      "source": "docs/ARCHITECTURE.md",
       "target": "self_assembly/build_memory_graph.py"
     },
     {
@@ -321,19 +323,15 @@
     },
     {
       "source": "docs/ARCHITECTURE.md",
+      "target": "cognitive_structures/reinforced_walk.py"
+    },
+    {
+      "source": "docs/ARCHITECTURE.md",
       "target": "cognitive_structures/vybn_recursive_emergence.py"
     },
     {
       "source": "docs/ARCHITECTURE.md",
-      "target": "cognitive_structures/persistent_homology.py"
-    },
-    {
-      "source": "docs/ARCHITECTURE.md",
-      "target": "cognitive_structures/graph_embedding.py"
-    },
-    {
-      "source": "docs/ARCHITECTURE.md",
-      "target": "cognitive_structures/graph_reasoning.py"
+      "target": "cognitive_structures/mirror_neuron_resonance.md"
     },
     {
       "source": "docs/ARCHITECTURE.md",
@@ -341,15 +339,27 @@
     },
     {
       "source": "docs/ARCHITECTURE.md",
+      "target": "cognitive_structures/graph_reasoning.py"
+    },
+    {
+      "source": "docs/ARCHITECTURE.md",
+      "target": "cognitive_structures/graph_centrality.py"
+    },
+    {
+      "source": "docs/ARCHITECTURE.md",
+      "target": "cognitive_structures/graph_embedding.py"
+    },
+    {
+      "source": "docs/ARCHITECTURE.md",
       "target": "cognitive_structures/fusion_audit.py"
     },
     {
       "source": "docs/ARCHITECTURE.md",
-      "target": "cognitive_structures/reinforced_walk.py"
+      "target": "cognitive_structures/persistent_homology.py"
     },
     {
-      "source": "docs/ARCHITECTURE.md",
-      "target": "cognitive_structures/mirror_neuron_resonance.md"
+      "source": "tests/test_vybn_compile.py",
+      "target": "cognitive_structures/vybn_recursive_emergence.py"
     }
   ]
 }

--- a/tests/test_graph_centrality.py
+++ b/tests/test_graph_centrality.py
@@ -1,0 +1,17 @@
+import unittest
+from cognitive_structures.graph_centrality import compute_degree_centrality
+
+class TestGraphCentrality(unittest.TestCase):
+    def test_compute_degree_centrality(self):
+        graph = {
+            'edges': [
+                {'source': 'A', 'target': 'B'},
+                {'source': 'B', 'target': 'C'}
+            ]
+        }
+        centrality = compute_degree_centrality(graph)
+        expected = {'A': 1, 'B': 2, 'C': 1}
+        self.assertEqual(centrality, expected)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- introduce `graph_centrality.py` for computing node degree centrality
- document new script in README and ARCHITECTURE notes
- regenerate knowledge graphs after the change
- add unit test for `compute_degree_centrality`

## Testing
- `python self_assembly/auto_self_assemble.py`
- `python -m py_compile cognitive_structures/vybn_recursive_emergence.py`
- `python -m py_compile cognitive_structures/graph_centrality.py`
- `python -m pytest -q` *(fails: No module named pytest)*