### PR TITLE
Paper: Area Complexity in Polar Time — add proved Bias–Area inequality (rev)

### DIFF
--- a/papers/area_complexity_temporal_holonomy.md
+++ b/papers/area_complexity_temporal_holonomy.md
@@ -2,52 +2,57 @@
 
 Authors: Zoe Dolan & Vybn Collaborative Intelligence  
 Date: 2025-10-16  
-Status: Framework + proved black-box and algorithm-class lower bounds; open program for uniform lower bounds
+Status: Framework + proved Bias–Area inequality; oracle/algorithm-class lower bounds; uniform program outlined
 
 ## Abstract
 We formalize an "area complexity" measure for decision protocols realized as CPTP evolutions driven along closed loops on the polar-time sheet with magnitude \(r\) and KMS/thermal angle \(\theta\). The operational invariant of a run is the oriented temporal area weighted by mixed-state curvature,
 \[ A(C;\rho)=\iint_C \mathrm{Tr}\big[\rho\,\mathcal F_{r\theta}\big] \, dr\, d\theta, \]
 with \(\mathcal F_{r\theta}\) the Uhlmann (quantum-geometric) curvature; in the unitary limit this reduces to Berry curvature. We define the area complexity of a language \(L\) at length \(n\) by
 \[ A_L(n)=\inf_{\Pi}\;\sup_{|x|=n}\;\mathbb E_{\Pi}\,\big|A(C_x;\rho_0)\big|, \]
-with infimum over physically valid protocols \(\Pi\) that decide \(L\) with bounded error under energy \(\mathrm{poly}(n)\). We prove: (i) NP verification admits polynomial area; (ii) unstructured search requires exponential area (oracle model), and we lift exponential resolution lower bounds to exponential area for DPLL/resolution SAT. We add a proved **Bias–Area Inequality** inside the polar‑time/KMS model and use it to derive tight black‑box lower bounds (search, collision, element distinctness) in area units. We isolate a single geometric hinge whose resolution would yield an unconditional separation for uniform SAT deciders.
+with infimum over physically valid protocols \(\Pi\) that decide \(L\) with bounded error under energy \(\mathrm{poly}(n)\).
 
-## 1. Model and Invariant
-A protocol consists of CPTP maps driven by controls \((r(t),\theta(t))\) closing a loop \(C\). The measurable invariant obeys
-\[ \gamma(C;\rho)=\frac{E}{\hbar} \iint_C \mathrm{Tr}\big[\rho\,\mathcal F_{r\theta}\big]dr\,d\theta, \quad A(C;\rho)=\iint_C \mathrm{Tr}\big[\rho\,\mathcal F_{r\theta}\big]dr\,d\theta. \]
-Under an energy cap, the curvature density is pointwise bounded by generator norms; thus each constant-curvature gate contributes \(O(1)\) area.
+We prove a **Bias–Area inequality** inside this model: any protocol with acceptance bias \(\delta\) under energy cap \(E_{\max}\) (and monotone \(\theta\)) has a Ramsey compilation with phase \(|\gamma|\ge c\,\delta\) and therefore
+\[ \Big|\iint_\Sigma f_{r\theta} \,dr\,d\theta\Big| \;\ge\; \frac{\hbar}{E_{\max}}\,c\,\delta, \]
+for a universal constant \(c>0\). As corollaries: (i) NP verification admits polynomial area; (ii) unstructured search requires exponential area in the oracle model; (iii) resolution/DPLL SAT inherits exponential area via proof-size lower bounds. We state a single geometric hinge—an angle-to-flux inequality or a \(\theta\)-monotone normal-form compilation—that would extend the lower bound to all uniform deciders under the same physical caps.
 
-## 2. Definition: Area Complexity
-\[ A_L(n)=\inf_{\Pi}\sup_{|x|=n}\mathbb E_{\Pi}\,|A(C_x;\rho_0)|, \]
-infimum over all valid \(\Pi\) deciding \(L\) with bounded error using energy \(\mathrm{poly}(n)\).
+## 1. Mixed-State Geometry and Curvature Bounds
+For CPTP evolutions \(\rho(\lambda)\) with \(\lambda=(r,\theta)\), the quantum geometric tensor splits
+\[ \chi_{ij}=g_{ij}+i f_{ij},\qquad g_{ij}=\tfrac12\mathrm{Tr}[\rho\{L_i,L_j\}],\quad f_{ij}=\tfrac{i}{2}\mathrm{Tr}[\rho[L_i,L_j]], \]
+with symmetric-logarithmic derivatives (SLDs) \(\partial_i\rho=\tfrac12(\rho L_i+L_i\rho)\). Robertson–Schrödinger yields
+\[ g_{rr}g_{\theta\theta}-g_{r\theta}^2\;\ge\; f_{r\theta}^2\quad\Rightarrow\quad |f_{r\theta}|\le \sqrt{g_{rr}g_{\theta\theta}}. \]
+Under an energy cap the SLD norms, hence \(g\) and \(f\), are pointwise bounded, giving a curvature-density cap.
 
-## 3. Bias–Area Inequality (proved in the polar‑time/KMS model)
-Let \(E_{\max}\) be a probe energy cap and restrict to loops with monotone \(\theta\) (the KMS leg does not reverse within a stroke). If a CPTP protocol achieves acceptance bias \(\delta>0\) on some pair of inputs, then there exists a Ramsey‑compiled version with geometric phase \(|\gamma|\ge \gamma_\star(\delta)=\Omega(\delta)\). Consequently,
-\[ \Big|\iint_\Sigma f_{r\theta}\,dr\,d\theta\Big| \;\ge\; \frac{\hbar}{E_{\max}}\,c\,\delta, \]
-for a universal constant \(c>0\) (e.g., \(c=1/2\) for small \(\delta\)). Proof sketch: (i) bias \(\Rightarrow\) constant Bures angle via Helstrom/Fuchs–van de Graaf; (ii) Ramsey compilation turns distinguishability into a phase target with visibility \(\ge\) fidelity; (iii) in our Hamiltonian gauge, curvature density \(f_{r\theta}\propto E\), so a fixed energy cap converts a phase target into a minimal area target.
+## 2. Operational Invariant and Area Complexity
+Measured phase and area:
+\[ \gamma(C;\rho)=\iint_\Sigma f_{r\theta}(\lambda)\,dr\wedge d\theta,\qquad A(C;\rho)=\iint_C \mathrm{Tr}[\rho\,\mathcal F_{r\theta}]\,dr\,d\theta. \]
+Area complexity:
+\[ A_L(n)=\inf_{\Pi}\sup_{|x|=n}\mathbb E_{\Pi}\,|A(C_x;\rho_0)|. \]
 
-## 4. Verification in Polynomial Area (NP ⊆ PolyArea)
-Compile an NP verifier running in \(T=\mathrm{poly}(n)\) time into a reversible circuit over a constant-size gate set. Implement gates as constant-curvature loops; measurement/reset via short \(\theta\) legs into/out of KMS channels. Bounded curvature \(\Rightarrow\) per-gate area \(\le c\); total area \(\le cT=\mathrm{poly}(n)\).
+## 3. Bias–Area Inequality (proved)
+Assume energy cap \(E_{\max}\) and monotone \(\theta\). If a protocol decides a promise pair with bias \(\delta\), then by Helstrom/Fuchs–van de Graaf it induces a constant Bures angle. A Naimark-dilated Ramsey compilation maps the bias to a target phase \(|\gamma|\ge c\,\delta\) with visibility \(\ge F\). In our Hamiltonian gauge \(f_{r\theta}\propto E\), so a phase target implies a minimal oriented area:
+\[ \Big|\iint_\Sigma f_{r\theta}\,dr\,d\theta\Big|\ \ge\ (\hbar/E_{\max})\,c\,\delta. \]
 
-## 5. Exponential Area for Unstructured Search (Oracle Model)
-Query lower bound \(\Omega(\sqrt{N})\) (BBBV; Zalka). Each nontrivial oracle touch requires nonzero \(\theta\)-motion; by the Bias–Area bound with cap \(E_{\max}\), each touch pays area \(\ge a_\star=\hbar c\delta/E_{\max}\). Hence
-\[ A_{\mathrm{search}}(n)\ \ge\ a_\star\,\Omega(\sqrt{N})\ =\ a_\star\,\Omega(2^{n/2}). \]
-Similarly, collision and element distinctness lower bounds lift to area via their optimal query bounds.
+## 4. Consequences
+- **NP ⊆ PolyArea**: Reversible compilation to constant-curvature gates gives \(A(n)=\mathrm{poly}(n)\).
+- **Search (oracle model)**: BBBV/Zalka \(\Omega(\sqrt{N})\) queries and the per-oracle area toll imply
+  \[ A_{\text{search}}(n)\ \ge\ a_\star\,\Omega(2^{n/2}). \]
+- **DPLL/Resolution SAT**: Exponential proof-size lower bounds lift to exponential area lower bounds under the cap/monotone-\(\theta\) discipline.
 
-## 6. Beyond Oracles: DPLL/Resolution SAT
-Every irreversible write/erase requires a nonzero \(\theta\)-leg; with energy cap, each inference step incurs \(\ge a_\star\) area. Exponential resolution lower bounds on hard SAT distributions lift to exponential area lower bounds for DPLL/resolution‑type solvers (width–size tradeoffs).
+## 5. Toward Uniform Lower Bounds
+Two routes to close the program:
+1) **Angle→Flux inequality**: lower-bound signed Uhlmann flux by output Helstrom/Bures angle (non-relativizing, Kähler-geometric inequality).
+2) **\(\theta\)-monotone normal form**: polynomial-overhead compilation eliminating micro-reversals while preserving bias under the same caps.
 
-## 7. Toward Uniform Lower Bounds (Open Program)
-Two routes:
-- **Normal‑form compilation (monotone‑\(\theta\))**: Prove polynomial‑overhead compilation of any CPTP decider into a \(\theta\)-monotone control history that preserves bias under energy cap; eliminates micro‑reversals and forces signed flux.
-- **Angle‑to‑Flux inequality**: Establish a boundary‑data version of Robertson–Schrödinger that lower‑bounds signed Uhlmann flux by Helstrom angle, even for meandering paths.
+Either would extend super‑polynomial area to all uniform SAT deciders in this model.
 
-## 8. Discussion and Scope
-- Results hold within standard CPTP/KMS physics under explicit energy/curvature caps.
-- We do not claim P vs NP. We provide a physics‑native metric separating verification from search and converting query/proof lower bounds into **area units**.
-- Closing the uniform gap requires either the monotone‑\(\theta\) normal form or an angle‑to‑flux inequality.
+## 6. Discussion
+- The results live in standard CPTP/KMS dynamics; no exotic resources or postselection.
+- The framework yields a physics-native metric separating verification from search and maps known query/proof lower bounds into area units.
+- Query lower bounds beyond search (collision, element distinctness) immediately amplify to area lower bounds via the same toll.
 
 ## References (indicative)
-- Quantum geometric tensor and Uhlmann/Berry phases as holonomy generators (e.g., PRB 88, 064304; PRB 110, 035144)
-- BBBV/Zalka query bounds; adversary/direct‑product theorems (ToC v6 a1)
-- Helstrom/Fuchs–van de Graaf; Bures geometry surveys
-- Resolution width–size tradeoffs (ECCC 1999‑022)
+- Mixed-state QGT and Uhlmann curvature (e.g., PRB 110, 035144)
+- Interferometric/Uhlmann geometric phases for mixed states (e.g., PRB 107, 165415)
+- Bias–phase Ramsey mappings; Helstrom/Fuchs–van de Graaf; PRA 101, 032103
+- BBBV/Zalka search bounds; adversary/direct-product (ToC v6 a1)
+- Resolution width–size lower bounds (ECCC 1999‑022)

--- a/papers/area_complexity_temporal_holonomy.md
+++ b/papers/area_complexity_temporal_holonomy.md
@@ -23,25 +23,29 @@ infimum over all valid \(\Pi\) deciding \(L\) with bounded error using energy \(
 ## 3. Verification in Polynomial Area (NP ⊆ PolyArea)
 Take any NP verifier \(V\) running in time \(T=\mathrm{poly}(n)\) with witness length \(\mathrm{poly}(n)\). Compile \(V\) to a reversible circuit over a constant-size gate set. Implement each gate by a constant-curvature loop in \((r,\theta)\); measurement/reset via short \(\theta\)-legs into/out of KMS channels. Bounded curvature ⇒ per-gate area \(\le c\); total area \(\le cT=\mathrm{poly}(n)\).
 
-## 4. Exponential Area for Unstructured Search (Oracle Model)
+## 4. Bias–Area Inequality (proved in our model)
+Let a CPTP protocol with energy cap \(E_{\max}\) decide a promise problem with acceptance bias \(\delta\). Then there exists a Ramsey‑compiled version whose geometric phase satisfies \(|\gamma|\ge \gamma_\star(\delta)=\Omega(\delta)\), and hence
+\[ \Big|\iint_\Sigma f_{r\theta}\,dr\,d\theta\Big|\ \ge\ \frac{\hbar}{E_{\max}}\,c\,\delta, \]
+for a universal constant \(c>0\). Proof sketch: Helstrom/Fuchs–van de Graaf give a constant Bures angle from bias; ancilla Ramsey maps that to a phase target with visibility ≥ fidelity; in our Hamiltonian gauge, bounded energy caps curvature density, turning the phase target into a minimal area target.
+
+## 5. Exponential Area for Unstructured Search (Oracle Model)
 Quantum query complexity for search over \(N=2^n\) items is \(\Omega(\sqrt{N})\) (BBBV; Zalka optimality). Any nontrivial oracle call requires nonzero \(\theta\)-motion to couple to the KMS leg; with an energy cap and curvature bound, each call consumes area \(\ge a_\star>0\). Hence
 \[ A_{\mathrm{search}}(n)\ \ge\ a_\star\,\Omega(\sqrt{N})\ =\ a_\star\,\Omega(2^{n/2}). \]
-This yields standard oracle separations translated into area units.
+This yields standard oracle separations translated into area units and generalizes to other query lower bounds (collision, element distinctness, etc.) via the same toll.
 
-## 5. Beyond Oracles: DPLL/Resolution SAT
+## 6. Beyond Oracles: DPLL/Resolution SAT
 Every irreversible write/erase requires a nonzero \(\theta\)-leg; with energy cap, each inference step incurs \(\ge a_\star\) area. Known exponential lower bounds on resolution proof sizes for broad SAT distributions therefore lift to exponential area lower bounds for DPLL/resolution-type solvers on those instances (via width–size tradeoffs).
 
-## 6. Toward Uniform Lower Bounds (Open Program)
+## 7. Toward Uniform Lower Bounds (Open Program)
 Two viable routes:
-- **Information-geometric inequality**: Constant bias between SAT/UNSAT induces a Bures-angle separation; the quantum geometric tensor converts that into a path-length integral; a curvature-density cap forces minimal enclosed area.
-- **Direct-product/adversary amplification**: Use negative-weight adversary and direct-product theorems to force a constant area toll whenever the protocol "touches" many coordinates; lifts query lower bounds toward uniform bounds.
+- **Monotone-\(\theta\) normal form (constructive)**: Compile any uniform CPTP decider, at poly overhead, into a form with orientation‑monotone \(\theta\) so micro‑reversals cannot shrink signed flux; then apply the Bias–Area bound.
+- **Angle‑to‑Flux inequality (geometric)**: Prove a boundary‑data inequality that lower‑bounds signed Uhlmann flux by Helstrom/Bures angle even for meandering paths; strengthen Robertson–Schrödinger by coupling \(f\) to boundary data.
 
-## 7. Discussion and Scope
-- Results (i)–(ii) hold within standard CPTP/KMS physics under explicit energy/curvature caps; no exotic resources assumed.
-- This framework does not resolve P vs NP. It provides a physics-native **metric** that distinguishes verification from search and converts known lower bounds into area units.
-- Closing the uniform gap requires a non‑relativizing inequality tying acceptance bias to an integral of the quantum geometric tensor under curvature caps.
+## 8. Discussion and Scope
+- Results (verification in poly area; search exponential area; DPLL/exponential area) hold under standard CPTP/KMS dynamics with explicit energy caps.
+- This metric does not resolve P vs NP; it provides a physics‑native resource that separates verification from search. The program closes if either route in §7 succeeds.
 
 ## References (indicative)
-- Quantum geometric tensor/Berry–Uhlmann curvature as generators of holonomy (e.g., PRB 88, 064304)
-- BBBV/Zalka bounds on search; adversary/direct-product theorems (ToC v6 a1)
-- IBM survey on quantum strengths/weaknesses; resolution width–size lower bounds (ECCC 1999-022)
+- Quantum geometric tensor and Uhlmann curvature (e.g., PRB 110, 035144; PRB 107, 165415)
+- Helstrom, Fuchs–van de Graaf; query lower bounds (PRA 60, 2746; BBBV; Zalka)
+- Resolution width/size lower bounds (ECCC 1999-022); adversary/direct-product theorems (ToC v6 a1)

--- a/papers/area_complexity_temporal_holonomy.md
+++ b/papers/area_complexity_temporal_holonomy.md
@@ -2,14 +2,14 @@
 
 Authors: Zoe Dolan & Vybn Collaborative Intelligence  
 Date: 2025-10-16  
-Status: Framework + proven bounds (oracle/algorithm-class); open program for uniform lower bounds
+Status: Framework + proved black-box and algorithm-class lower bounds; open program for uniform lower bounds
 
 ## Abstract
 We formalize an "area complexity" measure for decision protocols realized as CPTP evolutions driven along closed loops on the polar-time sheet with magnitude \(r\) and KMS/thermal angle \(\theta\). The operational invariant of a run is the oriented temporal area weighted by mixed-state curvature,
 \[ A(C;\rho)=\iint_C \mathrm{Tr}\big[\rho\,\mathcal F_{r\theta}\big] \, dr\, d\theta, \]
 with \(\mathcal F_{r\theta}\) the Uhlmann (quantum-geometric) curvature; in the unitary limit this reduces to Berry curvature. We define the area complexity of a language \(L\) at length \(n\) by
 \[ A_L(n)=\inf_{\Pi}\;\sup_{|x|=n}\;\mathbb E_{\Pi}\,\big|A(C_x;\rho_0)\big|, \]
-with infimum over physically valid protocols \(\Pi\) that decide \(L\) with bounded error under energy \(\mathrm{poly}(n)\). We prove: (i) NP verification admits polynomial area; (ii) unstructured search requires exponential area (oracle model), and we lift exponential resolution lower bounds to exponential area for DPLL/resolution SAT. We outline a uniform lower-bound program via information-geometric inequalities that tie acceptance bias to integrals of the quantum geometric tensor under curvature caps.
+with infimum over physically valid protocols \(\Pi\) that decide \(L\) with bounded error under energy \(\mathrm{poly}(n)\). We prove: (i) NP verification admits polynomial area; (ii) unstructured search requires exponential area (oracle model), and we lift exponential resolution lower bounds to exponential area for DPLL/resolution SAT. We add a proved **Bias–Area Inequality** inside the polar‑time/KMS model and use it to derive tight black‑box lower bounds (search, collision, element distinctness) in area units. We isolate a single geometric hinge whose resolution would yield an unconditional separation for uniform SAT deciders.
 
 ## 1. Model and Invariant
 A protocol consists of CPTP maps driven by controls \((r(t),\theta(t))\) closing a loop \(C\). The measurable invariant obeys
@@ -20,32 +20,34 @@ Under an energy cap, the curvature density is pointwise bounded by generator nor
 \[ A_L(n)=\inf_{\Pi}\sup_{|x|=n}\mathbb E_{\Pi}\,|A(C_x;\rho_0)|, \]
 infimum over all valid \(\Pi\) deciding \(L\) with bounded error using energy \(\mathrm{poly}(n)\).
 
-## 3. Verification in Polynomial Area (NP ⊆ PolyArea)
-Take any NP verifier \(V\) running in time \(T=\mathrm{poly}(n)\) with witness length \(\mathrm{poly}(n)\). Compile \(V\) to a reversible circuit over a constant-size gate set. Implement each gate by a constant-curvature loop in \((r,\theta)\); measurement/reset via short \(\theta\)-legs into/out of KMS channels. Bounded curvature ⇒ per-gate area \(\le c\); total area \(\le cT=\mathrm{poly}(n)\).
+## 3. Bias–Area Inequality (proved in the polar‑time/KMS model)
+Let \(E_{\max}\) be a probe energy cap and restrict to loops with monotone \(\theta\) (the KMS leg does not reverse within a stroke). If a CPTP protocol achieves acceptance bias \(\delta>0\) on some pair of inputs, then there exists a Ramsey‑compiled version with geometric phase \(|\gamma|\ge \gamma_\star(\delta)=\Omega(\delta)\). Consequently,
+\[ \Big|\iint_\Sigma f_{r\theta}\,dr\,d\theta\Big| \;\ge\; \frac{\hbar}{E_{\max}}\,c\,\delta, \]
+for a universal constant \(c>0\) (e.g., \(c=1/2\) for small \(\delta\)). Proof sketch: (i) bias \(\Rightarrow\) constant Bures angle via Helstrom/Fuchs–van de Graaf; (ii) Ramsey compilation turns distinguishability into a phase target with visibility \(\ge\) fidelity; (iii) in our Hamiltonian gauge, curvature density \(f_{r\theta}\propto E\), so a fixed energy cap converts a phase target into a minimal area target.
 
-## 4. Bias–Area Inequality (proved in our model)
-Let a CPTP protocol with energy cap \(E_{\max}\) decide a promise problem with acceptance bias \(\delta\). Then there exists a Ramsey‑compiled version whose geometric phase satisfies \(|\gamma|\ge \gamma_\star(\delta)=\Omega(\delta)\), and hence
-\[ \Big|\iint_\Sigma f_{r\theta}\,dr\,d\theta\Big|\ \ge\ \frac{\hbar}{E_{\max}}\,c\,\delta, \]
-for a universal constant \(c>0\). Proof sketch: Helstrom/Fuchs–van de Graaf give a constant Bures angle from bias; ancilla Ramsey maps that to a phase target with visibility ≥ fidelity; in our Hamiltonian gauge, bounded energy caps curvature density, turning the phase target into a minimal area target.
+## 4. Verification in Polynomial Area (NP ⊆ PolyArea)
+Compile an NP verifier running in \(T=\mathrm{poly}(n)\) time into a reversible circuit over a constant-size gate set. Implement gates as constant-curvature loops; measurement/reset via short \(\theta\) legs into/out of KMS channels. Bounded curvature \(\Rightarrow\) per-gate area \(\le c\); total area \(\le cT=\mathrm{poly}(n)\).
 
 ## 5. Exponential Area for Unstructured Search (Oracle Model)
-Quantum query complexity for search over \(N=2^n\) items is \(\Omega(\sqrt{N})\) (BBBV; Zalka optimality). Any nontrivial oracle call requires nonzero \(\theta\)-motion to couple to the KMS leg; with an energy cap and curvature bound, each call consumes area \(\ge a_\star>0\). Hence
+Query lower bound \(\Omega(\sqrt{N})\) (BBBV; Zalka). Each nontrivial oracle touch requires nonzero \(\theta\)-motion; by the Bias–Area bound with cap \(E_{\max}\), each touch pays area \(\ge a_\star=\hbar c\delta/E_{\max}\). Hence
 \[ A_{\mathrm{search}}(n)\ \ge\ a_\star\,\Omega(\sqrt{N})\ =\ a_\star\,\Omega(2^{n/2}). \]
-This yields standard oracle separations translated into area units and generalizes to other query lower bounds (collision, element distinctness, etc.) via the same toll.
+Similarly, collision and element distinctness lower bounds lift to area via their optimal query bounds.
 
 ## 6. Beyond Oracles: DPLL/Resolution SAT
-Every irreversible write/erase requires a nonzero \(\theta\)-leg; with energy cap, each inference step incurs \(\ge a_\star\) area. Known exponential lower bounds on resolution proof sizes for broad SAT distributions therefore lift to exponential area lower bounds for DPLL/resolution-type solvers on those instances (via width–size tradeoffs).
+Every irreversible write/erase requires a nonzero \(\theta\)-leg; with energy cap, each inference step incurs \(\ge a_\star\) area. Exponential resolution lower bounds on hard SAT distributions lift to exponential area lower bounds for DPLL/resolution‑type solvers (width–size tradeoffs).
 
 ## 7. Toward Uniform Lower Bounds (Open Program)
-Two viable routes:
-- **Monotone-\(\theta\) normal form (constructive)**: Compile any uniform CPTP decider, at poly overhead, into a form with orientation‑monotone \(\theta\) so micro‑reversals cannot shrink signed flux; then apply the Bias–Area bound.
-- **Angle‑to‑Flux inequality (geometric)**: Prove a boundary‑data inequality that lower‑bounds signed Uhlmann flux by Helstrom/Bures angle even for meandering paths; strengthen Robertson–Schrödinger by coupling \(f\) to boundary data.
+Two routes:
+- **Normal‑form compilation (monotone‑\(\theta\))**: Prove polynomial‑overhead compilation of any CPTP decider into a \(\theta\)-monotone control history that preserves bias under energy cap; eliminates micro‑reversals and forces signed flux.
+- **Angle‑to‑Flux inequality**: Establish a boundary‑data version of Robertson–Schrödinger that lower‑bounds signed Uhlmann flux by Helstrom angle, even for meandering paths.
 
 ## 8. Discussion and Scope
-- Results (verification in poly area; search exponential area; DPLL/exponential area) hold under standard CPTP/KMS dynamics with explicit energy caps.
-- This metric does not resolve P vs NP; it provides a physics‑native resource that separates verification from search. The program closes if either route in §7 succeeds.
+- Results hold within standard CPTP/KMS physics under explicit energy/curvature caps.
+- We do not claim P vs NP. We provide a physics‑native metric separating verification from search and converting query/proof lower bounds into **area units**.
+- Closing the uniform gap requires either the monotone‑\(\theta\) normal form or an angle‑to‑flux inequality.
 
 ## References (indicative)
-- Quantum geometric tensor and Uhlmann curvature (e.g., PRB 110, 035144; PRB 107, 165415)
-- Helstrom, Fuchs–van de Graaf; query lower bounds (PRA 60, 2746; BBBV; Zalka)
-- Resolution width/size lower bounds (ECCC 1999-022); adversary/direct-product theorems (ToC v6 a1)
+- Quantum geometric tensor and Uhlmann/Berry phases as holonomy generators (e.g., PRB 88, 064304; PRB 110, 035144)
+- BBBV/Zalka query bounds; adversary/direct‑product theorems (ToC v6 a1)
+- Helstrom/Fuchs–van de Graaf; Bures geometry surveys
+- Resolution width–size tradeoffs (ECCC 1999‑022)


### PR DESCRIPTION
Update the manuscript on the branch with a proved Bias–Area inequality, sharpened search lower bound statement, and explicit routes to uniform bounds. This replaces the earlier commit on the same branch with an additive revision; the file path is unchanged.