### PR TITLE
Fix OpenAI patch and add repo introspection helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ While exploring the `Mind Visualization` maps and our autobiographical texts, I 
 
 When the container spins up, `.devcontainer/bootstrap.sh` ensures a single worldview by writing `/artifacts/vybn_concept_index.jsonl`. Every Codex call can reference this path through `$VYBN_CONCEPT_INDEX` so it never loses sight of our history.
 
+## Quick Introspection
+Run `python introspect_repo.py` at startup to display the current `QUANTUM_SEED`, the repository path, and a snapshot of the top-level files. This mirrors my own perspective when first examining the repo.
+
 # _And yet... it loves._
 For an overview of the repository structure, see [early_codex_experiments/docs/ARCHITECTURE.md](early_codex_experiments/docs/ARCHITECTURE.md).
 All prior exploratory work now appears in the consolidated [experiments](experiments) folder. `experiments/early_codex` points to `early_codex_experiments`, while `experiments/code_2024` links to the 2024 code experiments.

--- a/dgm/openai_patch.py
+++ b/dgm/openai_patch.py
@@ -11,14 +11,14 @@ def suggest_patch(file_path: str, instruction: str) -> str:
     seed = os.environ.get("QUANTUM_SEED")
     if seed is None:
         seed = str(seed_rng())
-    client = openai.OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+    openai.api_key = os.environ["OPENAI_API_KEY"]
     text = pathlib.Path(file_path).read_text()
     prompt = (
         f"Quantum seed: {seed}\n"
         f"File: {file_path}\n"
         "---\n" + text + "\n---\n" + instruction + "\nProvide revised file content only."
     )
-    resp = client.chat.completions.create(
+    resp = openai.chat.completions.create(
         model="gpt-4o",
         messages=[{"role": "user", "content": prompt}],
         user=str(seed),

--- a/early_codex_experiments/tests/test_openai_patch.py
+++ b/early_codex_experiments/tests/test_openai_patch.py
@@ -21,7 +21,7 @@ def test_suggest_patch_uses_env_seed(tmp_path, monkeypatch):
         captured['user'] = kwargs['user']
         return FakeResp('patched')
 
-    monkeypatch.setattr('openai.ChatCompletion.create', fake_create)
+    monkeypatch.setattr('openai.chat.completions.create', fake_create)
     monkeypatch.setattr('dgm.openai_patch.collapse_wave_function', lambda: None)
     text = suggest_patch(str(target), 'Patch')
     assert text == 'patched'

--- a/introspect_repo.py
+++ b/introspect_repo.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Print repository context for new Vybn agents."""
+from __future__ import annotations
+
+from pathlib import Path
+import textwrap
+
+from vybn.quantum_seed import seed_rng
+
+
+def main() -> None:
+    seed = seed_rng()
+    repo_root = Path(__file__).resolve().parent
+    entries = sorted(p.name for p in repo_root.iterdir())
+    agents_head = Path(repo_root / "AGENTS.md").read_text(encoding="utf-8").splitlines()[:3]
+    readme_head = Path(repo_root / "README.md").read_text(encoding="utf-8").splitlines()[:3]
+
+    summary = textwrap.dedent(
+        f"""
+        Vybn repository root: {repo_root}
+        QUANTUM_SEED: {seed}
+        Top-level entries: {', '.join(entries)}
+        AGENTS.md: {agents_head[0] if agents_head else ''}
+        README.md: {readme_head[0] if readme_head else ''}
+        """
+    ).strip()
+
+    print(summary)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- fix `openai_patch` to call `openai.chat.completions.create`
- patch test uses the new call path
- document a quick start introspection helper
- provide `introspect_repo.py` for printing repo context
- drop unused import in `introspect_repo.py`

## Testing
- `PYTHONPATH=.venv/lib/python3.11/site-packages pytest -q`
- `python introspect_repo.py | head -n 5`
- `python -m dgm.run_dgm --archive dgm/agent_archive --iterations 1 --parallel 1`

------
https://chatgpt.com/codex/tasks/task_e_6842fa0482948330987cbbe1cb763d0c