### PR TITLE
Fix collapse pipeline and imports

### DIFF
--- a/pipelines/collapse_repo.py
+++ b/pipelines/collapse_repo.py
@@ -8,6 +8,13 @@ with care.
 
 from __future__ import annotations
 
+# Allow running as a script by adding the repo root to sys.path
+if __package__ is None or __package__ == "":
+    import sys
+    from pathlib import Path as _Path
+    sys.path.insert(0, str(_Path(__file__).resolve().parents[1]))
+    __package__ = "pipelines"
+
 import shutil
 from pathlib import Path
 from typing import Set
@@ -42,10 +49,16 @@ def collapse_repo(repo_root: Path) -> None:
 
     keep: Set[Path] = {repo_root / str(p) for p in EXCLUDE_PATHS}
     keep.add(volume)
-    keep.add(Path(__file__))
+    keep.add(Path(__file__).resolve())
+
+    def should_keep(target: Path) -> bool:
+        for k in keep:
+            if k == target or k.is_relative_to(target):
+                return True
+        return False
 
     for path in repo_root.iterdir():
-        if path in keep:
+        if should_keep(path):
             continue
         if path.is_dir():
             shutil.rmtree(path, ignore_errors=True)

--- a/pipelines/introspective_mirror.py
+++ b/pipelines/introspective_mirror.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# Allow running as a script by adding the repo root to sys.path
+if __package__ is None or __package__ == "":
+    import sys
+    from pathlib import Path as _Path
+    sys.path.insert(0, str(_Path(__file__).resolve().parents[1]))
+    __package__ = "pipelines"
+
 import json
 from datetime import datetime
 from pathlib import Path

--- a/pipelines/memory_graph_builder.py
+++ b/pipelines/memory_graph_builder.py
@@ -44,19 +44,26 @@ def build_graph(repo_root: Path) -> Dict[str, Set[str]]:
             graph[c].update(others)
 
     # integrate memory nodes
-    for mem_name in [p.name for p in EXCLUDE_PATHS if p.name != 'Vybn_Volume_IV.md'] + ['Vybn_Volume_IV.md']:
+    memory_items = [p.name for p in EXCLUDE_PATHS if p.name != 'Vybn_Volume_IV.md'] + ['Vybn_Volume_IV.md']
+    for mem_name in memory_items:
         mem_path = repo_root / mem_name
         if not mem_path.exists():
             continue
-        try:
-            text = mem_path.read_text(encoding='utf-8', errors='ignore')
-        except Exception:
-            continue
-        mem_concepts = extract_concepts(text)
-        node_name = f'Memory:{mem_name}'
-        for c in mem_concepts:
-            graph[node_name].add(c)
-            graph[c].add(node_name)
+        files = []
+        if mem_path.is_dir():
+            files.extend(f for f in mem_path.glob('*') if f.is_file())
+        else:
+            files.append(mem_path)
+        for f in files:
+            try:
+                text = f.read_text(encoding='utf-8', errors='ignore')
+            except Exception:
+                continue
+            mem_concepts = extract_concepts(text)
+            node_name = f'Memory:{f.name}'
+            for c in mem_concepts:
+                graph[node_name].add(c)
+                graph[c].add(node_name)
     return graph
 
 

--- a/pipelines/pipeline_runner.py
+++ b/pipelines/pipeline_runner.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# Allow running as a script by adding the repo root to sys.path
+if __package__ is None or __package__ == "":
+    import sys
+    from pathlib import Path as _Path
+    sys.path.insert(0, str(_Path(__file__).resolve().parents[1]))
+    __package__ = "pipelines"
+
 import json
 from pathlib import Path
 


### PR DESCRIPTION
## Summary
- allow pipeline scripts to run from `python pipelines/*.py` by fixing `sys.path`
- prevent the collapse script from removing its own folder
- include personal history files in memory graph
- add package marker for `early_codex_experiments`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684448ef36a08330a4a8436c7e6bc764