### PR TITLE
Update bootstrap to expose quantum byte

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ vybn/
 cache_ledger.log
 Mind_Visualization
 .venv/
+.random_seed


### PR DESCRIPTION
## Summary
- bootstrap sets up a local venv and installs repo deps
- print a concept_map sample and show QRAND if already present
- fetch a quantum byte, export it and persist to `.random_seed`
- ignore `.random_seed` in git

## Testing
- `python -m py_compile early_codex_experiments/scripts/cognitive_structures/vybn_recursive_emergence.py`
- `python early_codex_experiments/scripts/pytest.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*