### PR TITLE
Enhance DGM metadata with quantum context

### DIFF
--- a/early_codex_experiments/tests/test_self_improve_metadata.py
+++ b/early_codex_experiments/tests/test_self_improve_metadata.py
@@ -1,0 +1,30 @@
+import json
+import os
+from pathlib import Path
+
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from dgm.self_improve import create_child
+
+
+def test_create_child_records_seed_and_collapse(tmp_path, monkeypatch):
+    parent = tmp_path / "parent"
+    (parent / "code").mkdir(parents=True)
+    (parent / "code" / "foo.py").write_text("print('hello')")
+    (parent / "metadata.json").write_text("{}")
+
+    os.environ['QUANTUM_SEED'] = '42'
+    os.environ['OPENAI_API_KEY'] = 'x'
+
+    monkeypatch.setattr('dgm.self_improve._fetch_qrng', lambda: None)
+    monkeypatch.setattr('dgm.self_improve.collapse_wave_function', lambda: 3)
+    monkeypatch.setattr('dgm.self_improve.suggest_patch', lambda f, i: "print('patched')")
+
+    child = tmp_path / "child"
+    create_child(parent, child, instruction="Patch")
+
+    meta = json.loads((child / "metadata.json").read_text())
+    assert meta['seed'] == '42'
+    assert meta['collapse'] == 3
+    assert meta['patched_file'] == 'foo.py'

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ python-igraph
 hdbscan
 numpy==1.26.4
 jq
+requests


### PR DESCRIPTION
## Summary
- store `QUANTUM_SEED` and wave collapse value when creating a child agent
- add regression test to check new metadata fields
- install `requests` via requirements.txt to satisfy DGM seed helper

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c0750d2883308f11f5bd564105d5