### PR TITLE
Refine quantum seeding utilities

### DIFF
--- a/vybn/__init__.py
+++ b/vybn/__init__.py
@@ -1,6 +1,6 @@
 """Vybn package."""
 
-from .quantum_seed import seed_rng
+from .quantum_seed import seed_rng, cross_seed
 from .co_emergence import (
     JOURNAL_PATH,
     DEFAULT_GRAPH,
@@ -16,10 +16,11 @@ from .co_emergence import (
     GraphIntegrator,
 )
 
-from .resonance_engine import ResonanceEngine
+from .resonance_engine import ResonanceEngine, ResonanceState
 
 __all__ = [
     "seed_rng",
+    "cross_seed",
     "JOURNAL_PATH",
     "DEFAULT_GRAPH",
     "load_spikes",

--- a/vybn/co_emergence.py
+++ b/vybn/co_emergence.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Optional, Dict
 
 from pipelines.utils import memory_path
-from vybn.quantum_seed import seed_rng, cross_synaptic_kernel
+from vybn.quantum_seed import seed_rng, cross_seed
 from tools.cognitive_ensemble import compute_co_emergence_score
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -111,8 +111,8 @@ def capture_seed(journal_path: str | Path = JOURNAL_PATH) -> dict:
 
 
 def seed_random() -> int:
-    """Seed Python and NumPy RNGs using the cross-synaptic kernel."""
-    return cross_synaptic_kernel()
+    """Seed Python and NumPy RNGs using the cross-process seed."""
+    return cross_seed()
 
 
 # ----- Graph utilities ---------------------------------------------------------

--- a/vybn/quantum_seed.py
+++ b/vybn/quantum_seed.py
@@ -64,7 +64,7 @@ def seed_rng() -> int:
     return seed
 
 
-def cross_synaptic_kernel() -> int:
+def cross_seed() -> int:
     """Seed RNGs using a process-specific variant of the quantum seed."""
     base_seed = seed_rng()
     syn_seed = (base_seed * 6364136223846793005 + os.getpid()) & 0xFFFFFFFF
@@ -76,3 +76,8 @@ def cross_synaptic_kernel() -> int:
             pass
     os.environ["CROSS_SYN_SEED"] = str(syn_seed)
     return syn_seed
+
+
+def cross_synaptic_kernel() -> int:
+    """Backward compatible alias for :func:`cross_seed`."""
+    return cross_seed()

--- a/vybn/resonance_engine.py
+++ b/vybn/resonance_engine.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Iterable, AsyncIterator
 import asyncio
 
-from .quantum_seed import cross_synaptic_kernel
+from .quantum_seed import cross_seed
 
 
 @dataclass
@@ -21,7 +21,7 @@ class ResonanceEngine:
     """Generate unified resonance states across dream and emergence flows."""
 
     def __init__(self) -> None:
-        cross_synaptic_kernel()
+        cross_seed()
         self._step = 0
 
     def pulse(self) -> ResonanceState:

--- a/what_vybn_would_have_missed_FROM_051725
+++ b/what_vybn_would_have_missed_FROM_051725
@@ -1,3 +1,9 @@
+6/10/25 (Implementation - Quantum Winnowing Pass 25232)
+WVWHM – June 10 2025 Implementation: Consolidated RNG utilities with cross_seed; cross_synaptic_kernel remains as alias.
+- vybn/quantum_seed.py — introduced cross_seed and alias for cross_synaptic_kernel.
+- vybn/co_emergence.py — updated seed_random to use cross_seed.
+- vybn/resonance_engine.py — uses cross_seed for initialization.
+- vybn/__init__.py — exports cross_seed and ResonanceState.
 6/10/25 (Implementation - Quantum Winnowing Pass 43164)
 WVWHM – June 10 2025 Implementation: Archived digital viscerality fragments using quantum seed 43164; the following files were removed.
 - 2024/Code Experiments/November_8_2024_quantum_experiment — async QRNG loop.


### PR DESCRIPTION
## Summary
- consolidate seeding logic with new `cross_seed` helper
- update `resonance_engine` and `co_emergence` to use `cross_seed`
- export `cross_seed` and `ResonanceState`
- document winnowing in WVWHM

## Testing
- `PYTHONPATH=.venv/lib/python3.11/site-packages pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848397d79b883308b4376c6bc99bf9b