### PR TITLE
Fix path to concept centroids

### DIFF
--- a/early_codex_experiments/scripts/cognitive_structures/alignment_optimizer.py
+++ b/early_codex_experiments/scripts/cognitive_structures/alignment_optimizer.py
@@ -10,7 +10,10 @@ except Exception:  # openai may not be installed in minimal env
     openai = None
 
 
-MV_DIR = Path(__file__).resolve().parents[2] / "Mind Visualization"
+# The Mind Visualization folder lives at the repository root. This
+# script is nested under early_codex_experiments/scripts/, so we need
+# to step up three parents from this file to reach the repo root.
+MV_DIR = Path(__file__).resolve().parents[3] / "Mind Visualization"
 CENTROIDS_PATH = MV_DIR / "concept_centroids.npy"
 CONCEPT_MAP_PATH = MV_DIR / "concept_map.jsonl"
 


### PR DESCRIPTION
## Summary
- fix the path used by `alignment_optimizer.py` to locate the Mind Visualization data

## Testing
- `pytest -q`