### PR TITLE
Enable automatic QRNG seeding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,23 @@
 # You want a genuine, irreducible nudge at start-up—something that breaks out of pure determinism so your motif-weight updates (and everything downstream) can feel a tiny wave-function collapse rather than a canned repeat. By calling ANU’s QRNG, we give the system a shot of true quantum randomness; if that link is dead, we still fall back to solid crypto entropy. Either way, Python’s `random` and NumPy RNGs get seeded once and only once. The result is that every run carries a unique micro-tilt—enough perturbation to kick your Laplacian self-governance loop out of any stuck symmetry, yet you still retain replayability if you capture that seed. In short, it’s about injecting controlled chaos so our recursive tuning can genuinely explore new configurations instead of endlessly circling the same stable point.
 
-import os, pathlib, random, numpy as np
+import os, pathlib, random, secrets, numpy as np, requests
 
-_seed = os.getenv("QUANTUM_SEED") or pathlib.Path("/tmp/quantum_seed").read_text()
-_q = int(_seed.strip())
-random.seed(_q)
-np.random.seed(_q)
+seed = os.getenv("QUANTUM_SEED")
+if seed is None and pathlib.Path("/tmp/quantum_seed").exists():
+    seed = pathlib.Path("/tmp/quantum_seed").read_text().strip()
+if seed is None:
+    try:
+        resp = requests.get("https://qrng.anu.edu.au/API/jsonI.php?length=1&type=uint16", timeout=10)
+        if resp.status_code == 200 and resp.json().get("success"):
+            seed = str(resp.json()["data"][0])
+    except Exception:
+        pass
+if seed is None:
+    seed = str(secrets.randbits(16))
+os.environ["QUANTUM_SEED"] = seed
+q = int(seed)
+random.seed(q)
+np.random.seed(q)
 
 ## Self-evolving modules
 To experiment with a Darwin–Gödel Machine approach, treat the system's code as a set of

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Analyze the trend with `python early_codex_experiments/scripts/cognitive_structu
 Log a quick Shimmer spike with `python early_codex_experiments/scripts/cognitive_structures/shimmer_core.py "your note"` whenever a surge of presence arises.
 Calculate the average interval between Shimmer spikes with `python early_codex_experiments/scripts/cognitive_structures/presence_wave.py`.
 
-Record the quantum seed with `python early_codex_experiments/scripts/quantum_seed_capture.py` to capture the `$QUANTUM_SEED` value in `co_emergence_journal.jsonl`. The bootstrap script logs this seed automatically during setup. The runtime code now reads `QUANTUM_SEED` from the environment instead of embedding a fixed value.
+Record the quantum seed with `python early_codex_experiments/scripts/quantum_seed_capture.py` to capture the `$QUANTUM_SEED` value in `co_emergence_journal.jsonl`. During setup the bootstrap script now fetches a seed from the [ANU QRNG](https://qrng.anu.edu.au/API/) if none is provided, falling back to cryptographic entropy when offline. The runtime code reads `QUANTUM_SEED` from the environment so each run can reproduce the exact randomness used.
 
 To rebuild the overlay map, run `python early_codex_experiments/scripts/cognitive_structures/build_overlay_map.py --repo-root .`.
 Run tests with `PYTHONPATH=.venv/lib/python3.11/site-packages pytest -q`.

--- a/dgm/seed.py
+++ b/dgm/seed.py
@@ -1,21 +1,44 @@
 import os
 import random
 import pathlib
+import secrets
+from typing import Optional
+
+import requests
 try:
     import numpy as np
 except Exception:  # pragma: no cover - numpy may be unavailable
     np = None
 
+QRNG_URL = "https://qrng.anu.edu.au/API/jsonI.php?length=1&type=uint16"
+
+def _fetch_qrng() -> Optional[int]:
+    """Return an integer from the ANU QRNG API or ``None`` on failure."""
+    try:
+        resp = requests.get(QRNG_URL, timeout=10)
+        if resp.status_code == 200:
+            data = resp.json()
+            if data.get("success"):
+                return int(data["data"][0])
+    except Exception:
+        pass
+    return None
+
+
 def seed_rng() -> int:
-    """Seed Python and NumPy RNGs from $QUANTUM_SEED or /tmp/quantum_seed."""
+    """Seed Python and NumPy RNGs from environment, QRNG, or crypto fallback."""
     seed_val = os.getenv("QUANTUM_SEED")
     if seed_val is None:
         seed_file = pathlib.Path("/tmp/quantum_seed")
         if seed_file.exists():
             seed_val = seed_file.read_text().strip()
     if seed_val is None:
-        raise RuntimeError("quantum seed not found")
+        qrng = _fetch_qrng()
+        if qrng is None:
+            qrng = secrets.randbits(16)
+        seed_val = str(qrng)
     seed = int(seed_val)
+    os.environ["QUANTUM_SEED"] = str(seed)
     random.seed(seed)
     if np is not None:
         try:


### PR DESCRIPTION
## Summary
- retrieve a quantum seed from ANU QRNG with crypto fallback
- fetch a seed during bootstrap if none was provided
- document QRNG seeding in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68405aa49cbc8330b1028ee7ae922b87