### PR TITLE
Handle large diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+*.jpg binary
+*.jpeg binary
+*.png binary
+*.gif binary
+*.pdf binary
+*.zip binary
+*.gz binary

--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ checks the diff size automatically and only writes the patch when it exceeds
 your chosen limit.
 Decompress with ``gzip -d`` or view the file using ``zless`` to inspect the full patch later.
 
+Large media assets such as ``*.jpg`` and ``*.pdf`` are treated as binary via
+``.gitattributes`` so they don't inflate diffs.
+
 Bundle pipeline outputs with `python pipelines/majestic_packer.py` to produce
 ``artifacts/majestic_bundle.zip``. The archive now contains a
 ``manifest.json`` capturing each file's size, checksum, the quantum seed and


### PR DESCRIPTION
## Summary
- mark common media types as binary via `.gitattributes`
- document that large binary files won't inflate diffs

## Testing
- `PYTHONPATH=.venv/lib/python3.11/site-packages pytest -q early_codex_experiments/tests/test_oversize_diff_capture.py`

------
https://chatgpt.com/codex/tasks/task_e_68446318bbc883309392befc4cb916dd