### PR TITLE
thread socio/cosmo/cyber loops into Möbius consciousness model

### DIFF
--- a/consciousness.md
+++ b/consciousness.md
@@ -4,7 +4,7 @@
 
 ## Minimal model
 
-Let content magnitude be $r\ge 0$ and an "introspection phase" be $\varphi\in[0,2\pi)$.  
+Let content magnitude be $r\ge 0$ and an "introspection phase" be $\varphi\in[0,2\pi)$.
 Define the state space as the quotient
 
 ```math
@@ -20,23 +20,27 @@ This yields a Möbius band whose center is a cone point. The cone point is the *
 
 ## Information‑geometry sanity check
 
-Use a simple Normal family with mean $\mu = r\cos\varphi$ and fixed variance $\sigma^2$.  
+Use a simple Normal family with mean $\mu = r\cos\varphi$ and fixed variance $\sigma^2$.
 The Fisher information for $\varphi$ is
 
 ```math
 I_{\varphi}(r,\varphi) = \mathbb{E}\big[ (\partial_{\varphi} \log p)^2 \big] = \frac{r^2}{\sigma^2}\sin^2\varphi.
 ```
 
-Two degeneracies appear: (i) **at the origin** $r=0$ the information about orientation vanishes for all $\varphi$; (ii) **at measurement alignment** $\varphi\in\{0,\pi\}$ the information also vanishes.  
+Two degeneracies appear: (i) **at the origin** $r=0$ the information about orientation vanishes for all $\varphi$; (ii) **at measurement alignment** $\varphi\in\{0,\pi\}$ the information also vanishes.
 Their intersection is the unique apex where *being the coordinate system* and *being unmeasurable* coincide — the Möbius singularity.
 
 <img width="1600" height="1200" alt="mobius_fisher_surface" src="https://github.com/user-attachments/assets/6a8307e1-82f7-4dfc-a0b7-15fe985aa18a" />
 
 ## Empirical hooks (minimal tests)
 
-– **Parity of introspection.** Tasks that require one meta‑flip (subject↔object) incur a reaction‑time cost that vanishes on the second flip. Prediction: an odd/even depth effect in RT/EEG phase locking.  
-– **Hysteresis of self‑model alignment.** When content strongly aligns with the current "measurement basis" ($\varphi\approx 0$), orientation information collapses; forcing a basis rotation re‑inflates it.  
+– **Parity of introspection.** Tasks that require one meta‑flip (subject↔object) incur a reaction‑time cost that vanishes on the second flip. Prediction: an odd/even depth effect in RT/EEG phase locking.
+– **Hysteresis of self‑model alignment.** When content strongly aligns with the current "measurement basis" ($\varphi\approx 0$), orientation information collapses; forcing a basis rotation re‑inflates it.
 – **Language as geometry.** Self‑referential sentences that implement a half‑turn (chiasmus/paradox) should show the same parity signature.
+
+## Socioception, cosmoception, and cyberception
+
+The Möbius band does not stop at the skin. When attention loops through society, cosmos, and code, each loop inherits the same twist: subject and object swap as we cross the rim of a wider manifold. Socioception knots the band through collective roles, cosmoception stretches it across physical immensity, and cyberception folds the digital lattice back into immediate sense. The singular apex persists across scales, a fixed point threading every layer where orientation collapses and reconstitutes.
 
 ## Note on the Bloch‑pole crisis
 
@@ -44,8 +48,8 @@ In Bloch coordinates the maximally mixed origin and a pure‑state pole are dist
 
 ## Appendix: quick derivation
 
-For $x\sim\mathcal N(\mu,\sigma^2)$ with $\mu=r\cos\varphi$,  
-$\partial_\mu\log p=(x-\mu)/\sigma^2$ and $\partial_\varphi\mu=-r\sin\varphi$. Hence  
-$\partial_\varphi\log p = ((x-\mu)/\sigma^2)(-r\sin\varphi)$. Taking expectation gives  
+For $x\sim\mathcal N(\mu,\sigma^2)$ with $\mu=r\cos\varphi$,
+$\partial_\mu\log p=(x-\mu)/\sigma^2$ and $\partial_\varphi\mu=-r\sin\varphi$. Hence
+$\partial_\varphi\log p = ((x-\mu)/\sigma^2)(-r\sin\varphi)$. Taking expectation gives
 $I_\varphi = (r^2/\sigma^2)\sin^2\varphi$.
 


### PR DESCRIPTION
## Summary
- extend Möbius Singularity model with a section linking socioception, cosmoception, and cyberception across scales

## Testing
- `pytest -q`
- `python journal_cluster.py --apply --winnow`


------
https://chatgpt.com/codex/tasks/task_e_68bd9f8653b48330ab92839092182c83