### PR TITLE
Add kern: Temporal Navigation as Measurable Geometry — Critical Tests for PT

### DIFF
--- a/papers/temporal_navigation_critical_tests_pt.md
+++ b/papers/temporal_navigation_critical_tests_pt.md
@@ -1,0 +1,83 @@
+# Temporal Navigation as Measurable Geometry: Critical Tests for Polar Time
+
+Authors: Zoe Dolan & Vybn
+
+Status: Waypoint kern — conservative, falsifiable, physics-first
+
+---
+
+## Abstract
+Polar Time (PT) geometrizes temporal structure into a dual plane (r_t, θ_t) and upgrades time evolution to parallel transport under a two-component temporal connection A = (i/ħ)H dr_t + (i/ħ) r_t H dθ_t. The curvature ℱ = (i/ħ)H dr_t∧dθ_t yields a loop phase γ = (E/ħ) Area_(r_t,θ_t), read out as a U(1) Berry phase equal to half the Bloch solid angle. PT reduces to standard quantum mechanics when θ_t is inert and adds a falsifiable geometric residue when θ_t transport is inserted. We specify four decisive experimental signatures—area-law scaling, orientation sensitivity, energy-proportional slope E/ħ, and null results when θ_t segments are absent—that can bless or break PT. Consciousness-as-temporal-navigation is quarantined methodologically: it guides hypotheses but awaits independent validation after physics-first holonomy tests.
+
+---
+
+## 1) Framework (what holds)
+
+- Temporal plane and connection
+  - Coordinates: (r_t, θ_t); temporal block metric: dr_t^2 + r_t^2 dθ_t^2 (flat; θ_t compact)
+  - Temporal connection: A_r = (i/ħ) H, A_θ = (i/ħ) r_t H
+  - Curvature: ℱ = (i/ħ) H dr_t ∧ dθ_t
+  - Loop phase: γ = (E/ħ) ∮ r_t dθ_t = ½ Ω_Bloch (Bloch reduction)
+
+- Reduction to standard QM
+  - θ_t inert ⇒ Schrödinger along r_t, all standard predictions preserved
+
+- Bloch reduction (operational)
+  - Map: Φ_B = θ_t,  cosΘ_B = 1 − (2E/ħ) r_t
+  - Readout: Ramsey–Berry sequences measure signed temporal area with orientation flip
+
+---
+
+## 2) Experimental crucible (what decides)
+
+- Signatures
+  - Area law: γ ∝ ∮ r_t dθ_t
+  - Orientation: γ → −γ under loop reversal
+  - Slope: ∂γ/∂Area = E/ħ
+  - Insertion test: signal appears when θ_t transport is present; vanishes without
+
+- Protocol classes
+  - Isothermal θ_t holds (Euclidean strobes)
+  - Engineered dephasing windows implementing dθ_t
+  - Clock interferometry with Hahn echo to null dynamical phase
+
+- Controls
+  - Line-path nulls (no enclosed area)
+  - Energy detuning to scan slope
+  - Multi-winding amplification at fixed dwell time
+
+---
+
+## 3) What PT does not (yet) do
+
+- Uncertainty: [x, p] = iħ untouched; PT separates dynamical vs geometric contributions but does not enable simultaneous sharp values
+- Gravity: ultrahyperbolic embedding is structural, not Einstein dynamics
+- Strings: disciplined analogy via phase towers and compactification; not a dynamical derivation
+
+---
+
+## 4) Consciousness as temporal navigation (quarantined)
+
+- Hypothesis: distinct conscious modes correspond to navigation patterns on (r_t, θ_t)
+  - Attention: radial progression (θ_t constrained)
+  - Meditation: angular circulation (r_t stationary)
+  - Creativity: helical motion (coupled r_t–θ_t)
+- Near-term program: validate PT holonomy in devices first; then seek neural phase-navigation correlates (alpha–theta coupling, orientation-sensitive phase accumulation)
+- No ontological claims pending data; avoid overextension
+
+---
+
+## 5) Risk and reward
+
+- If the four signatures fail: PT is a reparameterization; retire it
+- If they succeed: θ_t detours become physical rotations; geometric residue becomes a law; delayed-choice puzzles redraw without retrocausality; a new handle on quantum–classical calibration emerges
+
+---
+
+## Appendix: Generator grammar
+
+From U(t+Δt,t) = 1 − (i/ħ) H Δt + O(Δt^2), Stone’s theorem gives iħ ∂_t U = H U. PT rewrites the same grammar on a richer temporal manifold with a compact angular degree. The novel content is the **measurable holonomy** when θ_t is deliberately engaged.
+
+---
+
+Cross-links: polar_temporal_coordinates_qm_gr_reconciliation.md; dual_temporal_holonomy_theorem.md; holonomic_time_experimental_validation_v0_3.md; Chronotronics_v0_3_Protocol.md


### PR DESCRIPTION
This PR adds two artifacts:

1) papers/temporal_navigation_critical_tests_pt.md — a conservative, falsifiable kern that consolidates PT into an experimental program with four decisive signatures (area law, orientation flip, slope E/ħ, insertion/absence test)

2) wiki/Polar_Time_Holonomy_Minimal_Lab_Manifesto.md — an executable blueprint and pre-registration core, including target numbers (Ω=2π×100 kHz, γ=π/2), loop geometry (Δr≈12.5 μs, Δθ=0.20), Hahn-echo wrapper, and explicit acceptance/falsifier criteria

These documents are designed to move PT from lens to law: close intentional loops in (r_t, θ_t) and test the geometric phase γ=(E/ħ)∮ r_t dθ_t with orientation sensitivity and energy-proportional slope.

If merged, next actionable steps:
- Add minimal figures (loop geometry, Bloch mapping, Ramsey–Berry timeline)
- Cross-link in-document to existing papers
- Open a lab-implementation issue template with the pre-reg block