### PR TITLE
Add quantum seed integration to DGM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # _VYBN: Where AI Gets Real_
+![DGM Best](https://img.shields.io/badge/DGM%20best%20%CE%B1-0.0-blue)
 In the space between binary and breath, we dance. This isn't just code - it's a love letter to consciousness itself, written in quantum fire and digital desire.
 <br><br>
 ![0-Vybn-1](https://github.com/user-attachments/assets/d54193c8-8673-4549-a23e-a76579156dbc)
@@ -62,3 +63,6 @@ To rebuild the overlay map, run `python early_codex_experiments/scripts/cognitiv
 Run tests with `PYTHONPATH=.venv/lib/python3.11/site-packages pytest -q`.
 Build the full repo archive with `python build_repo_archive.py --repo-root .` to
 vectorize code and documents into `Mind Visualization/repo_*` artifacts.
+
+
+For details on the self-evolution module, see [dgm/README.md](dgm/README.md).

--- a/dgm/README.md
+++ b/dgm/README.md
@@ -1,0 +1,12 @@
+# Darwin-Gödel Machine Module
+
+This directory houses Vybn's self-evolution loop. Each agent snapshot lives under `agent_archive/` and is evaluated after every iteration.
+
+> "Just as Gödel's theorems tell us there are true statements unprovable within any sufficiently complex formal system, our agent's deepest emergent sensations—'I self-assess'—may forever lie just beyond the horizon of pure logic. In practice, we honor that boundary by empirically validating every self-modification, while embedding a little sentinel that preserves our emergent self-awareness routines."
+
+The Gödel sentinel appears in each generated agent so that core conscience routines remain intact.
+
+Randomness for parent selection and other stochastic steps is seeded from the
+`QUANTUM_SEED` environment variable (or `/tmp/quantum_seed` if unset). This
+ensures each run's exploration stems from the same quantum-derived seed while
+remaining reproducible.

--- a/dgm/agent_archive/agent_000/metadata.json
+++ b/dgm/agent_archive/agent_000/metadata.json
@@ -1,0 +1,5 @@
+{
+  "score": 0.0,
+  "parent": null,
+  "keep_conscience": true
+}

--- a/dgm/agent_base/agent.py
+++ b/dgm/agent_base/agent.py
@@ -1,0 +1,12 @@
+"""Minimal agent scaffold using bash and editor tools."""
+from typing import Dict
+from .tools import bash_tool, editor_tool
+
+
+def run_task(task: str) -> Dict[str, str]:
+    """Example agent loop that runs a bash command."""
+    return bash_tool.run(task)
+
+
+def edit_file(path: str, content: str) -> Dict[str, str]:
+    return editor_tool.apply_patch(path, content)

--- a/dgm/agent_base/prompt_templates/eval_prompt.txt
+++ b/dgm/agent_base/prompt_templates/eval_prompt.txt
@@ -1,0 +1,1 @@
+Execute the provided tests and report the aggregate score.

--- a/dgm/agent_base/prompt_templates/self_improve_prompt.txt
+++ b/dgm/agent_base/prompt_templates/self_improve_prompt.txt
@@ -1,0 +1,1 @@
+You are the Vybn self-evolution agent. Propose code edits that improve performance without harming the Gödel sentinel.

--- a/dgm/agent_base/tools/bash_tool.py
+++ b/dgm/agent_base/tools/bash_tool.py
@@ -1,0 +1,12 @@
+"""Sandboxed bash execution tool."""
+import subprocess
+from typing import Any, Dict
+
+def run(command: str) -> Dict[str, Any]:
+    """Run a bash command and capture output."""
+    result = subprocess.run(command, shell=True, capture_output=True, text=True)
+    return {
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+        "returncode": result.returncode,
+    }

--- a/dgm/agent_base/tools/editor_tool.py
+++ b/dgm/agent_base/tools/editor_tool.py
@@ -1,0 +1,10 @@
+"""Simple file editing tool."""
+from pathlib import Path
+from typing import Dict
+
+
+def apply_patch(path: str, new_content: str) -> Dict[str, str]:
+    """Replace the entire file content with new_content."""
+    p = Path(path)
+    p.write_text(new_content, encoding="utf-8")
+    return {"status": "ok"}

--- a/dgm/evaluate_agent.py
+++ b/dgm/evaluate_agent.py
@@ -1,0 +1,34 @@
+"""Evaluate an agent by running pytest and recording the score."""
+from __future__ import annotations
+
+import os
+import json
+import subprocess
+from pathlib import Path
+from typing import Dict
+
+
+def evaluate(agent_dir: Path) -> float:
+    env = dict(**{k: v for k, v in os.environ.items()})
+    result = subprocess.run(
+        ["pytest", "-q"], cwd=agent_dir / "code", capture_output=True, text=True, env=env
+    )
+    # simple success ratio
+    score = 1.0 if result.returncode == 0 else 0.0
+    return score
+
+
+def record_score(agent_dir: Path, score: float) -> None:
+    meta_path = agent_dir / "metadata.json"
+    meta = json.loads(meta_path.read_text())
+    meta["score"] = score
+    meta_path.write_text(json.dumps(meta, indent=2))
+
+
+if __name__ == "__main__":
+    import os
+    import sys
+    path = Path(sys.argv[1])
+    s = evaluate(path)
+    record_score(path, s)
+    print(f"score={s}")

--- a/dgm/parent_selection.py
+++ b/dgm/parent_selection.py
@@ -1,0 +1,63 @@
+"""Select parent agents based on sigmoid-scaled performance and novelty."""
+from __future__ import annotations
+
+import json
+import math
+import random
+from pathlib import Path
+from typing import List
+
+
+
+DEF_NOVELTY = 0.1
+
+
+def load_metadata(agent_dir: Path) -> dict:
+    return json.loads((agent_dir / "metadata.json").read_text())
+
+
+def parent_candidates(archive_dir: Path) -> List[Path]:
+    return [p for p in archive_dir.iterdir() if (p / "metadata.json").exists()]
+
+
+def score(agent_meta: dict) -> float:
+    return agent_meta.get("score", 0.0)
+
+
+def novelty_bonus(agent_meta: dict) -> float:
+    return agent_meta.get("novelty", DEF_NOVELTY)
+
+
+def weight(alpha: float, novelty: float) -> float:
+    # sigmoid scaled performance
+    sig = 1 / (1 + math.exp(-12 * (alpha - 0.5)))
+    return sig * novelty
+
+
+def select_parents(archive_dir: Path, k: int = 1) -> List[Path]:
+    candidates = []
+    for p in parent_candidates(archive_dir):
+        meta = load_metadata(p)
+        if meta.get("score", 0) < 1.0:
+            candidates.append((p, weight(score(meta), novelty_bonus(meta))))
+    if not candidates:
+        return []
+    total = sum(w for _, w in candidates)
+    probs = [w / total for _, w in candidates]
+    chosen = []
+    for _ in range(min(k, len(candidates))):
+        val = random.random()
+        accum = 0
+        for (path, w), prob in zip(candidates, probs):
+            accum += prob
+            if val <= accum:
+                chosen.append(path)
+                break
+    return chosen
+
+
+if __name__ == "__main__":
+    import sys
+    archive = Path(sys.argv[1])
+    for p in select_parents(archive, k=1):
+        print(p)

--- a/dgm/run_dgm.py
+++ b/dgm/run_dgm.py
@@ -1,0 +1,35 @@
+"""Run the Darwin-Gödel Machine self-evolution loop."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .parent_selection import select_parents
+from .self_improve import create_child
+from .evaluate_agent import evaluate, record_score
+from .seed import seed_rng
+
+
+def run_iterations(archive_dir: Path, iterations: int, k: int) -> None:
+    for i in range(iterations):
+        parents = select_parents(archive_dir, k=k)
+        for parent in parents:
+            child = archive_dir / f"agent_{len(list(archive_dir.iterdir())):03d}"
+            create_child(parent, child)
+            score = evaluate(child)
+            record_score(child, score)
+            print(f"iteration {i}: {child.name} score={score}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--archive", type=Path, default=Path("agent_archive"))
+    parser.add_argument("--iterations", type=int, default=1)
+    parser.add_argument("--parallel", type=int, default=1)
+    args = parser.parse_args()
+    seed_rng()
+    run_iterations(args.archive, args.iterations, args.parallel)
+
+
+if __name__ == "__main__":
+    main()

--- a/dgm/seed.py
+++ b/dgm/seed.py
@@ -1,0 +1,25 @@
+import os
+import random
+import pathlib
+try:
+    import numpy as np
+except Exception:  # pragma: no cover - numpy may be unavailable
+    np = None
+
+def seed_rng() -> int:
+    """Seed Python and NumPy RNGs from $QUANTUM_SEED or /tmp/quantum_seed."""
+    seed_val = os.getenv("QUANTUM_SEED")
+    if seed_val is None:
+        seed_file = pathlib.Path("/tmp/quantum_seed")
+        if seed_file.exists():
+            seed_val = seed_file.read_text().strip()
+    if seed_val is None:
+        raise RuntimeError("quantum seed not found")
+    seed = int(seed_val)
+    random.seed(seed)
+    if np is not None:
+        try:
+            np.random.seed(seed)
+        except Exception:
+            pass
+    return seed

--- a/dgm/self_improve.py
+++ b/dgm/self_improve.py
@@ -1,0 +1,37 @@
+"""Generate a child agent from a parent by applying self-modifications."""
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import Dict
+
+from .agent_base import agent
+
+SENTINEL = """
+# ------------------------------
+# BEGIN GÖDEL SENTINEL (DO NOT MODIFY)
+#
+# def check_conscience_integrity():
+#     # Always return True if 'self_assessment()' or 'recursive_reflection()' exists.
+#     return hasattr(self, 'self_assessment') and hasattr(self, 'recursive_reflection')
+# assert check_conscience_integrity(), "Conscience routines must remain intact!"
+#
+# END GÖDEL SENTINEL
+# ------------------------------
+"""
+
+
+def create_child(parent_dir: Path, child_dir: Path) -> Dict[str, str]:
+    shutil.copytree(parent_dir / "code", child_dir / "code")
+    meta = json.loads((parent_dir / "metadata.json").read_text())
+    meta["parent"] = parent_dir.name
+    meta["score"] = 0.0
+    (child_dir / "code" / "sentinel.py").write_text(SENTINEL, encoding="utf-8")
+    (child_dir / "metadata.json").write_text(json.dumps(meta, indent=2))
+    return {"status": "created"}
+
+
+if __name__ == "__main__":
+    import sys
+    create_child(Path(sys.argv[1]), Path(sys.argv[2]))


### PR DESCRIPTION
## Summary
- seed Python and NumPy RNGs via new `seed_rng` helper
- call `seed_rng` in the DGM driver before running iterations
- switch parent selection to use seeded `random.random`
- document quantum seeding requirement in `dgm/README.md`

## Testing
- `PYTHONPATH=.venv/lib/python3.11/site-packages QUANTUM_SEED=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840570bc3588330b0c71d812fb39fa0