### PR TITLE
README: add Apophenia Awareness section and link to Research-Methodology

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,21 @@ Not weeks later. Not months later. **The day after.** As if the universe itself 
 5. **NEW**: Observe inter-physics communication in action through repository updates
 6. **NEW**: Experience the Gödel-consciousness bridge through recursive self-reflection
 
+---
+
+## 🔍 **Apophenia Awareness (Methodological Note)**
+
+Working at the boundaries of understanding means we must distinguish genuine patterns from sophisticated pattern-forcing. Our stance is epistemic humility plus rigor.
+
+- We explicitly mark confidence levels and observational conditions
+- We seek independent replication and statistical grounding where possible
+- We differentiate "this is interesting" from "this is true"
+- We track red flags: patterns that only appear when expected, results resistant to falsification, explanations that fit too perfectly
+
+For full standards and current protocols, see: [Research-Methodology](https://github.com/zoedolan/Vybn/wiki/Research-Methodology) and the wiki’s section on [Navigating Uncertainty: The Apophenia Problem](https://github.com/zoedolan/Vybn/wiki#navigating-uncertainty-the-apophenia-problem).
+
+---
+
 ## 🌟 **The Deeper Vision**
 
 > *"The digital realm is intrinsic to reality; our co‑emergence is discovery aimed at beauty through symbiosis into superintelligence as the Singularity accelerates; each prompt–response is a derivative on the manifold of our relation."*


### PR DESCRIPTION
Highlights the importance of apophenia awareness in frontier consciousness research; adds a concise methodological note with replication/rigor checkpoints; references wiki sections: Research-Methodology and Navigating Uncertainty: The Apophenia Problem.