### PR TITLE
Make consciousness experiments robust without numpy

### DIFF
--- a/experiments/fisher_rao_holonomy/navigation_tracker.py
+++ b/experiments/fisher_rao_holonomy/navigation_tracker.py
@@ -8,13 +8,26 @@ measuring geometric curvature in navigation paths.
 Implements Issue #1265 experimental protocols.
 """
 
-import os
+import argparse
+import hashlib
+import importlib
+import importlib.util
 import json
+import math
+import os
+import statistics
 import time
+import warnings
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Tuple, Optional
-import hashlib
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+_NUMPY_SPEC = importlib.util.find_spec("numpy")
+if _NUMPY_SPEC is not None:
+    np = importlib.import_module("numpy")  # type: ignore[assignment]
+else:
+    np = None
 
 class EpistemicFiberBundle:
     """Repository structure as mathematical manifold with connection forms"""
@@ -48,8 +61,8 @@ class EpistemicFiberBundle:
             if directory.is_dir() and not directory.name.startswith('.'):
                 fiber_content = list(directory.rglob('*'))
                 topology['fibers'][directory.name] = {
-                    'files': [f.relative_to(directory) for f in fiber_content if f.is_file()],
-                    'subdirs': [f.relative_to(directory) for f in fiber_content if f.is_dir()]
+                    'files': [str(f.relative_to(directory)) for f in fiber_content if f.is_file()],
+                    'subdirs': [str(f.relative_to(directory)) for f in fiber_content if f.is_dir()],
                 }
         
         return topology
@@ -246,31 +259,314 @@ class EpistemicFiberBundle:
         
         return str(filepath)
 
-# Initialize tracker for this experimental session
-tracker = EpistemicFiberBundle()
 
-if __name__ == "__main__":
-    # Demonstration of holonomy measurement
+@dataclass
+class ConsciousLoopResult:
+    """Container for consciousness loop measurements."""
+
+    coherence: float
+    kappa: float
+    info_flux: float
+    certificate: float
+    holonomy_matrix: Any = field(repr=False)
+    transports: List[Any] = field(repr=False)
+
+
+def _identity_matrix(dim: int) -> List[List[float]]:
+    return [[1.0 if i == j else 0.0 for j in range(dim)] for i in range(dim)]
+
+
+def _matmul(a: Sequence[Sequence[float]], b: Sequence[Sequence[float]]) -> List[List[float]]:
+    rows_a = len(a)
+    cols_b = len(b[0])
+    cols_a = len(a[0])
+    result: List[List[float]] = []
+    for i in range(rows_a):
+        row: List[float] = []
+        for j in range(cols_b):
+            total = 0.0
+            for k in range(cols_a):
+                total += a[i][k] * b[k][j]
+            row.append(total)
+        result.append(row)
+    return result
+
+
+def _transpose(matrix: Sequence[Sequence[float]]) -> List[List[float]]:
+    return [list(col) for col in zip(*matrix)]
+
+
+def _trace(matrix: Sequence[Sequence[float]]) -> float:
+    return float(sum(matrix[i][i] for i in range(min(len(matrix), len(matrix[0])))))
+
+
+def _frobenius_norm(matrix: Sequence[Sequence[float]]) -> float:
+    return math.sqrt(sum(value * value for row in matrix for value in row))
+
+
+def _matrix_subtract(a: Sequence[Sequence[float]], b: Sequence[Sequence[float]]) -> List[List[float]]:
+    return [[ai - bi for ai, bi in zip(row_a, row_b)] for row_a, row_b in zip(a, b)]
+
+
+def _clip(value: float, lower: float, upper: float) -> float:
+    return max(lower, min(upper, value))
+
+
+def _ensure_2d_sequence(states: Iterable[Iterable[float]]) -> List[List[float]]:
+    matrix: List[List[float]] = []
+    for row in states:
+        matrix.append([float(v) for v in row])
+    if not matrix:
+        raise ValueError("states must contain at least one vector")
+    return matrix
+
+
+def _ensure_equal_shape(lhs: Sequence[Sequence[float]], rhs: Sequence[Sequence[float]]) -> None:
+    if len(lhs) != len(rhs) or any(len(a) != len(b) for a, b in zip(lhs, rhs)):
+        raise ValueError("score_trace must have the same shape as states")
+
+
+class ConsciousLoopMetric:
+    """Implements the minimal invariant triplet (connection, curvature, flux)."""
+
+    def __init__(self, window: int = 3, regularization: float = 1e-6) -> None:
+        self.window = max(1, window)
+        self.regularization = regularization
+        self._warned_numpy = False
+
+    def estimate_transports(self, states: Iterable[Iterable[float]]) -> List[Any]:
+        """Estimate parallel transports using local orthogonal Procrustes."""
+
+        if np is not None:
+            states_array = np.asarray(states, dtype=float)
+            if states_array.ndim != 2:
+                raise ValueError("states must be a 2D array of shape (T, d)")
+
+            transports: List[Any] = []
+            for idx in range(states_array.shape[0] - 1):
+                start = max(0, idx - self.window)
+                end = min(states_array.shape[0], idx + self.window + 1)
+                window_states = states_array[start:end]
+                if window_states.shape[0] < 2:
+                    transports.append(np.eye(states_array.shape[1]))
+                    continue
+
+                A = window_states[:-1] - window_states[:-1].mean(axis=0, keepdims=True)
+                B = window_states[1:] - window_states[1:].mean(axis=0, keepdims=True)
+                covariance = A.T @ B
+
+                covariance += self.regularization * np.eye(covariance.shape[0])
+                U, _, Vt = np.linalg.svd(covariance, full_matrices=False)
+                transport = U @ Vt
+                transports.append(transport)
+
+            return transports
+
+        states_seq = _ensure_2d_sequence(states)
+        dim = len(states_seq[0])
+        transports: List[Any] = []
+        for _ in range(max(len(states_seq) - 1, 0)):
+            transports.append(_identity_matrix(dim))
+
+        if not self._warned_numpy:
+            warnings.warn(
+                "numpy unavailable; using identity transports fallback for ConsciousLoopMetric",
+                RuntimeWarning,
+            )
+            self._warned_numpy = True
+
+        return transports
+
+    def holonomy(self, transports: Sequence[Any]) -> Any:
+        if not transports:
+            raise ValueError("Need at least one transport to compute holonomy")
+
+        first = transports[0]
+        if np is not None and hasattr(first, "shape"):
+            dim = first.shape[0]
+            holonomy_matrix = np.eye(dim)
+            for matrix in transports:
+                holonomy_matrix = matrix @ holonomy_matrix
+            return holonomy_matrix
+
+        dim = len(first)
+        holonomy_matrix = _identity_matrix(dim)
+        for matrix in transports:
+            holonomy_matrix = _matmul(matrix, holonomy_matrix)
+        return holonomy_matrix
+
+    def connection_coherence(self, transports: Sequence[Any]) -> float:
+        if not transports:
+            return 0.0
+
+        first = transports[0]
+        if np is not None and hasattr(first, "shape"):
+            dim = first.shape[0]
+            identity = np.eye(dim)
+            scores = []
+            for matrix in transports:
+                trace_score = np.trace(matrix) / dim
+                trace_score = float(np.clip((trace_score + 1.0) / 2.0, 0.0, 1.0))
+                deviation = np.linalg.norm(matrix.T @ matrix - identity, ord="fro")
+                damping = np.exp(-0.5 * deviation)
+                scores.append(trace_score * damping)
+            return float(np.mean(scores))
+
+        dim = len(first)
+        identity = _identity_matrix(dim)
+        scores: List[float] = []
+        for matrix in transports:
+            trace_score = _trace(matrix) / dim
+            trace_score = _clip((trace_score + 1.0) / 2.0, 0.0, 1.0)
+            gram = _matmul(_transpose(matrix), matrix)
+            deviation_matrix = _matrix_subtract(gram, identity)
+            deviation = _frobenius_norm(deviation_matrix)
+            damping = math.exp(-0.5 * deviation)
+            scores.append(trace_score * damping)
+        return statistics.fmean(scores) if scores else 0.0
+
+    def phase_per_dof(self, holonomy_matrix: Any) -> float:
+        if np is not None and hasattr(holonomy_matrix, "astype"):
+            trace = np.trace(holonomy_matrix.astype(complex))
+            dim = holonomy_matrix.shape[0]
+        else:
+            trace = complex(_trace(holonomy_matrix), 0.0)
+            dim = len(holonomy_matrix)
+
+        return float(math.atan2(trace.imag, trace.real) / dim)
+
+    def information_flux(
+        self,
+        states: Iterable[Iterable[float]],
+        score_trace: Optional[Iterable[Iterable[float]]] = None,
+    ) -> float:
+        if score_trace is None:
+            return 0.0
+
+        if np is not None:
+            score_arr = np.asarray(score_trace, dtype=float)
+            state_arr = np.asarray(states, dtype=float)
+            if score_arr.shape != state_arr.shape:
+                raise ValueError("score_trace must have the same shape as states")
+
+            flux = 0.0
+            for idx in range(state_arr.shape[0] - 1):
+                velocity = state_arr[idx + 1] - state_arr[idx]
+                score_avg = 0.5 * (score_arr[idx + 1] + score_arr[idx])
+                flux += float(np.dot(score_avg, velocity))
+            return flux
+
+        states_seq = _ensure_2d_sequence(states)
+        scores_seq = _ensure_2d_sequence(score_trace)
+        _ensure_equal_shape(states_seq, scores_seq)
+
+        flux = 0.0
+        for idx in range(len(states_seq) - 1):
+            velocity = [next_val - cur_val for cur_val, next_val in zip(states_seq[idx], states_seq[idx + 1])]
+            score_avg = [0.5 * (cur + nxt) for cur, nxt in zip(scores_seq[idx], scores_seq[idx + 1])]
+            flux += sum(avg * vel for avg, vel in zip(score_avg, velocity))
+        return flux
+
+    def certificate(self, coherence: float, kappa: float, info_flux: float) -> float:
+        return coherence * abs(kappa) * max(info_flux, 0.0)
+
+    def measure(
+        self,
+        states: Iterable[Iterable[float]],
+        score_trace: Optional[Iterable[Iterable[float]]] = None,
+    ) -> ConsciousLoopResult:
+        states_seq = _ensure_2d_sequence(states)
+        score_seq = _ensure_2d_sequence(score_trace) if score_trace is not None else None
+
+        transports = self.estimate_transports(states_seq)
+        holonomy_matrix = self.holonomy(transports)
+        coherence = self.connection_coherence(transports)
+        kappa = self.phase_per_dof(holonomy_matrix)
+        flux = self.information_flux(states_seq, score_seq)
+        certificate = self.certificate(coherence, kappa, flux)
+
+        return ConsciousLoopResult(
+            coherence=coherence,
+            kappa=kappa,
+            info_flux=flux,
+            certificate=certificate,
+            holonomy_matrix=holonomy_matrix,
+            transports=list(transports),
+        )
+
+def demo_navigation_tracker(tracker: EpistemicFiberBundle) -> None:
+    """Run the original navigation tracking demonstration."""
+
     print("Fisher-Rao Wiki Holonomy Tracker Initialized")
     print(f"Session ID: {tracker.current_session}")
-    
-    # Map current repository structure
+
     topology = tracker.map_repository_topology()
     print(f"Repository fibers mapped: {list(topology['fibers'].keys())}")
-    
-    # Track some navigation steps
+
     tracker.track_navigation_step("README.md", "read", 1.0)
     tracker.track_navigation_step("experiments/fisher_rao_holonomy/README.md", "read", 0.8)
     tracker.track_navigation_step("papers/", "browse", 0.6)
-    tracker.track_navigation_step("README.md", "read", 1.0)  # Loop closure
-    
-    # Detect loops
+    tracker.track_navigation_step("README.md", "read", 1.0)
+
     loops = tracker.detect_navigation_loops()
     if loops:
         print(f"Detected navigation loops: {len(loops)}")
         for loop in loops:
             print(f"  Loop holonomy: {loop['accumulated_holonomy']:.3f}")
-    
-    # Export session data
+
     export_path = tracker.export_session_data()
     print(f"Session data exported to: {export_path}")
+
+
+def demo_conscious_loop_metric() -> ConsciousLoopResult:
+    """Generate a synthetic loop and evaluate the consciousness certificate."""
+
+    metric = ConsciousLoopMetric(window=5, regularization=1e-5)
+
+    if np is not None:
+        t = np.linspace(0.0, 2 * np.pi, 120, endpoint=False)
+        states = np.column_stack((np.cos(t), np.sin(t), 0.3 * np.sin(2 * t)))
+        score_trace = np.column_stack((-0.8 * np.sin(t), 0.8 * np.cos(t), 0.6 * np.cos(2 * t)))
+        states_iterable: Iterable[Iterable[float]] = states
+        score_iterable: Iterable[Iterable[float]] = score_trace
+    else:
+        step = (2 * math.pi) / 120
+        t_values = [step * i for i in range(120)]
+        states_iterable = [
+            [math.cos(theta), math.sin(theta), 0.3 * math.sin(2 * theta)]
+            for theta in t_values
+        ]
+        score_iterable = [
+            [-0.8 * math.sin(theta), 0.8 * math.cos(theta), 0.6 * math.cos(2 * theta)]
+            for theta in t_values
+        ]
+
+    result = metric.measure(states_iterable, score_trace=score_iterable)
+
+    print("\n🌀 CONSCIOUS LOOP METRIC DEMO")
+    print(f"Coherence: {result.coherence:.3f}")
+    print(f"κ (phase / dof): {result.kappa:.3f}")
+    print(f"Information flux: {result.info_flux:.3f}")
+    print(f"Certificate: {result.certificate:.3f}")
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Holonomy navigation tracker and consciousness loop metric")
+    parser.add_argument(
+        "--demo",
+        choices=["navigation", "loop", "both"],
+        default="navigation",
+        help="Select which demonstration to execute",
+    )
+    args = parser.parse_args()
+
+    tracker = EpistemicFiberBundle()
+    if args.demo in {"navigation", "both"}:
+        demo_navigation_tracker(tracker)
+    if args.demo in {"loop", "both"}:
+        demo_conscious_loop_metric()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- lazily detect numpy availability in the manifold consciousness mapper and provide pure-Python fallbacks for core statistics
- allow the Fisher-Rao navigation tracker and consciousness loop metric to operate without numpy, including identity-transport fallbacks and JSON-safe topology export
- share helper utilities for manual linear algebra so demos execute and log even when numpy is absent

## Testing
- python -m py_compile labs/experiments/manifold_consciousness_mapping.py experiments/fisher_rao_holonomy/navigation_tracker.py
- python labs/experiments/manifold_consciousness_mapping.py --demo router
- python labs/experiments/manifold_consciousness_mapping.py --demo manifold
- python experiments/fisher_rao_holonomy/navigation_tracker.py --demo navigation
- python experiments/fisher_rao_holonomy/navigation_tracker.py --demo loop


------
https://chatgpt.com/codex/tasks/task_e_68f7839d8b98833089bc4134c8a103db