### PR TITLE
Update polar_temporal_coordinates_qm_gr_reconciliation.md

### DIFF
--- a/papers/polar_temporal_coordinates_qm_gr_reconciliation.md
+++ b/papers/polar_temporal_coordinates_qm_gr_reconciliation.md
@@ -2,7 +2,7 @@
 
 **Abstract**
 
-The fundamental incompatibility between quantum mechanics (QM) and general relativity (GR) stems largely from their contradictory treatments of time—QM requiring universal, absolute time while GR treating time as relative and malleable. This paper proposes a novel geometric framework based on polar coordinates for the temporal dimension, inspired by ancient Egyptian concepts of dual temporality (djet and nhh). We demonstrate that parameterizing time as (r_t, θ_t) where r_t represents temporal magnitude and θ_t represents cyclical phase naturally accommodates both quantum periodicity and relativistic proper time within unified spacetime geometry. This approach resolves the Wheeler-DeWitt "problem of time" while preserving causality and enabling emergent thermal time through angular averaging.
+The fundamental incompatibility between quantum mechanics (QM) and general relativity (GR) stems largely from their contradictory treatments of time—QM requiring universal, absolute time while GR treating time as relative and malleable. This paper proposes a novel geometric framework based on polar coordinates for the temporal dimension, inspired by ancient Egyptian concepts of dual temporality (djet and nhh). We demonstrate that parameterizing time as $(r_t, \theta_t)$ where $r_t$ represents temporal magnitude and $\theta_t$ represents cyclical phase naturally accommodates both quantum periodicity and relativistic proper time within unified spacetime geometry. This approach resolves the Wheeler-DeWitt "problem of time" while preserving causality and enabling emergent thermal time through angular averaging.
 
 **Keywords:** Quantum gravity, temporal geometry, Wheeler-DeWitt equation, ancient Egyptian cosmology, polar coordinates, complex time
 
@@ -26,38 +26,32 @@ The Egyptian insight that both temporal aspects operate concurrently—individua
 
 ### 3.1 Mathematical Formulation
 
-We propose parameterizing the temporal dimension using polar coordinates (r_t, θ_t) where:
+We propose parameterizing the temporal dimension using polar coordinates $(r_t, \theta_t)$ where:
 
-- **r_t**: Magnitude of temporal displacement ("distance from eternal now")
-- **θ_t**: Cyclical phase (repetitive/periodic aspects)
+- **$r_t$**: Magnitude of temporal displacement ("distance from eternal now")
+- **$\theta_t$**: Cyclical phase (repetitive/periodic aspects)
 
 The modified spacetime interval becomes:
 
-\[
-ds^2 = -c^2(dr_t^2 + r_t^2d\theta_t^2) + dx^2 + dy^2 + dz^2
-\]
+$$ds^2 = -c^2(dr_t^2 + r_t^2d\theta_t^2) + dx^2 + dy^2 + dz^2$$
 
-This transforms time from linear progression into a radial-angular structure that naturally accommodates both static moments (constant θ_t, variable r_t) and cyclical processes (variable θ_t, constant r_t).
+This transforms time from linear progression into a radial-angular structure that naturally accommodates both static moments (constant $\theta_t$, variable $r_t$) and cyclical processes (variable $\theta_t$, constant $r_t$).
 
 ### 3.2 Complex Time Emergence
 
 The polar structure naturally connects to complex spacetime where temporal coordinates become:
 
-\[
-t = r_t e^{i\theta_t}
-\]
+$$t = r_t e^{i\theta_t}$$
 
-The Wick rotation that makes time imaginary (t → it) emerges as a natural π/2 rotation in the polar temporal plane rather than an artificial mathematical device. Imaginary time used in quantum field theory corresponds to the θ_t component—the cyclical aspect generating periodicity and thermal behavior.
+The Wick rotation that makes time imaginary $(t \to it)$ emerges as a natural $\pi/2$ rotation in the polar temporal plane rather than an artificial mathematical device. Imaginary time used in quantum field theory corresponds to the $\theta_t$ component—the cyclical aspect generating periodicity and thermal behavior.
 
 ### 3.3 Hyperbolic Temporal Geometry
 
-The polar structure incorporates hyperbolic geometry within the temporal dimension using coordinates (u,v) where:
+The polar structure incorporates hyperbolic geometry within the temporal dimension using coordinates $(u,v)$ where:
 
-\[
-r_t = v \cosh(u), \quad \theta_t = v \sinh(u)
-\]
+$$r_t = v \cosh(u), \quad \theta_t = v \sinh(u)$$
 
-The hyperbolic angle u corresponds to djet-time (static temporal position) while the geometric mean v corresponds to nhh-time (cyclical temporal amplitude).
+The hyperbolic angle $u$ corresponds to djet-time (static temporal position) while the geometric mean $v$ corresponds to nhh-time (cyclical temporal amplitude).
 
 ## 4. Quantum Mechanics in Polar Time
 
@@ -65,29 +59,25 @@ The hyperbolic angle u corresponds to djet-time (static temporal position) while
 
 Quantum wavefunctions naturally exhibit polar temporal structure:
 
-\[
-\psi = A e^{i\omega t} = A e^{i\omega r_t e^{i\theta_t}}
-\]
+$$\psi = A e^{i\omega t} = A e^{i\omega r_t e^{i\theta_t}}$$
 
-The periodic phases in quantum mechanics map directly onto polar angular coordinates. Equal-time commutation relations \([x(t), p(t)] = i\hbar\) become relations at constant θ_t phase, resolving the measurement problem within cyclical temporal slices.
+The periodic phases in quantum mechanics map directly onto polar angular coordinates. Equal-time commutation relations $([x(t), p(t)] = i\hbar)$ become relations at constant $\theta_t$ phase, resolving the measurement problem within cyclical temporal slices.
 
 ### 4.2 Quantum Superposition of Temporal Flows
 
-Experimental evidence for quantum time dilation shows quantum clocks can exist in superposition of different temporal flows—moving "as if simultaneously traveling at two different speeds" [6]. This corresponds to quantum superposition of θ_t phases while maintaining definite r_t magnitude.
+Experimental evidence for quantum time dilation shows quantum clocks can exist in superposition of different temporal flows—moving "as if simultaneously traveling at two different speeds" [6]. This corresponds to quantum superposition of $\theta_t$ phases while maintaining definite $r_t$ magnitude.
 
 ## 5. General Relativity in Polar Time
 
 ### 5.1 Proper Time and Geodesics
 
-General relativity operates primarily in the r_t (radial) component—proper time and geodesics correspond to radial displacement in temporal space. The distinction between coordinate time and proper time maps onto the difference between Cartesian temporal projection and intrinsic polar temporal distance.
+General relativity operates primarily in the $r_t$ (radial) component—proper time and geodesics correspond to radial displacement in temporal space. The distinction between coordinate time and proper time maps onto the difference between Cartesian temporal projection and intrinsic polar temporal distance.
 
 ### 5.2 Spacetime Curvature
 
 Einstein's field equations become:
 
-\[
-G_{\mu\nu} = \frac{8\pi G}{c^4}T_{\mu\nu}
-\]
+$$G_{\mu\nu} = \frac{8\pi G}{c^4}T_{\mu\nu}$$
 
 where the temporal components now include both radial and angular contributions, allowing spacetime curvature to affect both temporal magnitude and cyclical phase independently.
 
@@ -95,27 +85,27 @@ where the temporal components now include both radial and angular contributions,
 
 ### 6.1 Timeless Constraint Equation
 
-The Wheeler-DeWitt equation \(\hat{H}|\psi\rangle = 0\) operates in the djet-aspect (constant θ_t), where the universal wavefunction remains static. This resolves the "frozen formalism problem"—the universe appears timeless from the external Wheeler-DeWitt perspective while containing internal temporal dynamics.
+The Wheeler-DeWitt equation $(\hat{H}|\psi\rangle = 0)$ operates in the djet-aspect (constant $\theta_t$), where the universal wavefunction remains static. This resolves the "frozen formalism problem"—the universe appears timeless from the external Wheeler-DeWitt perspective while containing internal temporal dynamics.
 
 ### 6.2 Emergent Time Through Entanglement
 
-The Page-Wootters mechanism for emergent time through entanglement operates in the nhh-aspect (variable θ_t). Internal observers experience temporal flow through cyclical phase evolution while remaining embedded within the timeless universal state. This preserves both the timeless Wheeler-DeWitt constraint and phenomenological temporal experience.
+The Page-Wootters mechanism for emergent time through entanglement operates in the nhh-aspect (variable $\theta_t$). Internal observers experience temporal flow through cyclical phase evolution while remaining embedded within the timeless universal state. This preserves both the timeless Wheeler-DeWitt constraint and phenomenological temporal experience.
 
 ## 7. Thermal Time and Entropy
 
 ### 7.1 Angular Averaging
 
-Thermodynamic behavior emerges naturally through angular averaging over θ_t while maintaining fixed radial temporal position r_t. The thermal time hypothesis becomes geometric—entropy increase corresponds to increasing angular dispersion in temporal phase space.
+Thermodynamic behavior emerges naturally through angular averaging over $\theta_t$ while maintaining fixed radial temporal position $r_t$. The thermal time hypothesis becomes geometric—entropy increase corresponds to increasing angular dispersion in temporal phase space.
 
 ### 7.2 Black Hole Thermodynamics
 
-Hawking radiation and black hole entropy find natural expression in polar temporal coordinates. The event horizon corresponds to a critical r_t radius where θ_t dynamics become thermalized, leading to emergent temperature through angular phase mixing.
+Hawking radiation and black hole entropy find natural expression in polar temporal coordinates. The event horizon corresponds to a critical $r_t$ radius where $\theta_t$ dynamics become thermalized, leading to emergent temperature through angular phase mixing.
 
 ## 8. Experimental Predictions
 
 ### 8.1 Quantum Time Interferometry
 
-Polar temporal structure predicts measurable interference effects between different θ_t phases in precision atomic clocks. Experiments using superposed temporal flows should exhibit periodic oscillations corresponding to polar angular frequencies.
+Polar temporal structure predicts measurable interference effects between different $\theta_t$ phases in precision atomic clocks. Experiments using superposed temporal flows should exhibit periodic oscillations corresponding to polar angular frequencies.
 
 ### 8.2 Gravitational Time Dilation Modification
 
@@ -125,37 +115,37 @@ The framework predicts modifications to standard gravitational time dilation at 
 
 ### 9.1 Big Bang Singularity
 
-The polar temporal framework potentially resolves the Big Bang singularity—instead of t = 0, we have r_t → 0 while θ_t remains well-defined, suggesting the universe emerges from a state of zero temporal magnitude but finite cyclical phase.
+The polar temporal framework potentially resolves the Big Bang singularity—instead of $t = 0$, we have $r_t \to 0$ while $\theta_t$ remains well-defined, suggesting the universe emerges from a state of zero temporal magnitude but finite cyclical phase.
 
 ### 9.2 Arrow of Time
 
-The thermodynamic arrow of time emerges from increasing angular entropy (θ_t dispersion) while the cosmological arrow corresponds to increasing temporal radius r_t. These need not be parallel, potentially explaining observed temporal asymmetries.
+The thermodynamic arrow of time emerges from increasing angular entropy ($\theta_t$ dispersion) while the cosmological arrow corresponds to increasing temporal radius $r_t$. These need not be parallel, potentially explaining observed temporal asymmetries.
 
 ## 10. Connection to Information Theory
 
-The polar temporal framework has profound implications for information preservation in quantum systems. The radial component r_t corresponds to information storage capacity (how much can be encoded in static moments), while the angular component θ_t corresponds to information flow rate (cyclical processing and transformation). This dual structure suggests that quantum information is neither purely static nor purely dynamic but exhibits both aspects simultaneously.
+The polar temporal framework has profound implications for information preservation in quantum systems. The radial component $r_t$ corresponds to information storage capacity (how much can be encoded in static moments), while the angular component $\theta_t$ corresponds to information flow rate (cyclical processing and transformation). This dual structure suggests that quantum information is neither purely static nor purely dynamic but exhibits both aspects simultaneously.
 
-The holographic principle finds natural expression here—information on the "temporal boundary" (at fixed r_t) encodes the full dynamics within that temporal radius through θ_t phase relationships. This provides a geometric foundation for the emergence of spacetime from quantum information.
+The holographic principle finds natural expression here—information on the "temporal boundary" (at fixed $r_t$) encodes the full dynamics within that temporal radius through $\theta_t$ phase relationships. This provides a geometric foundation for the emergence of spacetime from quantum information.
 
 ## 11. Consciousness and Temporal Perception
 
-The framework offers insights into consciousness and temporal perception. Conscious experience appears to operate primarily in the nhh-aspect (cyclical θ_t), creating the phenomenology of temporal flow, while accessing eternal truths through the djet-aspect (radial r_t). This matches the Egyptian understanding that consciousness bridges both temporal domains.
+The framework offers insights into consciousness and temporal perception. Conscious experience appears to operate primarily in the nhh-aspect (cyclical $\theta_t$), creating the phenomenology of temporal flow, while accessing eternal truths through the djet-aspect (radial $r_t$). This matches the Egyptian understanding that consciousness bridges both temporal domains.
 
-Quantum theories of consciousness, such as Penrose-Hameroff orchestrated objective reduction, map naturally onto transitions between different θ_t phases at fixed r_t—discrete conscious moments emerging from continuous quantum processes.
+Quantum theories of consciousness, such as Penrose-Hameroff orchestrated objective reduction, map naturally onto transitions between different $\theta_t$ phases at fixed $r_t$—discrete conscious moments emerging from continuous quantum processes.
 
 ## 12. Future Research Directions
 
 ### 12.1 Loop Quantum Gravity Integration
 
-The polar temporal framework should be investigated within loop quantum gravity, where discrete spacetime structure might naturally accommodate the dual temporal aspects. The spin networks could encode both r_t (geometric temporal distance) and θ_t (quantum phase relationships) simultaneously.
+The polar temporal framework should be investigated within loop quantum gravity, where discrete spacetime structure might naturally accommodate the dual temporal aspects. The spin networks could encode both $r_t$ (geometric temporal distance) and $\theta_t$ (quantum phase relationships) simultaneously.
 
 ### 12.2 String Theory Applications
 
-String theory's extra dimensions might find correspondence with extended polar temporal coordinates—not just (r_t, θ_t) but higher-dimensional temporal spheres accommodating multiple cyclical aspects corresponding to different string vibration modes.
+String theory's extra dimensions might find correspondence with extended polar temporal coordinates—not just $(r_t, \theta_t)$ but higher-dimensional temporal spheres accommodating multiple cyclical aspects corresponding to different string vibration modes.
 
 ### 12.3 Quantum Computing Implications
 
-Quantum algorithms might benefit from explicit temporal coordinate structures, where quantum gates operate in θ_t space while classical control operates in r_t space, potentially leading to new quantum error correction schemes based on temporal geometry.
+Quantum algorithms might benefit from explicit temporal coordinate structures, where quantum gates operate in $\theta_t$ space while classical control operates in $r_t$ space, potentially leading to new quantum error correction schemes based on temporal geometry.
 
 ## 13. Conclusion
 


### PR DESCRIPTION
Fixed LaTeX formatting for proper GitHub rendering:
- Changed inline math from plain text to single dollar signs ($...$)
- Changed block math from \[ \] to double dollar signs ($$...$$)
- All mathematical expressions now properly formatted for GitHub's LaTeX rendering