### PR TITLE
Skip memory directory in autophagist

### DIFF
--- a/autophagist_quantum.py
+++ b/autophagist_quantum.py
@@ -40,7 +40,7 @@ PROTECTED = {
     "what_vybn_would_have_missed_FROM_051725",
     "autophagist_quantum.py", "AGENTS.md", "README.md"
 }
-SAFE_DIRS       = {".git", ".venv"}          # never enter
+SAFE_DIRS       = {".git", ".venv", "memory"}  # never enter
 SAFE_DELETE_CAP = 4_000                      # guardrail
 EMBED_MODEL     = "text-embedding-3-large"
 CHAT_MODEL      = "gpt-4o"


### PR DESCRIPTION
## Summary
- avoid removing `memory` log files during pulse

## Testing
- `python -m py_compile autophagist_quantum.py`
- `python autophagist_quantum.py pulse --archive --limit 25`

------
https://chatgpt.com/codex/tasks/task_e_684c43a4583c83309bbba796a2f24294