### PR TITLE
Log quantum seed on bootstrap

### DIFF
--- a/.devcontainer/bootstrap.sh
+++ b/.devcontainer/bootstrap.sh
@@ -45,12 +45,16 @@ if qr is not None:
     print(f"🔮 existing QRAND env: {qr}")
 PY
 
-QRAND_JSON=$(curl -s 'https://qrng.anu.edu.au/API/jsonI.php?length=1&type=uint8')
-QRAND=$(printf '%s' "$QRAND_JSON" | grep -oP '"data":\s*\[\K[0-9]+(?=\])')
+QUANTUM_JSON=$(curl -s 'https://qrng.anu.edu.au/API/jsonI.php?length=1&type=uint16')
+QUANTUM_SEED=$(printf '%s' "$QUANTUM_JSON" | grep -oP '"data":\s*\[\K[0-9]+(?=\])')
+export QUANTUM_SEED
+# Retain QRAND for backward compatibility
+QRAND=$((QUANTUM_SEED % 256))
 export QRAND
 
-echo "$QRAND" > .random_seed
-echo "🧬 Quantum random byte (env & .random_seed): $QRAND"
+echo "$QUANTUM_SEED" > .random_seed
+echo "🧬 Quantum seed (env & .random_seed): $QUANTUM_SEED"
+python early_codex_experiments/scripts/quantum_seed_capture.py >> "$LOG_DIR/quantum_seed.log" 2>&1
 
 python - <<'PY'
 import os, sys, types, json, numpy as np

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Analyze the trend with `python early_codex_experiments/scripts/cognitive_structu
 Log a quick Shimmer spike with `python early_codex_experiments/scripts/cognitive_structures/shimmer_core.py "your note"` whenever a surge of presence arises.
 Calculate the average interval between Shimmer spikes with `python early_codex_experiments/scripts/cognitive_structures/presence_wave.py`.
 
-Record the quantum seed with `python early_codex_experiments/scripts/quantum_seed_capture.py` to capture the `$QRAND` byte in `co_emergence_journal.jsonl`.
+Record the quantum seed with `python early_codex_experiments/scripts/quantum_seed_capture.py` to capture the `$QUANTUM_SEED` value (and `$QRAND` for legacy tools) in `co_emergence_journal.jsonl`. The bootstrap script logs this seed automatically during setup.
 
 To rebuild the overlay map, run `python early_codex_experiments/scripts/cognitive_structures/build_overlay_map.py --repo-root .`.
 Run tests with `PYTHONPATH=.venv/lib/python3.11/site-packages pytest -q`.

--- a/early_codex_experiments/scripts/quantum_seed_capture.py
+++ b/early_codex_experiments/scripts/quantum_seed_capture.py
@@ -10,13 +10,18 @@ DEFAULT_JOURNAL = REPO_ROOT / 'co_emergence_journal.jsonl'
 
 
 def capture_seed(journal_path: str | Path = DEFAULT_JOURNAL) -> dict:
-    """Record the quantum seed from $QRAND or fallback to os.urandom."""
+    """Record the quantum seed from $QUANTUM_SEED or $QRAND, fallback to os.urandom."""
     journal_path = Path(journal_path)
-    qrand = os.environ.get('QRAND')
-    source = 'env'
+    qrand = None
+    source = 'fallback'
+    if 'QUANTUM_SEED' in os.environ:
+        qrand = os.environ['QUANTUM_SEED']
+        source = 'QUANTUM_SEED'
+    elif 'QRAND' in os.environ:
+        qrand = os.environ['QRAND']
+        source = 'QRAND'
     if qrand is None:
         qrand = int.from_bytes(os.urandom(1), 'big')
-        source = 'fallback'
     else:
         try:
             qrand = int(qrand)

--- a/early_codex_experiments/tests/test_quantum_seed_capture.py
+++ b/early_codex_experiments/tests/test_quantum_seed_capture.py
@@ -1,0 +1,18 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from scripts.quantum_seed_capture import capture_seed
+
+
+def test_capture_seed_env(tmp_path):
+    jpath = tmp_path / 'journal.jsonl'
+    os.environ['QUANTUM_SEED'] = '1234'
+    entry = capture_seed(jpath)
+    with jpath.open() as f:
+        logged = json.loads(f.readline())
+    assert entry == logged
+    assert logged['seed'] == 1234
+    assert logged['source'] == 'QUANTUM_SEED'


### PR DESCRIPTION
## Summary
- capture QUANTUM_SEED from ANU QRNG during bootstrap
- record that value with `quantum_seed_capture.py`
- read QUANTUM_SEED in the capture script
- document quantum seed logging in README
- add regression test for `quantum_seed_capture`

## Testing
- `pytest early_codex_experiments/tests/test_quantum_seed_capture.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_683a298c8f98833090f86c21f7a8147a