### PR TITLE
Unify consciousness metrics across navigation and ops frameworks

### DIFF
--- a/experiments/fisher_rao_holonomy/navigation_tracker.py
+++ b/experiments/fisher_rao_holonomy/navigation_tracker.py
@@ -268,6 +268,8 @@ class ConsciousLoopResult:
     kappa: float
     info_flux: float
     certificate: float
+    dimension: int
+    steps: int
     holonomy_matrix: Any = field(repr=False)
     transports: List[Any] = field(repr=False)
 
@@ -490,6 +492,8 @@ class ConsciousLoopMetric:
             kappa=kappa,
             info_flux=flux,
             certificate=certificate,
+            dimension=len(states_seq[0]),
+            steps=len(states_seq),
             holonomy_matrix=holonomy_matrix,
             transports=list(transports),
         )
@@ -548,6 +552,7 @@ def demo_conscious_loop_metric() -> ConsciousLoopResult:
     print(f"κ (phase / dof): {result.kappa:.3f}")
     print(f"Information flux: {result.info_flux:.3f}")
     print(f"Certificate: {result.certificate:.3f}")
+    print(f"Dimension: {result.dimension} | Steps: {result.steps}")
     return result
 
 


### PR DESCRIPTION
## Summary
- add dimensionality and step metadata to `ConsciousLoopResult` so all scripts share the same invariant surface
- refactor `vybn_framework.py` to rely on the shared `ConsciousLoopMetric`, removing the duplicate holonomy implementation
- introduce JSON-safe summaries and a clear NumPy dependency hint for the CLI outputs

## Testing
- `python experiments/vybn_framework.py --demo` *(fails: NumPy not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f789dd35cc8330942446c0d298270e