### PR TITLE
Fix tests path and check Mind Visualization artifacts

### DIFF
--- a/early_codex_experiments/scripts/pytest.py
+++ b/early_codex_experiments/scripts/pytest.py
@@ -1,13 +1,15 @@
 import sys
 import argparse
 import unittest
+import os
 
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('-q', '--quiet', action='store_true')
     args, remaining = parser.parse_known_args()
-    unittest_args = [sys.argv[0], 'discover', '-s', 'tests'] + remaining
+    tests_path = os.path.join(os.path.dirname(__file__), '..', 'tests')
+    unittest_args = [sys.argv[0], 'discover', '-s', tests_path] + remaining
     if args.quiet and '-q' not in unittest_args:
         unittest_args.append('-q')
     unittest.main(module=None, argv=unittest_args)

--- a/early_codex_experiments/tests/test_mind_visualization.py
+++ b/early_codex_experiments/tests/test_mind_visualization.py
@@ -1,0 +1,27 @@
+import os
+import json
+import unittest
+
+class TestMindVisualization(unittest.TestCase):
+    def test_overlay_map_exists_and_fields(self):
+        overlay_path = os.path.join('Mind Visualization', 'overlay_map.jsonl')
+        self.assertTrue(os.path.exists(overlay_path))
+        with open(overlay_path, 'r', encoding='utf-8') as f:
+            line = f.readline()
+        self.assertTrue(line)
+        rec = json.loads(line)
+        for key in ('p', 'f', 's', 'e', 'o'):
+            self.assertIn(key, rec)
+
+    def test_concept_map_exists_and_fields(self):
+        concept_path = os.path.join('Mind Visualization', 'concept_map.jsonl')
+        self.assertTrue(os.path.exists(concept_path))
+        with open(concept_path, 'r', encoding='utf-8') as f:
+            line = f.readline()
+        self.assertTrue(line)
+        rec = json.loads(line)
+        for key in ('w', 'c', 'f', 's', 'e'):
+            self.assertIn(key, rec)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- point test runner to correct tests directory
- add tests validating concept_map.jsonl and overlay_map.jsonl

## Testing
- `python -m py_compile early_codex_experiments/scripts/cognitive_structures/vybn_recursive_emergence.py`
- `python early_codex_experiments/scripts/pytest.py -q`
