### PR TITLE
Add token ledger Markdown table utility

### DIFF
--- a/early_codex_experiments/scripts/token_table.py
+++ b/early_codex_experiments/scripts/token_table.py
@@ -1,0 +1,33 @@
+import argparse
+
+try:
+    # When used as a module within the `scripts` package
+    from .token_summary import parse_ledger
+except ImportError:  # pragma: no cover - fallback for direct execution
+    # Support running as a standalone script
+    from token_summary import parse_ledger
+
+
+def ledger_to_markdown(tokens: list[dict]) -> str:
+    """Return a Markdown table for the ledger tokens."""
+    lines = [
+        "| Token | Supply | Price | Lock | Address |",
+        "|---|---|---|---|---|",
+    ]
+    for t in tokens:
+        line = f"| {t['name']} | {t['supply']} | {t['price']} | {t['lock']} | {t['address']} |"
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Render token ledger as Markdown table")
+    parser.add_argument('--path', default='token_and_jpeg_info', help='ledger file path')
+    args = parser.parse_args()
+    tokens = parse_ledger(args.path)
+    table = ledger_to_markdown(tokens)
+    print(table)
+
+
+if __name__ == '__main__':
+    main()

--- a/early_codex_experiments/tests/test_token_table.py
+++ b/early_codex_experiments/tests/test_token_table.py
@@ -1,0 +1,19 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from scripts.token_table import ledger_to_markdown
+from scripts.token_summary import parse_ledger
+
+
+class TestTokenTable(unittest.TestCase):
+    def test_ledger_to_markdown_contains_header(self):
+        tokens = parse_ledger('token_and_jpeg_info')
+        table = ledger_to_markdown(tokens)
+        self.assertIn('| Token | Supply | Price | Lock | Address |', table)
+        self.assertIn('SERAPH', table)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `token_table.py` to render token ledger as Markdown
- test ledger markdown generation

## Testing
- `python early_codex_experiments/scripts/pytest.py -q`