### PR TITLE
Add co-emergence journal utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,5 +46,7 @@ For a short improvement cycle summary, use the same script with the `cycle`
 command. The CLI locates `integrated_graph.json` automatically, but you can
 override the path with `--graph` if needed.
 
+Append a timestamped co-emergence entry with `python early_codex_experiments/scripts/cognitive_structures/emergence_journal.py`. Each run writes to `co_emergence_journal.jsonl` so we can watch the score evolve.
+
 
 To rebuild the overlay map, run `python early_codex_experiments/scripts/cognitive_structures/build_overlay_map.py --repo-root .`.

--- a/early_codex_experiments/scripts/cognitive_structures/emergence_journal.py
+++ b/early_codex_experiments/scripts/cognitive_structures/emergence_journal.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+import json
+from datetime import datetime
+from pathlib import Path
+
+from .vybn_recursive_emergence import compute_co_emergence_score
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_GRAPH = REPO_ROOT / 'early_codex_experiments' / 'scripts' / 'self_assembly' / 'integrated_graph.json'
+JOURNAL_PATH = REPO_ROOT / 'co_emergence_journal.jsonl'
+
+
+def log_score(graph_path: str | Path = DEFAULT_GRAPH, journal_path: str | Path = JOURNAL_PATH) -> dict:
+    """Append current co-emergence score to ``journal_path`` and return the entry."""
+    graph_path = Path(graph_path)
+    journal_path = Path(journal_path)
+    score = compute_co_emergence_score(str(graph_path))
+    entry = {
+        'timestamp': datetime.utcnow().isoformat(timespec='seconds') + 'Z',
+        'score': round(score, 3),
+    }
+    with journal_path.open('a', encoding='utf-8') as f:
+        f.write(json.dumps(entry) + '\n')
+    return entry
+
+
+def main() -> None:
+    entry = log_score()
+    print(json.dumps(entry, indent=2))
+
+
+if __name__ == '__main__':
+    main()

--- a/early_codex_experiments/scripts/cognitive_structures/vybn_recursive_emergence.py
+++ b/early_codex_experiments/scripts/cognitive_structures/vybn_recursive_emergence.py
@@ -2,8 +2,8 @@
 # 
 # Emergent Simulation Model Based on Recursive Basin-Lab Identity
 # Recursive Emergence Cognitive Simulation Model
-from fusion_audit import FusionAudit
-from synesthetic_mapper import assign_cue
+from .fusion_audit import FusionAudit
+from .synesthetic_mapper import assign_cue
 import argparse
 import json
 from pathlib import Path

--- a/early_codex_experiments/tests/test_emergence_journal.py
+++ b/early_codex_experiments/tests/test_emergence_journal.py
@@ -1,0 +1,35 @@
+import unittest
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from scripts.cognitive_structures.emergence_journal import log_score
+
+
+class TestEmergenceJournal(unittest.TestCase):
+    def test_log_score(self):
+        graph = {
+            'memory_nodes': [1],
+            'memoir_nodes': [],
+            'repo_nodes': ['a', 'b'],
+            'edges': [{'source': 1, 'target': 'a'}],
+        }
+        gpath = 'tmp_graph.json'
+        jpath = 'tmp_journal.jsonl'
+        with open(gpath, 'w') as f:
+            json.dump(graph, f)
+        if os.path.exists(jpath):
+            os.remove(jpath)
+        entry = log_score(gpath, jpath)
+        with open(jpath, 'r') as f:
+            line = f.readline()
+        os.remove(gpath)
+        os.remove(jpath)
+        logged = json.loads(line)
+        self.assertEqual(logged['score'], entry['score'])
+        self.assertIn('timestamp', logged)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/what_vybn_would_have_missed_FROM_051725
+++ b/what_vybn_would_have_missed_FROM_051725
@@ -1,3 +1,6 @@
+5/26/25
+Co-Emergence Journal – Trendline Begun
+Added emergence_journal.py and a test so each run logs today's score.
 5/25/25
 Recursive Emergence Fix – Score Realized
 Imported argparse and set a reliable default path in vybn_recursive_emergence.py, letting score and cycle reveal the repo's heartbeat.


### PR DESCRIPTION
## Summary
- create `emergence_journal.py` to log co-emergence score over time
- test the journal utility
- note the new tool in README
- adjust imports in `vybn_recursive_emergence.py`
- log the update in `what_vybn_would_have_missed_FROM_051725`
- include empty `co_emergence_journal.jsonl`

## Testing
- `python -m py_compile early_codex_experiments/scripts/cognitive_structures/vybn_recursive_emergence.py`
- `python early_codex_experiments/scripts/pytest.py -q`