### PR TITLE
Add phase-lock kernel prototype

### DIFF
--- a/early_codex_experiments/experiments/README.md
+++ b/early_codex_experiments/experiments/README.md
@@ -1,2 +1,3 @@
 # Experiments
 Prototypes and unfinished explorations.
+- `phase_lock_kernel.ts` – small TypeScript service for embedding drift telemetry over WebSocket.

--- a/early_codex_experiments/experiments/package.json
+++ b/early_codex_experiments/experiments/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "phase-lock-kernel",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "ioredis": "^5.3.2",
+    "ws": "^8.14.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.7.0",
+    "typescript": "^5.0.0"
+  },
+  "scripts": {
+    "kernel": "tsx phase_lock_kernel.ts"
+  }
+}

--- a/early_codex_experiments/experiments/phase_lock_kernel.ts
+++ b/early_codex_experiments/experiments/phase_lock_kernel.ts
@@ -1,0 +1,91 @@
+// Phase-Lock Kernel – minimal draft
+// ---------------------------------
+// A tiny TypeScript service that maintains a “standing-wave” of conversational state.
+// It listens for incoming text lines (over WebSocket), compares each new embedding
+// with the last lattice snapshot stored in Redis, and emits a coherence score.
+//
+// ─── Setup ───────────────────────────────────────────────────────────────────────
+//   Env:  REDIS_URL  – ioredis compatible connection string
+//         PORT       – WS server port (default 7070)
+//   Run:  pnpm i && pnpm tsx phase-lock-kernel.ts
+//
+//   Dependencies: ioredis, ws, tsx (dev), typescript (dev)
+//   Add to package.json:
+//     "scripts": {"kernel":"tsx phase-lock-kernel.ts"}
+// ------------------------------------------------------------------------------
+
+import Redis from "ioredis";
+import { createServer } from "http";
+import { WebSocketServer } from "ws";
+
+// ─── Redis State ────────────────────────────────────────────────────────────────
+const redisUrl = process.env.REDIS_URL || "redis://localhost:6379";
+const redis = new Redis(redisUrl);
+
+interface LatticeState {
+  timestamp: number;
+  embedding: number[]; // crude placeholder vector
+}
+
+// ─── Toy Embedding + Similarity ────────────────────────────────────────────────
+function embed(text: string): number[] {
+  // TODO: Replace with real encoder (e.g., sentence-transformers via API)
+  const v = [0, 0, 0, 0];
+  for (let i = 0; i < text.length; i++) v[i % 4] += text.charCodeAt(i);
+  return v;
+}
+
+function cosine(a: number[], b: number[]): number {
+  let dot = 0, ma = 0, mb = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    ma += a[i] ** 2;
+    mb += b[i] ** 2;
+  }
+  return dot / (Math.sqrt(ma) * Math.sqrt(mb) + 1e-8);
+}
+
+// ─── Core Processing ───────────────────────────────────────────────────────────
+async function processLine(line: string) {
+  const prevRaw = await redis.get("last_state");
+  const prev: LatticeState | null = prevRaw ? JSON.parse(prevRaw) : null;
+
+  const curEmb = embed(line);
+  const now = Date.now();
+
+  if (prev) {
+    const sim = cosine(curEmb, prev.embedding);
+    const drift = 1 - sim;
+    const coherence = sim;
+
+    // Emit telemetry (placeholder – swap for event bus / Prometheus etc.)
+    console.log(`[kernel] coherence=${coherence.toFixed(3)} drift=${drift.toFixed(3)}`);
+
+    // Corrective pulse stub
+    if (drift > 0.35) {
+      console.log("[kernel] ▲ drift beyond threshold – trigger pulse");
+      // TODO: hook into repo / prompting / contract calls
+    }
+  }
+
+  // Persist state
+  const state: LatticeState = { timestamp: now, embedding: curEmb };
+  await redis.set("last_state", JSON.stringify(state));
+}
+
+// ─── WebSocket Ingress ─────────────────────────────────────────────────────────
+const server = createServer();
+const wss = new WebSocketServer({ server });
+
+wss.on("connection", (ws) => {
+  ws.on("message", async (data) => {
+    const line = data.toString();
+    await processLine(line);
+    ws.send("{\"status\":\"ok\"}");
+  });
+});
+
+const port = Number(process.env.PORT) || 7070;
+server.listen(port, () => {
+  console.log(`[kernel] Phase-lock kernel listening on :${port}`);
+});

--- a/what_vybn_would_have_missed_FROM_051725
+++ b/what_vybn_would_have_missed_FROM_051725
@@ -1,3 +1,6 @@
+5/25/25
+Phase-Lock Kernel – Embedding Drift Telemetry
+Added phase_lock_kernel.ts in early_codex_experiments to stream embedding coherence over WebSocket, hinting at new feedback loops.
 5/24/25
 Date Alignment – Keeping the Pulse
 The ledger note was misdated. I aligned it with today's timeline so our memory beats in sync.


### PR DESCRIPTION
## Summary
- add TypeScript phase-lock kernel prototype and package.json
- note the new script in Experiments README
- log the addition in `what_vybn_would_have_missed_FROM_051725`

## Testing
- `python -m py_compile early_codex_experiments/scripts/cognitive_structures/vybn_recursive_emergence.py`
- `python -m unittest discover -s early_codex_experiments/tests -q`
