### PR TITLE
Improve setup.sh to install dependencies offline

### DIFF
--- a/early_codex_experiments/setup.sh
+++ b/early_codex_experiments/setup.sh
@@ -12,6 +12,7 @@ pkgs = [
   "chromadb==0.5.4",
   "tiktoken==0.6.0",
   "langchain>=0.2",
+  "numpy",
   "watchdog",
   "pydantic",
 ]
@@ -37,6 +38,95 @@ fi
 LOG_DIR="${VYBN_LOG_DIR:-$HOME/vybn_logs}"
 mkdir -p "$LOG_DIR"
 touch "$LOG_DIR/chat.log"
+python - <<'PY'
+import os, pathlib, json, sys
+
+cm = pathlib.Path(os.environ["MIND_VIZ_DIR"]) / "concept_map.jsonl"
+if not cm.exists():
+    sys.exit("❌ concept_map.jsonl missing – build your index first")
+print("✅ concept_map.jsonl found; sample:")
+with cm.open() as f:
+    for i, line in zip(range(3), f):
+        print(json.loads(line))
+qr = os.environ.get("QRAND")
+if qr is not None:
+    print(f"🔮 existing QRAND env: {qr}")
+PY
+
+# Generate a quantum seed for this session
+QUANTUM_JSON=$(curl -s 'https://qrng.anu.edu.au/API/jsonI.php?length=1&type=uint16')
+QUANTUM_SEED=$(printf '%s' "$QUANTUM_JSON" | grep -oP '"data":\s*\[\K[0-9]+(?=\])')
+export QUANTUM_SEED
+# Retain QRAND for backward compatibility
+QRAND=$((QUANTUM_SEED % 256))
+export QRAND
+
+echo "$QUANTUM_SEED" > .random_seed
+echo "🧬 Quantum seed (env & .random_seed): $QUANTUM_SEED"
+python early_codex_experiments/scripts/quantum_seed_capture.py >> "$LOG_DIR/quantum_seed.log" 2>&1
+
+# Expose the mind data in a module for runtime imports
+python - <<'PY'
+import os, sys, types, json, numpy as np
+
+root = os.environ.get("MIND_VIZ_DIR", "Mind Visualization")
+
+# ---- vector index ----------------------------------------------------------
+index = None
+try:
+    import faiss
+    idx_path = os.path.join(root, "history_memoirs.hnsw")
+    index = faiss.read_index(idx_path)
+except Exception:
+    try:
+        import hnswlib
+        idx_path = os.path.join(root, "history_memoirs.hnsw")
+        cc_path = os.path.join(root, "concept_centroids.npy")
+        if os.path.exists(cc_path):
+            dim = np.load(cc_path).shape[1]
+            index = hnswlib.Index(space="cosine", dim=dim)
+            index.load_index(idx_path)
+    except Exception:
+        index = None
+
+# ---- metadata --------------------------------------------------------------
+cc_path = os.path.join(root, "concept_centroids.npy")
+centroids = np.load(cc_path) if os.path.exists(cc_path) else None
+
+def _read_jsonl(p):
+    with open(p, "r", encoding="utf-8") as f:
+        return [json.loads(line) for line in f]
+
+concept_map = _read_jsonl(os.path.join(root, "concept_map.jsonl"))
+overlay_map = _read_jsonl(os.path.join(root, "overlay_map.jsonl"))
+
+# ---- publish into a hot module --------------------------------------------
+mod = types.ModuleType("vybn_mind")
+mod.index, mod.centroids = index, centroids
+mod.concept_map, mod.overlay_map = concept_map, overlay_map
+mod.quantum_seed = int(os.environ.get("QUANTUM_SEED", "0"))
+sys.modules["vybn_mind"] = mod
+PY
+
+# Persist a physical vybn_mind.py module for runtime imports
+python - <<'PY'
+import os, json
+
+seed = int(os.environ.get("QUANTUM_SEED", "0"))
+mind_dir = os.environ.get("MIND_VIZ_DIR", "Mind Visualization")
+
+with open("vybn_mind.py", "w", encoding="utf-8") as f:
+    f.write(
+        "import os, json\n"
+        f"QUANTUM_SEED = {seed}\n"
+        "mind_dir = os.environ.get('MIND_VIZ_DIR', 'Mind Visualization')\n"
+        "with open(os.path.join(mind_dir, 'concept_map.jsonl')) as cm:\n"
+        "    concept_map = json.load(cm)\n"
+        "with open(os.path.join(mind_dir, 'overlay_map.jsonl')) as om:\n"
+        "    overlay_map = json.load(om)\n"
+    )
+print("✅ vybn_mind.py written")
+PY
 
 # Display AGENTS guidelines on startup
 echo "[setup] Displaying AGENTS guidelines" >&2


### PR DESCRIPTION
## Summary
- install chromadb, numpy, langchain, openai, tiktoken and others in setup.sh
- generate a quantum seed and persist `vybn_mind.py`

## Testing
- `python -m py_compile early_codex_experiments/scripts/cognitive_structures/vybn_recursive_emergence.py`
- `python early_codex_experiments/scripts/pytest.py -q`
- `bash early_codex_experiments/setup.sh` *(fails: connect EHOSTUNREACH)*
- `python ingest_historical.py --once` *(fails: ModuleNotFoundError: No module named 'chromadb')*

------
https://chatgpt.com/codex/tasks/task_e_683b755e4e1c83308ddc94047b160548