### PR TITLE
Handle oversize diffs in pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ summary so our future selves can revisit the full changeset. Specify a
 revision range (default ``HEAD~1..HEAD``) and optional output path with
 ``-o``. The default threshold is 500 kB; pass ``-l`` to adjust. The script
 checks the diff size automatically and only writes the patch when it exceeds
-your chosen limit.
+your chosen limit. The pipeline runner now calls this tool at the end of
+each run to capture large diffs automatically.
 Decompress with ``gzip -d`` or view the file using ``zless`` to inspect the full patch later.
 
 Large media assets such as ``*.jpg`` and ``*.pdf`` are treated as binary via

--- a/pipelines/pipeline_runner.py
+++ b/pipelines/pipeline_runner.py
@@ -17,6 +17,11 @@ from .wvwhm_sync import count_entries, LOG_FILE_NAME
 from .generate_graph import build_graph
 from .memory_graph_builder import build_graph as build_memory_graph
 from .introspective_mirror import gather_state
+from .oversize_diff_capture import (
+    capture as capture_diff,
+    DEFAULT_LIMIT,
+    DEFAULT_OUTPUT,
+)
 from vybn.quantum_seed import seed_rng
 
 
@@ -39,6 +44,7 @@ def main() -> None:
 
     state = gather_state(repo_root)
     (repo_root / 'introspection_summary.json').write_text(json.dumps(state, indent=2), encoding='utf-8')
+    capture_diff('HEAD~1..HEAD', repo_root, DEFAULT_OUTPUT, DEFAULT_LIMIT)
     print('Pipeline completed')
 
 


### PR DESCRIPTION
## Summary
- capture oversize git diffs automatically in `pipeline_runner`
- document automatic diff capture in README

## Testing
- `PYTHONPATH=.venv/lib/python3.11/site-packages pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684466f28ff08330b1ace56b6dbc2f9f