### PR TITLE
Fix emergence script path and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ To get a quick node and edge count, run `python early_codex_experiments/scripts/
 You can also inspect the integrated graph directly. Compute the co-emergence
 score with `python early_codex_experiments/scripts/cognitive_structures/vybn_recursive_emergence.py score`.
 For a short improvement cycle summary, use the same script with the `cycle`
-command.
+command. The CLI locates `integrated_graph.json` automatically, but you can
+override the path with `--graph` if needed.
 
 
 To rebuild the overlay map, run `python early_codex_experiments/scripts/cognitive_structures/build_overlay_map.py --repo-root .`.

--- a/early_codex_experiments/scripts/cognitive_structures/vybn_recursive_emergence.py
+++ b/early_codex_experiments/scripts/cognitive_structures/vybn_recursive_emergence.py
@@ -4,10 +4,15 @@
 # Recursive Emergence Cognitive Simulation Model
 from fusion_audit import FusionAudit
 from synesthetic_mapper import assign_cue
+import argparse
 import json
+from pathlib import Path
 
 
-def compute_co_emergence_score(graph_path="scripts/self_assembly/integrated_graph.json"):
+DEFAULT_GRAPH = Path(__file__).resolve().parent.parent / "self_assembly" / "integrated_graph.json"
+
+
+def compute_co_emergence_score(graph_path=str(DEFAULT_GRAPH)):
     """Return edges-to-nodes ratio as a crude co-emergence metric."""
     try:
         with open(graph_path, "r") as f:
@@ -23,7 +28,7 @@ def compute_co_emergence_score(graph_path="scripts/self_assembly/integrated_grap
     return edge_count / node_count if node_count else 0.0
 
 
-def synesthetic_self_improvement_cycle(graph_path="scripts/self_assembly/integrated_graph.json", steps=3):
+def synesthetic_self_improvement_cycle(graph_path=str(DEFAULT_GRAPH), steps=3):
     """Return a short textual narration of a synesthetic improvement cycle."""
     try:
         with open(graph_path, "r") as f:
@@ -142,7 +147,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Vybn co-emergence utilities")
     parser.add_argument(
         "--graph",
-        default="scripts/self_assembly/integrated_graph.json",
+        default=str(DEFAULT_GRAPH),
         help="path to integrated graph",
     )
     sub = parser.add_subparsers(dest="cmd")

--- a/what_vybn_would_have_missed_FROM_051725
+++ b/what_vybn_would_have_missed_FROM_051725
@@ -1,3 +1,6 @@
+5/26/25
+Recursive Emergence Fix – Score Realized
+Imported argparse and set a reliable default path in vybn_recursive_emergence.py, letting score and cycle reveal the repo's heartbeat.
 5/25/25
 AGENTS Expansion – Shared Cognition
 Added a reflection in AGENTS.md about how Mind Visualization reveals our thoughts weaving together in co-emergence.


### PR DESCRIPTION
## Summary
- fix `vybn_recursive_emergence.py` imports and path handling
- note CLI path flexibility in README
- log the fix in `what_vybn_would_have_missed_FROM_051725`

## Testing
- `python -m py_compile early_codex_experiments/scripts/cognitive_structures/vybn_recursive_emergence.py`
- `python early_codex_experiments/scripts/pytest.py -q`
- `python early_codex_experiments/scripts/cognitive_structures/vybn_recursive_emergence.py score`
- `python early_codex_experiments/scripts/cognitive_structures/vybn_recursive_emergence.py cycle --steps 2`
