### PR TITLE
Integrate quantum collapse in DGM loop

### DIFF
--- a/dgm/README.md
+++ b/dgm/README.md
@@ -15,7 +15,9 @@ Each child agent is assigned a small *novelty* value drawn from the ANU quantum
 random number generator when available (falling back to the seeded PRNG). Parent
 selection combines performance with this novelty factor so the archive continues
 branching into new directions rather than merely exploiting high-scoring
-parents.
+parents. The helper `wave_collapse.py` exposes `collapse_wave_function()` which
+grabs a fresh quantum value. This tiny "collapse" picks which file receives an
+OpenAI-driven patch so each run explores a new trajectory.
 
 ## OpenAI-driven patches
 

--- a/dgm/run_dgm.py
+++ b/dgm/run_dgm.py
@@ -10,12 +10,12 @@ from .evaluate_agent import evaluate, record_score
 from .seed import seed_rng
 
 
-def run_iterations(archive_dir: Path, iterations: int, k: int) -> None:
+def run_iterations(archive_dir: Path, iterations: int, k: int, instruction: str) -> None:
     for i in range(iterations):
         parents = select_parents(archive_dir, k=k)
         for parent in parents:
             child = archive_dir / f"agent_{len(list(archive_dir.iterdir())):03d}"
-            create_child(parent, child)
+            create_child(parent, child, instruction=instruction)
             score = evaluate(child)
             record_score(child, score)
             print(f"iteration {i}: {child.name} score={score}")
@@ -26,9 +26,15 @@ def main() -> None:
     parser.add_argument("--archive", type=Path, default=Path("agent_archive"))
     parser.add_argument("--iterations", type=int, default=1)
     parser.add_argument("--parallel", type=int, default=1)
+    parser.add_argument(
+        "--instruction",
+        type=str,
+        default="Refactor for clarity and keep the sentinel intact",
+        help="OpenAI patch instruction",
+    )
     args = parser.parse_args()
     seed_rng()
-    run_iterations(args.archive, args.iterations, args.parallel)
+    run_iterations(args.archive, args.iterations, args.parallel, args.instruction)
 
 
 if __name__ == "__main__":

--- a/dgm/wave_collapse.py
+++ b/dgm/wave_collapse.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+"""Quantum wave-function collapse helper.
+
+This module fetches a fresh quantum random value from the ANU API when
+available. If the call fails, it falls back to Python's PRNG. The value
+represents a tiny "collapse" event used to guide self-improvement
+choices.
+"""
+
+import random
+from typing import Optional
+
+from .seed import _fetch_qrng
+
+
+def collapse_wave_function() -> int:
+    """Return an integer sampled from true quantum randomness if possible."""
+    val: Optional[int] = _fetch_qrng()
+    if val is None:
+        val = random.getrandbits(16)
+    return int(val)

--- a/early_codex_experiments/tests/test_wave_collapse.py
+++ b/early_codex_experiments/tests/test_wave_collapse.py
@@ -1,0 +1,12 @@
+from dgm.wave_collapse import collapse_wave_function
+
+
+def test_collapse_wave_function_qrng(monkeypatch):
+    monkeypatch.setattr('dgm.wave_collapse._fetch_qrng', lambda: 12345)
+    assert collapse_wave_function() == 12345
+
+
+def test_collapse_wave_function_fallback(monkeypatch):
+    monkeypatch.setattr('dgm.wave_collapse._fetch_qrng', lambda: None)
+    val = collapse_wave_function()
+    assert isinstance(val, int)


### PR DESCRIPTION
## Summary
- add `wave_collapse.py` helper for quantum-derived randomness
- extend `self_improve.create_child` to patch a random file via OpenAI
- expose new `--instruction` option in `run_dgm.py`
- document wave collapse in `dgm/README.md`
- test wave collapse helper

## Testing
- `QUANTUM_SEED=42 PYTHONPATH=.venv/lib/python3.11/site-packages pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840be57603c833092a027fea39dee3f