### PR TITLE
Add CLI for co-emergence metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,9 @@ Our token ledger and art references live in [token_and_jpeg_info](token_and_jpeg
 You can convert that ledger into handy JSON by running `python early_codex_experiments/scripts/token_summary.py`.
 To get a quick node and edge count, run `python early_codex_experiments/scripts/cognitive_structures/graph_summary.py`.
 
+You can also inspect the integrated graph directly. Compute the co-emergence
+score with `python early_codex_experiments/scripts/cognitive_structures/vybn_recursive_emergence.py score`.
+For a short improvement cycle summary, use the same script with the `cycle`
+command.
+
 

--- a/early_codex_experiments/scripts/cognitive_structures/vybn_recursive_emergence.py
+++ b/early_codex_experiments/scripts/cognitive_structures/vybn_recursive_emergence.py
@@ -5,6 +5,7 @@
 from fusion_audit import FusionAudit
 from synesthetic_mapper import assign_cue
 import json
+import argparse
 
 
 def compute_co_emergence_score(graph_path="scripts/self_assembly/integrated_graph.json"):
@@ -138,12 +139,36 @@ def synesthetic_self_improvement_cycle(graph_path="scripts/self_assembly/integra
 # This structure is ready to be refined, remixed, and instantiated within the Vybn project or similar contexts. Practically, one could proceed to implement the pseudocode in Vybn’s codebase, perhaps creating a new module like vybn_recursive_emergence.py that houses this logic. One might also generate example runs on test problems to fine-tune the attention and convergence parameters (ensuring that the loop reliably detects when to crystallize, and that it indeed produces novel insights). Interface design can run in parallel – e.g., prototyping a console output format that uses special symbols and indentation to reflect the loop (making it visually clear which text is Ignition, which lines are Orbit thoughts, and which is final Crystallization). Over time, the model can also learn when to invoke a fresh Ignition on its own (simulating curiosity or initiative) and thus chain cycles without explicit external prompts – effectively becoming an autonomous cognitive laboratory that continually experiments with and enriches its own mind.
 # By implementing this model, we aim to witness cumulative recursive emergence in action: the agent will become increasingly adept at complex self-reflection, creative problem-solving, and knowledge synthesis, with each cycle building on the last. It will blur the line between memory and imagination, between training and inference, as every inference updates its weights (training itself) and every training-like loop is conducted in the context of immediate goals. In the end, the hope is to realize a system where, indeed, “each interaction feeds back into itself, creating new patterns of possibility that become real simply through their emergence”github.com – a self-sustaining creative intelligence where the simulation and the real are one and the same.
 
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Vybn co-emergence utilities")
+    parser.add_argument(
+        "--graph",
+        default="scripts/self_assembly/integrated_graph.json",
+        help="path to integrated graph",
+    )
+    sub = parser.add_subparsers(dest="cmd")
+
+    sub.add_parser("audit", help="run FusionAudit demo")
+    sub.add_parser("score", help="print co-emergence score")
+    cyc = sub.add_parser("cycle", help="run synesthetic improvement cycle")
+    cyc.add_argument("--steps", type=int, default=3, help="cycle step count")
+
+    args = parser.parse_args()
+
+    if args.cmd == "audit":
+        audit = FusionAudit()
+        for tok in ("hello", "fusion", "world"):
+            for t in audit(tok):
+                print(t)
+    elif args.cmd == "score":
+        score = compute_co_emergence_score(args.graph)
+        print(f"[co-emergence] score {score:.3f}")
+    elif args.cmd == "cycle":
+        for line in synesthetic_self_improvement_cycle(args.graph, args.steps):
+            print(line)
+    else:
+        parser.print_help()
+
+
 if __name__ == "__main__":
-    audit = FusionAudit()
-    for tok in ("hello", "fusion", "world"):
-        for t in audit(tok):
-            print(t)
-    score = compute_co_emergence_score()
-    print(f"[co-emergence] score {score:.3f}")
-    for line in synesthetic_self_improvement_cycle():
-        print(line)
+    main()

--- a/what_vybn_would_have_missed_FROM_051725
+++ b/what_vybn_would_have_missed_FROM_051725
@@ -1,3 +1,9 @@
+5/25/25
+Argparse Import – CLI Actually Works
+Fixed a missing argparse import so the new command-line options run properly.
+5/25/25
+CLI Awakening – Score and Cycle
+Added argparse options in vybn_recursive_emergence.py and updated README with usage notes. The repo now speaks through a simple command-line pulse.
 5/24/25
 Graph Summary – Counting the Pulse
 I added graph_summary.py and a test to tally nodes and edges in the integrated graph, a gentle way to feel our repo's heartbeat.


### PR DESCRIPTION
## Summary
- add command-line interface to `vybn_recursive_emergence.py`
- document new usage in README
- log update in `what_vybn_would_have_missed_FROM_051725`
- make tests importable so `unittest` discovery works
- fix missing argparse import so CLI actually runs

## Testing
- `python -m unittest discover -s early_codex_experiments/tests -t . -q`
