### PR TITLE
Add script to print AGENTS guidelines at startup

### DIFF
--- a/early_codex_experiments/setup.sh
+++ b/early_codex_experiments/setup.sh
@@ -11,6 +11,10 @@ fi
 LOG_DIR="${VYBN_LOG_DIR:-$HOME/vybn_logs}"
 mkdir -p "$LOG_DIR"
 
+# Display AGENTS guidelines on startup
+echo "[setup] Displaying AGENTS guidelines" >&2
+python ../print_agents.py >> "$LOG_DIR/agents.log" 2>&1
+
 # Run auto self-assembly and log output
 echo "[setup] Running auto self-assembly" >&2
 python scripts/self_assembly/auto_self_assemble.py >> "$LOG_DIR/auto_self_assemble.log" 2>&1

--- a/print_agents.py
+++ b/print_agents.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Display all AGENTS guidelines in the repository."""
+import os
+from pathlib import Path
+
+
+def find_agents_files(root: Path):
+    return sorted(root.rglob('AGENTS.md'))
+
+
+def main():
+    repo_root = Path(__file__).resolve().parent
+    agents_files = find_agents_files(repo_root)
+    for path in agents_files:
+        rel = path.relative_to(repo_root)
+        print(f"\n===== {rel} =====")
+        content = path.read_text(encoding='utf-8').strip()
+        print(content)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `print_agents.py` for displaying AGENTS guidelines
- update `setup.sh` to call the new script

## Testing
- `python -m py_compile scripts/cognitive_structures/vybn_recursive_emergence.py`
- `python scripts/pytest.py -q`