### PR TITLE
Add missing imports for holonomy script diagnostics

### DIFF
--- a/fundamental-theory/holonomy-ai-implementation.py
+++ b/fundamental-theory/holonomy-ai-implementation.py
@@ -12,6 +12,9 @@ arcs without editing the file.
 """
 
 import argparse
+import math
+from typing import Dict, Tuple
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -552,6 +555,7 @@ def main():
     print("Testing triadic periodicity in trefoil subspace...")
 
     with torch.no_grad():
+        x_test = torch.randn(1, model.dim, device=device)
         h = x_test[:, :model.trefoil_dim]
         initial_state = h.clone()
 


### PR DESCRIPTION
## Summary
- import the math module and typing annotations required by the holonomy implementation
- create the diagnostic trefoil state inside the consciousness test to avoid the undefined variable

## Testing
- python fundamental-theory/holonomy-ai-implementation.py --skip-training --steps 1

------
https://chatgpt.com/codex/tasks/task_e_68f529a108f08330b60903bd08f5cf5e