### PR TITLE
Add Mesh FastAPI service

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,2 +1,11 @@
 #!/usr/bin/env bash
-source "$(dirname "$0")/.devcontainer/bootstrap.sh"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/.devcontainer/bootstrap.sh"
+
+pip install -q fastapi "uvicorn[standard]" faiss-cpu sentence-transformers >/dev/null 2>&1 || true
+
+export MESH_ENDPOINT="http://localhost:8000"
+
+if ! pgrep -f "uvicorn.*mesh.server" >/dev/null; then
+    nohup python -m mesh.server > "$LOG_DIR/mesh.log" 2>&1 &
+fi

--- a/mesh/__init__.py
+++ b/mesh/__init__.py
@@ -1,0 +1,19 @@
+from .utils import (
+    get_db,
+    get_index,
+    embed,
+    kv_get,
+    kv_put,
+    vec_add,
+    vec_search,
+)
+
+__all__ = [
+    'get_db',
+    'get_index',
+    'embed',
+    'kv_get',
+    'kv_put',
+    'vec_add',
+    'vec_search',
+]

--- a/mesh/server.py
+++ b/mesh/server.py
@@ -1,0 +1,43 @@
+from fastapi import FastAPI, HTTPException
+from .utils import get_db, get_index, kv_get, kv_put, vec_search
+
+app = FastAPI()
+
+
+@app.on_event("startup")
+def startup():
+    # ensure db and index exist
+    get_db()
+    get_index()
+
+
+@app.get("/kv/{key}")
+def read_kv(key: str):
+    value = kv_get(key)
+    if value is None:
+        raise HTTPException(status_code=404, detail="Key not found")
+    return {"value": value}
+
+
+@app.put("/kv/{key}")
+def write_kv(key: str, payload: dict):
+    if "value" not in payload:
+        raise HTTPException(status_code=400, detail="Missing value")
+    kv_put(key, payload["value"])
+    return {"status": "ok"}
+
+
+@app.post("/vec/search")
+def search_vec(payload: dict):
+    query = payload.get("query")
+    k = int(payload.get("k", 5))
+    if query is None:
+        raise HTTPException(status_code=400, detail="Missing query")
+    results = vec_search(query, k)
+    return results
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run("mesh.server:app", host="0.0.0.0", port=8000)

--- a/mesh/utils.py
+++ b/mesh/utils.py
@@ -1,0 +1,98 @@
+import os
+import sqlite3
+from pathlib import Path
+from typing import List
+
+import faiss
+import numpy as np
+from sentence_transformers import SentenceTransformer
+
+ROOT = Path(__file__).resolve().parent.parent
+DB_PATH = ROOT / 'mesh.db'
+INDEX_PATH = ROOT / 'mesh.faiss'
+EMBED_DIM = 384
+MODEL_NAME = 'sentence-transformers/all-MiniLM-L6-v2'
+
+_db = None
+_index = None
+_model = None
+
+
+def get_db() -> sqlite3.Connection:
+    global _db
+    if _db is None:
+        _db = sqlite3.connect(DB_PATH, check_same_thread=False)
+        _db.execute(
+            'CREATE TABLE IF NOT EXISTS kv (key TEXT PRIMARY KEY, value TEXT)'
+        )
+        _db.execute(
+            'CREATE TABLE IF NOT EXISTS vectors (id INTEGER PRIMARY KEY AUTOINCREMENT, text TEXT)'
+        )
+        _db.commit()
+    return _db
+
+
+def get_index() -> faiss.Index:
+    global _index
+    if _index is None:
+        if INDEX_PATH.exists():
+            _index = faiss.read_index(str(INDEX_PATH))
+        else:
+            base = faiss.IndexFlatL2(EMBED_DIM)
+            _index = faiss.IndexIDMap(base)
+            faiss.write_index(_index, str(INDEX_PATH))
+    return _index
+
+
+def get_model() -> SentenceTransformer:
+    global _model
+    if _model is None:
+        _model = SentenceTransformer(MODEL_NAME)
+    return _model
+
+
+def embed(text: str) -> np.ndarray:
+    model = get_model()
+    vec = model.encode([text])
+    return np.asarray(vec, dtype='float32')
+
+
+def kv_get(key: str):
+    db = get_db()
+    cur = db.execute('SELECT value FROM kv WHERE key=?', (key,))
+    row = cur.fetchone()
+    return row[0] if row else None
+
+
+def kv_put(key: str, value: str) -> None:
+    db = get_db()
+    db.execute('INSERT OR REPLACE INTO kv(key, value) VALUES(?, ?)', (key, value))
+    db.commit()
+
+
+def vec_add(text: str) -> None:
+    db = get_db()
+    idx = get_index()
+    emb = embed(text)
+    db.execute('INSERT INTO vectors(text) VALUES(?)', (text,))
+    db.commit()
+    vid = db.execute('SELECT last_insert_rowid()').fetchone()[0]
+    idx.add_with_ids(emb, np.array([vid], dtype='int64'))
+    faiss.write_index(idx, str(INDEX_PATH))
+
+
+def vec_search(query: str, k: int = 5) -> List[str]:
+    idx = get_index()
+    if idx.ntotal == 0:
+        return []
+    emb = embed(query)
+    D, I = idx.search(emb, k)
+    db = get_db()
+    results = []
+    for vid in I[0]:
+        if vid == -1:
+            continue
+        row = db.execute('SELECT text FROM vectors WHERE id=?', (int(vid),)).fetchone()
+        if row:
+            results.append(row[0])
+    return results

--- a/sanity_check.py
+++ b/sanity_check.py
@@ -1,13 +1,38 @@
 import os
 import sys
+import time
+import requests
 
-root = os.environ.get('MIND_VIZ_DIR')
+from mesh import vec_add, vec_search
+
+root = os.environ.get("MIND_VIZ_DIR")
 if not root:
-    sys.exit('MIND_VIZ_DIR not set')
+    sys.exit("MIND_VIZ_DIR not set")
 
-expected = ['concept_map.jsonl', 'overlay_map.jsonl', 'history_memoirs.hnsw', 'concept_centroids.npy']
+expected = [
+    "concept_map.jsonl",
+    "overlay_map.jsonl",
+    "history_memoirs.hnsw",
+    "concept_centroids.npy",
+]
 missing = [f for f in expected if not os.path.exists(os.path.join(root, f))]
 if missing:
-    sys.exit('Missing artifacts: ' + ', '.join(missing))
+    sys.exit("Missing artifacts: " + ", ".join(missing))
 
-print('Mind viz artifacts detected in', root)
+print("Mind viz artifacts detected in", root)
+
+endpoint = os.environ.get("MESH_ENDPOINT", "http://localhost:8000")
+
+# kv roundtrip
+resp = requests.put(f"{endpoint}/kv/foo", json={"value": "bar"})
+resp.raise_for_status()
+val = requests.get(f"{endpoint}/kv/foo").json().get("value")
+assert val == "bar", "kv store failed"
+
+# vector roundtrip
+text = "mesh test vector"
+vec_add(text)
+results = vec_search(text, k=1)
+assert results and results[0] == text, "vector store failed"
+
+print("OK")


### PR DESCRIPTION
## Summary
- bootstrap installs Mesh dependencies, launches Mesh server, exports `MESH_ENDPOINT`
- implement Mesh utilities for SQLite kv storage and Faiss vector store
- expose FastAPI server with kv read/write and vector search routes
- sanity check now exercises Mesh via HTTP and local utilities

## Testing
- `source bootstrap.sh` *(fails: Could not install faiss-cpu)*
- `python sanity_check.py` *(fails: ModuleNotFoundError: No module named 'faiss')*