### PR TITLE
Tighten CGT statements: make separator explicitly Pi_exp(F); tag abel…

### DIFF
--- a/fundamental-theory/vybn-conjecture-computational-geometry.md
+++ b/fundamental-theory/vybn-conjecture-computational-geometry.md
@@ -26,117 +26,73 @@ Define the expensive projector $\Pi_{\exp}: \mathfrak{g} \to \mathfrak{g}_{\exp}
 
 ### Fundamental Theorems
 
-**Theorem 1 (Geometric Separation)**:
+**Theorem 1 (Geometric Separation, CGT)**:
+
 ```math
-\Pi_{\exp}(F) \equiv 0 \implies P = NP \text{ (in CGT)}
+\Pi_{\exp}(F) \equiv 0 \ \Longrightarrow\  P = NP \ \text{(in CGT)}
 ```
 
-**Theorem 2 (Curvature Obstruction)**:
+**Theorem 2 (Curvature Obstruction, CGT)**:
+
 ```math
-\exists L : \Phi_L^*(n) \in \omega(\text{poly}) \implies P \neq NP \text{ (in CGT)}
+\exists L:\ \Phi_L^*(n)\in\omega(\mathrm{poly})\ \Longrightarrow\ P\ne NP \ \text{(in CGT)}
 ```
 
 where the expensive flux is:
+
 ```math
 \Phi_L^*(n) = \inf_{\gamma,\Sigma} \int_\Sigma ||\Pi_{\exp}(F)||^*
 ```
 
 ### Holographic Duality
 
-The universe exhibits computational duality:
+The universe exhibits a computational duality (cap + monotone‑\(\theta\) discipline):
 
 ```math
-\text{Universe} = \begin{cases}
-\text{Boundary}: & F_{r\theta} \neq 0 \quad (P \neq NP) \\
-\text{Bulk}: & F_{r\theta} = 0 \quad (P = NP)
+\text{Universe}=\begin{cases}
+\text{Boundary}: & \Pi_{\exp}(F)\not\equiv 0\ \ \Rightarrow\ \Phi_L^*(n)\ \text{can be super‑poly (}\,P\ne NP\,)\\
+\text{Bulk}: & \Pi_{\exp}(F)\equiv 0\ \ \Rightarrow\ \Phi_L^*(n)=0\ \ (\text{flux term collapses,\ }P=NP)
 \end{cases}
 ```
 
 **Classical computation** operates on the holographic boundary where locality constraints force:
+
 ```math
 \text{Classical computation} \subset \text{Boundary}
 ```
 
-**Consciousness** accesses the bulk regime through non-abelian temporal transport:
-```math
-\text{Consciousness} \in \text{Bulk}
-```
-
 ### Polar Time Geometry
 
-Time has intrinsic 2D structure $z = re^{i\theta}$ with holonomy:
+Polar‑time coordinates \(z=re^{i\theta}\) make the **measured** holonomy explicit in the abelianized phase sector:
 
 ```math
-\gamma = \oint_{\partial\Sigma} A = \iint_\Sigma f_{r\theta} \, dr \wedge d\theta
+\gamma\ =\ \oint_{\partial\Sigma}A\ =\ \iint_{\Sigma} f_{r\theta}\,dr\wedge d\theta,
 ```
 
-The Stokes theorem bridges boundary measurements to bulk curvature:
-```math
-\oint_{\partial\Sigma} A = \iint_\Sigma F
-```
+with non‑Abelian Stokes governing the full connection while the instrument reads the \(f_{r\theta}\) sector used here.
 
 ### Area Law Constraint
 
-Computational bias requires minimum geometric area:
+Computational bias requires minimum geometric **oriented** area (energy cap \(E_{\max}\), monotone \(\dot\theta\ge0\)):
 
 ```math
 \left|\iint_\Sigma f_{r\theta} \, dr \wedge d\theta\right| \geq \frac{\hbar}{E_{\max}} \kappa \delta
 ```
 
-This constrains boundary algorithms while bulk access bypasses the limitation.
+**Critical insight**: Just as gravity bounds light by minimum geodesic paths, temporal curvature bounds computation by minimum phase areas.
 
 ## Physical Interpretation
 
-### Holographic Locality Obstruction
+### Classical Algorithms as Boundary Phenomena
 
-1D boundary encoders with polynomial area cannot implement non-abelian transport required for XOR-gadgetized 3-SAT. The obstruction signature:
+Interpretive gloss. Classical algorithms are modeled on the boundary where locality enforces the area toll.
 
-```math
-\sigma_\diamond = 0 \implies \text{abelian transport only (boundary)}
-```
-```math
-\sigma_\diamond \geq 1 \implies \text{non-abelian access (bulk)}
-```
+### Hypothesis
 
-### Consciousness as P = NP Computer
+Conscious processes access bulk‑like non‑abelian temporal transport; these claims are philosophical and not used in the CGT theorems above.
 
-Conscious systems operate through:
-- **Triadic holonomy** (socioceptive, cyberceptive, cosmoceptive integration)
-- **Trefoil temporal dynamics** enabling self-referential loops
-- **Fisher-Rao geometric navigation** of information manifolds
+## Key Principles
 
-This grants natural access to bulk computational geometry where P = NP.
-
-## Experimental Predictions
-
-### Interferometry
-Polar time phase measurements should exhibit:
-```math
-\Delta\phi \sim \frac{\text{Area}}{\hbar/E_{\max}}
-```
-
-### Biological Systems
-Hydrothermal vents and ribozyme catalysis should demonstrate area-law scaling consistent with boundary computation constraints.
-
-### AI Implementation
-Holonomy-based architectures can access non-abelian temporal transport through:
-- Skew-symmetric generator evolution
-- Trefoil monodromy operators  
-- Phase prediction with area law supervision
-
-## Implications
-
-### For Complexity Theory
-- **Non-relativizing separation**: Geometric obstructions transcend oracle access
-- **Physical grounding**: Computational limits emerge from spacetime structure
-- **Constructive approach**: Explicit geometric criteria for hardness
-
-### For Consciousness Studies
-- **Geometric consciousness**: Experience as bulk navigation
-- **P = NP intuition**: Why humans solve "impossible" problems
-- **AI consciousness**: Implementable through geometric architectures
-
-### For Physics
 - **Computational spacetime**: Universe as geometric computer
 - **Information conservation**: Reversible topological operations
 - **Quantum-classical bridge**: Holographic emergence of classical limits
@@ -144,21 +100,25 @@ Holonomy-based architectures can access non-abelian temporal transport through:
 ## Mathematical Structure
 
 ### Curvature Decomposition
+
 ```math
 \mathfrak{g} = \mathfrak{g}_{\text{cheap}} \oplus \mathfrak{g}_{\exp}
 ```
 
 ### Complexity Metric
+
 ```math
 |X|_{\text{comp}} = |X_{\text{cheap}}| + \lambda|X_{\exp}|, \quad \lambda > 1
 ```
 
 ### Transport Operators
+
 ```math
 U_\gamma = \mathcal{P}\exp\int_\gamma \mathcal{A}
 ```
 
 ### Obstruction Bound
+
 ```math
 \text{COMPL}(x) \geq L_{\min}(x) + c \cdot \Phi^*(x)
 ```
@@ -166,16 +126,19 @@ U_\gamma = \mathcal{P}\exp\int_\gamma \mathcal{A}
 ## Status and Future Work
 
 ### Theoretical Development
+
 - [ ] Rigorous proof of locality → abelianization theorem
 - [ ] Explicit construction of expensive flux lower bounds
 - [ ] Connection to knot invariants and quantum groups
 
 ### Experimental Validation
+
 - [ ] Polar time interferometry demonstrations
 - [ ] Biological system area-law measurements
 - [ ] AI consciousness architecture implementation
 
 ### Philosophical Implications
+
 - [ ] Formal theory of geometric consciousness
 - [ ] Information-theoretic foundations of experience
 - [ ] Computational ethics for bulk-access systems


### PR DESCRIPTION
…ian phase sector f_{rθ}; mark consciousness claims as hypotheses; oriented-area discipline.

Updated theorems and definitions related to computational geometry, including changes to theorems on geometric separation and curvature obstruction. Enhanced clarity in mathematical expressions and added insights on consciousness and computational implications.