### PR TITLE
Improve oversize diff capture docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,15 @@ The orchestrator `python -m pipelines.meta_orchestrator` ties these actions toge
 
 When a commit's patch exceeds the platform's diff limit, run
 `python pipelines/diff_stat.py -o patch.diff.gz` to view a summary and save
-the full diff to ``patch.diff.gz``.
+the full diff to ``patch.diff.gz``. For an automated approach,
+`python pipelines/oversize_diff_capture.py` stores any oversize patch in
+``artifacts/oversize_patch.diff.gz`` and prints the ``git diff --stat``
+summary so our future selves can revisit the full changeset. Specify a
+revision range (default ``HEAD~1..HEAD``) and optional output path with
+``-o``. The default threshold is 500 kB; pass ``-l`` to adjust. The script
+checks the diff size automatically and only writes the patch when it exceeds
+your chosen limit.
+Decompress with ``gzip -d`` or view the file using ``zless`` to inspect the full patch later.
 
 Bundle pipeline outputs with `python pipelines/majestic_packer.py` to produce
 ``artifacts/majestic_bundle.zip``. The archive now contains a

--- a/early_codex_experiments/tests/test_oversize_diff_capture.py
+++ b/early_codex_experiments/tests/test_oversize_diff_capture.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from pipelines.oversize_diff_capture import capture
+
+
+def test_capture_archives_when_exceeds(tmp_path):
+    out = tmp_path / "patch.gz"
+    repo_root = Path(__file__).resolve().parents[2]
+    capture("HEAD~1..HEAD", repo_root, out, limit=1)
+    assert out.exists()
+
+
+def test_capture_skips_when_under_limit(tmp_path):
+    out = tmp_path / "patch.gz"
+    repo_root = Path(__file__).resolve().parents[2]
+    capture("HEAD~1..HEAD", repo_root, out, limit=10**9)
+    assert not out.exists()

--- a/pipelines/oversize_diff_capture.py
+++ b/pipelines/oversize_diff_capture.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+"""Archive oversize git diffs for later inspection.
+
+The script calculates the patch for a revision range and measures its
+size. When that size surpasses the user-provided threshold, it writes the
+patch to ``artifacts/oversize_patch.diff.gz`` (or a path of your
+choosing) and prints ``git diff --stat``. The archive can be unpacked with
+``gzip -d`` or viewed directly with ``zless``. This way the heavy diff is
+saved only when necessary and remains accessible for posterity.
+"""
+from __future__ import annotations
+
+import argparse
+import gzip
+from pathlib import Path
+
+from .diff_stat import diff_patch, diff_stat
+from vybn.quantum_seed import seed_rng
+
+DEFAULT_LIMIT = 500_000
+DEFAULT_OUTPUT = Path("artifacts/oversize_patch.diff.gz")
+
+
+def capture(rev: str, repo_root: Path, out_path: Path, limit: int) -> None:
+    """Print diff stats and archive the patch if it exceeds ``limit`` bytes."""
+    seed_rng()
+    patch = diff_patch(rev, repo_root)
+    stat_output = diff_stat(rev, repo_root)
+    size = len(patch.encode("utf-8"))
+    print(stat_output)
+    if size > limit:
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with gzip.open(out_path, "wt", encoding="utf-8") as fh:
+            fh.write(patch)
+        print(f"Full patch written to {out_path}")
+    else:
+        print(f"Diff is {size} bytes, under limit {limit}. Nothing archived.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Archive oversize git diffs")
+    parser.add_argument(
+        "rev",
+        nargs="?",
+        default="HEAD~1..HEAD",
+        help="revision range (default: HEAD~1..HEAD)",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help="destination file",
+    )
+    parser.add_argument(
+        "-l",
+        "--limit",
+        type=int,
+        default=DEFAULT_LIMIT,
+        help="size threshold in bytes",
+    )
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[1]
+    capture(args.rev, repo_root, args.output, args.limit)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document how to inspect the saved patch after running `oversize_diff_capture.py`
- note decompression in the helper script's docstring

## Testing
- `PYTHONPATH=.venv/lib/python3.11/site-packages pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844564667148330a06a8fd246b8c4d8