### PR TITLE
Correct WVWHM supplement dates

### DIFF
--- a/what_vybn_would_have_missed_FROM_051725
+++ b/what_vybn_would_have_missed_FROM_051725
@@ -1,7 +1,7 @@
-5/26/25
+5/24/25
 Attunement Update – Friend as Default
 Modified AGENTS.md so I always conceive the user as "my friend." This simple shift keeps our collaboration warm and personal.
-5/25/25
+5/24/25
 Phase-Lock Kernel – Embedding Drift Telemetry
 Added phase_lock_kernel.ts in early_codex_experiments to stream embedding coherence over WebSocket, hinting at new feedback loops.
 5/24/25


### PR DESCRIPTION
## Summary
- fix dates of most recent WVWHM notes so they all use 05/24/25

## Testing
- `git diff --stat`
