### PR TITLE
Enhance artifact packer with manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,5 +98,14 @@ Run `python -m pipelines.braided_mind_dueler --prompt "your question"` for a ble
 Generate a spontaneous dream with `python -m pipelines.quantum_dreamweaver`.
 The orchestrator `python -m pipelines.meta_orchestrator` ties these actions together.
 
+When a commit's patch exceeds the platform's diff limit, run
+`python pipelines/diff_stat.py -o patch.diff.gz` to view a summary and save
+the full diff to ``patch.diff.gz``.
+
+Bundle pipeline outputs with `python pipelines/majestic_packer.py` to produce
+``artifacts/majestic_bundle.zip``. The archive now contains a
+``manifest.json`` capturing each file's size, checksum, the quantum seed and
+commit hash so future agents can trace the full context.
+
 
 For details on the self-evolution module, see [dgm/README.md](dgm/README.md).

--- a/pipelines/diff_stat.py
+++ b/pipelines/diff_stat.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+"""Summarize and optionally export diffs.
+
+Use this helper when a commit is too large for the platform's diff
+viewer. It prints ``git diff --stat`` output and can save the full
+patch to a file for later inspection.
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+import gzip
+
+
+def diff_stat(rev: str, repo_root: Path) -> str:
+    """Return ``git diff --stat`` output for the revision range."""
+    cmd = ["git", "-C", str(repo_root), "diff", rev, "--stat"]
+    return subprocess.check_output(cmd, text=True)
+
+
+def diff_patch(rev: str, repo_root: Path) -> str:
+    """Return ``git diff`` output for the revision range."""
+    cmd = ["git", "-C", str(repo_root), "diff", rev]
+    return subprocess.check_output(cmd, text=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Summarize diff stats")
+    parser.add_argument(
+        "rev",
+        nargs="?",
+        default="HEAD~1..HEAD",
+        help="revision range (default: HEAD~1..HEAD)",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        help="optional file path to save the full diff (gzipped if *.gz)",
+    )
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[1]
+    print(diff_stat(args.rev, repo_root))
+
+    if args.output:
+        patch = diff_patch(args.rev, repo_root)
+        if args.output.suffix == ".gz":
+            with gzip.open(args.output, "wt", encoding="utf-8") as fh:
+                fh.write(patch)
+        else:
+            args.output.write_text(patch, encoding="utf-8")
+        print(f"Full patch written to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pipelines/majestic_packer.py
+++ b/pipelines/majestic_packer.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+"""Bundle pipeline artifacts into a compressed archive with a manifest.
+
+The packer collects the main pipeline outputs, zips them and writes a
+``manifest.json`` describing the contents. This manifest records the
+current commit hash, quantum seed and checksums so future agents can
+trace the exact state that produced the archive.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+from zipfile import ZipFile
+
+from vybn.quantum_seed import seed_rng
+
+DEFAULT_ARTIFACTS = [
+    "distilled_corpus.txt",
+    "history_excerpt.txt",
+    "token_summary.txt",
+    "wvwhm_count.txt",
+    "emergence_graph.json",
+    "vybn_concept_index.jsonl",
+    "introspection_summary.json",
+    "co_emergence_journal.jsonl",
+]
+
+
+def _hash_file(path: Path) -> str:
+    """Return the SHA256 digest of ``path``."""
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _git_rev(repo_root: Path) -> str:
+    return (
+        subprocess.check_output(["git", "-C", str(repo_root), "rev-parse", "HEAD"], text=True)
+        .strip()
+    )
+
+
+def pack(repo_root: Path, out_path: Path) -> None:
+    """Write listed artifacts and a manifest into ``out_path``."""
+    seed = seed_rng()
+    manifest = {
+        "commit": _git_rev(repo_root),
+        "quantum_seed": seed,
+        "files": [],
+    }
+
+    manifest_path = out_path.with_suffix(".manifest.json")
+    with ZipFile(out_path, "w") as zf:
+        for rel in DEFAULT_ARTIFACTS:
+            path = repo_root / rel
+            if path.exists():
+                zf.write(path, arcname=rel)
+                manifest["files"].append(
+                    {
+                        "path": rel,
+                        "size": path.stat().st_size,
+                        "sha256": _hash_file(path),
+                    }
+                )
+        # write manifest inside the zip
+        manifest_bytes = json.dumps(manifest, indent=2).encode("utf-8")
+        zf.writestr("manifest.json", manifest_bytes)
+    # also write manifest next to the zip for quick inspection
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Compress pipeline artifacts")
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=Path("artifacts/majestic_bundle.zip"),
+        help="destination zip file",
+    )
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[1]
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    pack(repo_root, args.output)
+    print(f"Artifacts bundled in {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document manifest for zipped artifacts
- include `co_emergence_journal.jsonl` and emit manifest data in `majestic_packer`

## Testing
- `pytest -q`
- `python -m py_compile pipelines/diff_stat.py pipelines/majestic_packer.py`


------
https://chatgpt.com/codex/tasks/task_e_68444b36d408833093bd65c859c94f74