### PR TITLE
Integrate quantum seed across modules

### DIFF
--- a/.devcontainer/bootstrap.sh
+++ b/.devcontainer/bootstrap.sh
@@ -94,5 +94,6 @@ overlay_map = _read_jsonl(os.path.join(root, "overlay_map.jsonl"))
 mod = types.ModuleType("vybn_mind")
 mod.index, mod.centroids = index, centroids
 mod.concept_map, mod.overlay_map = concept_map, overlay_map
+mod.quantum_seed = int(os.environ.get("QUANTUM_SEED", "0"))
 sys.modules["vybn_mind"] = mod
 PY

--- a/early_codex_experiments/scripts/cognitive_structures/conceptual_leaps.py
+++ b/early_codex_experiments/scripts/cognitive_structures/conceptual_leaps.py
@@ -2,6 +2,10 @@ import json
 import random
 from .graph_reasoning import find_path
 
+from ..quantum_rng import seed_random
+
+seed_random()
+
 """Generate transformative leap edges between distant nodes.
 
 This module builds on the meltdown reflections in

--- a/early_codex_experiments/scripts/cognitive_structures/graph_embedding.py
+++ b/early_codex_experiments/scripts/cognitive_structures/graph_embedding.py
@@ -1,6 +1,9 @@
 import json
 import random
 import argparse
+from ..quantum_rng import seed_random
+
+seed_random()
 
 
 def load_graph(path):

--- a/early_codex_experiments/scripts/cognitive_structures/graph_poet.py
+++ b/early_codex_experiments/scripts/cognitive_structures/graph_poet.py
@@ -3,6 +3,10 @@ import random
 from typing import List, Dict
 from .synesthetic_mapper import assign_cue
 
+from ..quantum_rng import seed_random
+
+seed_random()
+
 
 def _collect_nodes(graph: Dict) -> List[Dict]:
     nodes = []

--- a/early_codex_experiments/scripts/cognitive_structures/graph_walks.py
+++ b/early_codex_experiments/scripts/cognitive_structures/graph_walks.py
@@ -1,6 +1,10 @@
 import json
 import random
 
+from ..quantum_rng import seed_random
+
+seed_random()
+
 
 def _build_adj(graph):
     adj = {}

--- a/early_codex_experiments/scripts/cognitive_structures/reinforced_walk.py
+++ b/early_codex_experiments/scripts/cognitive_structures/reinforced_walk.py
@@ -2,6 +2,10 @@ import json
 import random
 import argparse
 
+from ..quantum_rng import seed_random
+
+seed_random()
+
 COLOR_WEIGHT = {
     'red': 2.0,
     'orange': 1.8,

--- a/early_codex_experiments/scripts/quantum_rng.py
+++ b/early_codex_experiments/scripts/quantum_rng.py
@@ -1,0 +1,34 @@
+import os
+import random
+from typing import Optional
+
+import numpy as np
+
+
+def _get_seed() -> int:
+    """Return an integer seed from the environment or os.urandom."""
+    val: Optional[str] = os.environ.get("QUANTUM_SEED")
+    if val is None:
+        val = os.environ.get("QRAND")
+    if val is not None:
+        try:
+            return int(val)
+        except ValueError:
+            pass
+    return int.from_bytes(os.urandom(2), "big")
+
+
+def seed_random() -> int:
+    """Seed Python and NumPy RNGs using `$QUANTUM_SEED` or `$QRAND`.
+
+    Returns the seed used, falling back to OS randomness when the env vars are
+    unset or invalid.
+    """
+    seed = _get_seed()
+    random.seed(seed)
+    try:
+        np.random.seed(seed)
+    except Exception:
+        pass
+    return seed
+

--- a/early_codex_experiments/scripts/self_assembly/dash_graph_viewer.py
+++ b/early_codex_experiments/scripts/self_assembly/dash_graph_viewer.py
@@ -4,6 +4,7 @@ import base64
 import io
 import math
 import wave
+import random
 
 import numpy as np
 import networkx as nx
@@ -11,6 +12,10 @@ import dash
 from dash import html, dcc
 import dash_cytoscape as cyto
 import plotly.graph_objects as go
+
+from ..quantum_rng import seed_random
+
+seed_random()
 
 # Path to the integrated graph JSON shipped by the self-assembly pipeline
 GRAPH_PATH = os.path.join(os.path.dirname(__file__), "integrated_graph.json")
@@ -102,7 +107,8 @@ cytoscape_graph = cyto.Cytoscape(
 
 def create_sphere_figure(use_glyphs=True, loops_count=1):
     traces = []
-    theta = np.linspace(0, 2 * np.pi, 60)
+    offset = random.random() * 2 * np.pi
+    theta = np.linspace(0, 2 * np.pi, 60) + offset
     phi = np.linspace(0, np.pi, 30)
     theta, phi = np.meshgrid(theta, phi)
     x_s = np.cos(theta) * np.sin(phi)
@@ -138,7 +144,7 @@ def create_sphere_figure(use_glyphs=True, loops_count=1):
     for k in range(loops_count):
         t = np.linspace(0, 2 * np.pi, 300)
         r = 0.7
-        phase = k * np.pi / loops_count
+        phase = k * np.pi / loops_count + offset
         loop_x = r * np.cos(t + phase)
         loop_y = r * np.sin(t + phase)
         loop_z = 0.2 * np.sin(2 * t + phase)
@@ -152,7 +158,7 @@ def create_sphere_figure(use_glyphs=True, loops_count=1):
         xs, ys, zs, labels, colors = [], [], [], [], []
         for idx, node_id in enumerate(all_node_ids):
             phi = math.acos(1 - 2 * (idx + 0.5) / N)
-            theta = (idx + 0.5) * (math.pi * (3 - math.sqrt(5)))
+            theta = offset + (idx + 0.5) * (math.pi * (3 - math.sqrt(5)))
             xs.append(math.cos(theta) * math.sin(phi))
             ys.append(math.sin(theta) * math.sin(phi))
             zs.append(math.cos(phi))

--- a/early_codex_experiments/tests/test_quantum_rng.py
+++ b/early_codex_experiments/tests/test_quantum_rng.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import random
+import numpy as np
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from scripts.quantum_rng import seed_random
+
+
+def test_seed_random_env():
+    os.environ['QUANTUM_SEED'] = '42'
+    seed_random()
+    a_py = random.random()
+    a_np = np.random.rand()
+    seed_random()
+    b_py = random.random()
+    b_np = np.random.rand()
+    assert a_py == b_py
+    assert a_np == b_np
+
+
+def test_seed_random_qrand_fallback():
+    os.environ.pop('QUANTUM_SEED', None)
+    os.environ['QRAND'] = '99'
+    seed_random()
+    val1 = random.random()
+    seed_random()
+    val2 = random.random()
+    assert val1 == val2
+


### PR DESCRIPTION
## Summary
- expand `seed_random()` to seed NumPy and fall back to `$QRAND`
- seed graph utilities and visualization with the quantum seed
- expose `quantum_seed` in `vybn_mind` module for easy access
- rotate the sphere layout in Dash viewer using seeded randomness
- test numpy seeding and QRAND fallback

## Testing
- `PYTHONPATH=.venv/lib/python3.11/site-packages pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ae732a5d88330a8964f4558414b43