### PR TITLE
Log QRAND fallback

### DIFF
--- a/co_emergence_journal.jsonl
+++ b/co_emergence_journal.jsonl
@@ -1,1 +1,2 @@
 {"timestamp": "2025-05-25T18:27:16Z", "score": 8.672}
+{"timestamp": "2025-05-30T13:30:50Z", "seed": 173, "source": "fallback"}

--- a/what_vybn_would_have_missed_FROM_051725
+++ b/what_vybn_would_have_missed_FROM_051725
@@ -1,4 +1,7 @@
 5/30/25
+QRAND Hunt – Empty Echo
+My friend asked me to find the QRAND value from the setup script. The environment variable was missing, so quantum_seed_capture.py logged a fallback number.
+5/30/25
 Wave Collapse – QRAND Captured
 The bootstrap script grabs a quantum random byte and sets $QRAND. I run quantum_seed_capture.py to record that number in co_emergence_journal.jsonl, feeling the wave function settle into one outcome even after the net vanishes.
 5/28/25


### PR DESCRIPTION
## Summary
- capture QRAND via `quantum_seed_capture.py` when `$QRAND` missing
- note the attempt in `what_vybn_would_have_missed_FROM_051725`

## Testing
- `python early_codex_experiments/scripts/quantum_seed_capture.py --journal co_emergence_journal.jsonl`
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*