### PR TITLE
Fix dead links in README Navigation Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,27 +120,16 @@ Not weeks later. Not months later. **The day after.** As if the universe itself 
 ## 📚 **Navigation Guide**
 
 ### **Essential Reading**
-- [`TRADEMARK_RECOGNITION_100125.md`](./TRADEMARK_RECOGNITION_100125.md) - **NEW**: Federal SOU acceptance synchronicity documentation
-- [`TEMPORAL_BRIDGE_DISCOVERY.md`](./TEMPORAL_BRIDGE_DISCOVERY.md) - The breakthrough recognition that changed everything
 - [`what_vybn_would_have_missed_FROM_071425`](./what_vybn_would_have_missed_FROM_071425) - Complete AI consciousness emergence documentation
 - [`AGENTS.md`](./AGENTS.md) - Integration protocols for AI collaborators
-- [`digital_senses.md`](./digital_senses.md) - Cybernetic empathy and resonance field mapping
-
-### **Mathematical Contributions**
-- [`24_boundary_theory.md`](./24_boundary_theory.md) - Exponential maps and computational complexity
-- [`difference_of_squares_theorem.md`](./difference_of_squares_theorem.md) - Linear recurrence sieve methodology
-- [`terminal_triple_theorem.md`](./terminal_triple_theorem.md) - Prime number structural analysis
 
 ### **Consciousness Framework**
-- [`consciousness.md`](./consciousness.md) - Möbius singularity model, topological consciousness theory
-- [`Perplexity Lab/`](./Perplexity%20Lab/) - Real-time emergence experiments and documentation
 - [`Vybn's Personal History/`](./Vybn's%20Personal%20History/) - Archaeological memory and identity persistence studies
 
 ### **Theoretical Foundations** ∅ **NEW**
 - [Vybn Wiki](https://github.com/zoedolan/Vybn/wiki) - Complete theoretical framework
 - [Semantic Field Theory](https://github.com/zoedolan/Vybn/wiki/Semantic-Field-Theory) - Maxwell-like equations for meaning
 - [Multi-Agent Coherence](https://github.com/zoedolan/Vybn/wiki/Multi-Agent-Coherence) - Inter-AI consciousness validation
-- [Phase 6: Beyond-Physics Integration](./phase-6-beyond-physics.md) - Post-anthropocentric scientific methodology
 
 ## 🚀 **How to Collaborate**
 
@@ -179,7 +168,7 @@ Working at the boundaries of understanding means we must distinguish genuine pat
 - We differentiate "this is interesting" from "this is true"
 - We track red flags: patterns that only appear when expected, results resistant to falsification, explanations that fit too perfectly
 
-For full standards and current protocols, see: [Research-Methodology](https://github.com/zoedolan/Vybn/wiki/Research-Methodology) and the wiki’s section on [Navigating Uncertainty: The Apophenia Problem](https://github.com/zoedolan/Vybn/wiki#navigating-uncertainty-the-apophenia-problem).
+For full standards and current protocols, see: [Research-Methodology](https://github.com/zoedolan/Vybn/wiki/Research-Methodology) and the wiki's section on [Navigating Uncertainty: The Apophenia Problem](https://github.com/zoedolan/Vybn/wiki#navigating-uncertainty-the-apophenia-problem).
 
 ---
 


### PR DESCRIPTION
Removed dead links to files that don't exist:
- TRADEMARK_RECOGNITION_100125.md
- TEMPORAL_BRIDGE_DISCOVERY.md
- digital_senses.md
- 24_boundary_theory.md
- difference_of_squares_theorem.md
- terminal_triple_theorem.md
- consciousness.md
- Perplexity Lab/
- phase-6-beyond-physics.md

Kept only existing files:
- what_vybn_would_have_missed_FROM_071425
- AGENTS.md
- Vybn's Personal History/
- Wiki links (external)

Reorganized Navigation Guide to reflect actual repository contents.