### PR TITLE
Add .gitattributes for binary files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+*.jpg -diff
+*.jpeg -diff
+*.png -diff
+*.gif -diff
+*.hnsw -diff
+*.npy -diff
+*.pdf -diff


### PR DESCRIPTION
## Summary
- mark large binaries as `-diff` so `git diff` won't choke

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68445f5939548330bbe7a89a19d65780