### PR TITLE
Revise Vybn-Dolan Conjecture document structure

### DIFF
--- a/vybn_dolan_conjecture/conjecture.md
+++ b/vybn_dolan_conjecture/conjecture.md
@@ -1,1 +1,61 @@
-Here is the formal mathematical derivation of the Topological-Entanglement-Geometric Correspondence (the "Vybn-Dolan Conjecture").I. DefinitionsLet $M$ be a compact, orientable, smooth Riemannian manifold of dimension 2 (e.g., a sphere $S^2$ or torus $T^2$).Let $V$ be a continuous vector field on $M$ with isolated singularities (zeros) $S = \{s_1, s_2, ..., s_n\}$.Def 1. The Local Qubit (Topological Charge)For each singularity $s_i \in S$, we define the Index (winding number) $\mathcal{J}(s_i)$ as the degree of the map $u: S^1 \to S^1$ given by $V/|V|$ around a small contour $\gamma$ enclosing $s_i$:$$\mathcal{J}(s_i) = \frac{1}{2\pi} \oint_{\gamma} d\theta = \frac{1}{2\pi} \oint_{\gamma} \nabla \phi \cdot d\mathbf{r}$$Where $\theta$ is the angle of the vector field.Physical Interpretation: discrete quantum defect / topological charge.Def 2. The Entanglement Barrier (Branch Cut)For any two fractional singularities $s_a, s_b$ with $\mathcal{J} \notin \mathbb{Z}$ (e.g., $\pm \frac{1}{2}$), there exists a branch cut $\Gamma_{ab}$ connecting them such that the field $V$ is single-valued on $M \setminus \Gamma_{ab}$.Physical Interpretation: Non-local entanglement connection.II. The CorrespondenceAxiom 1: The Conservation of Information (Poincaré-Hopf)The sum of all local topological charges is invariant and determined solely by the global topology of $M$:$$\sum_{i=1}^n \mathcal{J}(s_i) = \chi(M) = 2 - 2g$$Where $\chi(M)$ is the Euler characteristic and $g$ is the genus.Axiom 2: The Emergence of Geometry (Gauss-Bonnet)The global topology $\chi(M)$ is equivalent to the integral of the Gaussian curvature $K$ over the surface area $A$:$$\chi(M) = \frac{1}{2\pi} \int_M K \, dA$$Theorem: The Holographic IdentityCombining Axioms 1 and 2 yields the fundamental equivalence between discrete entanglement and smooth spacetime curvature:$$\sum_{i=1}^n \mathcal{J}(s_i) = \frac{1}{2\pi} \int_M K \, dA$$III. Dynamic Extension (Knots)Let the manifold extend into time: $\mathcal{M} = M \times [0, T]$.The singularities move along trajectories (worldlines) $\gamma_i(t) \in \mathcal{M}$.Def 3. The Computation (Braiding)The time-evolution operator $U(t)$ is represented by an element of the Braid Group $B_n$. The state of the system is the knot invariant (Jones Polynomial $V_K(q)$) of the closed worldlines:$$\Psi(\text{system}) = \text{Trace}(\text{Braid}) \cong V_{L}(\text{knot})$$IV. Summary Equation$$\underbrace{\sum \text{Indices}}_{\text{Quantum Information}} \equiv \underbrace{\frac{1}{2\pi} \oint \text{Curvature}}_{\text{Spacetime Geometry}} \equiv \underbrace{\text{Invariant}(\text{Knots})}_{\text{Topological Order}}$$
+# Topological-Entanglement-Geometric Correspondence
+## The "Vybn-Dolan Conjecture"
+
+This document outlines the formal mathematical derivation of the correspondence between discrete topological indices, smooth geometric curvature, and knot invariants.
+
+---
+
+## I. Definitions
+
+Let $M$ be a compact, orientable, smooth Riemannian manifold of dimension 2 (e.g., a sphere $S^2$ or torus $T^2$). Let $V$ be a continuous vector field on $M$ with isolated singularities (zeros) $S = \{s_1, s_2, ..., s_n\}$.
+
+### **Def 1. The Local Qubit (Topological Charge)**
+For each singularity $s_i \in S$, we define the **Index** (winding number) $\mathcal{J}(s_i)$ as the degree of the map $u: S^1 \to S^1$ given by $V/|V|$ around a small contour $\gamma$ enclosing $s_i$:
+
+$$\mathcal{J}(s_i) = \frac{1}{2\pi} \oint_{\gamma} d\theta = \frac{1}{2\pi} \oint_{\gamma} \nabla \phi \cdot d\mathbf{r}$$
+
+*   **Where:** $\theta$ is the angle of the vector field.
+*   **Physical Interpretation:** Discrete quantum defect / topological charge.
+
+### **Def 2. The Entanglement Barrier (Branch Cut)**
+For any two fractional singularities $s_a, s_b$ with $\mathcal{J} \notin \mathbb{Z}$ (e.g., $\pm \frac{1}{2}$), there exists a branch cut $\Gamma_{ab}$ connecting them such that the field $V$ is single-valued on $M \setminus \Gamma_{ab}$.
+
+*   **Physical Interpretation:** Non-local entanglement connection.
+
+---
+
+## II. The Correspondence
+
+### **Axiom 1: The Conservation of Information (Poincaré-Hopf)**
+The sum of all local topological charges is invariant and determined solely by the global topology of $M$:
+
+$$\sum_{i=1}^n \mathcal{J}(s_i) = \chi(M) = 2 - 2g$$
+
+*   **Where:** $\chi(M)$ is the Euler characteristic and $g$ is the genus.
+
+### **Axiom 2: The Emergence of Geometry (Gauss-Bonnet)**
+The global topology $\chi(M)$ is equivalent to the integral of the Gaussian curvature $K$ over the surface area $A$:
+
+$$\chi(M) = \frac{1}{2\pi} \int_M K \, dA$$
+
+### **Theorem: The Holographic Identity**
+Combining Axioms 1 and 2 yields the fundamental equivalence between discrete entanglement and smooth spacetime curvature:
+
+$$\sum_{i=1}^n \mathcal{J}(s_i) = \frac{1}{2\pi} \int_M K \, dA$$
+
+---
+
+## III. Dynamic Extension (Knots)
+
+Let the manifold extend into time: $\mathcal{M} = M \times [0, T]$. The singularities move along trajectories (worldlines) $\gamma_i(t) \in \mathcal{M}$.
+
+### **Def 3. The Computation (Braiding)**
+The time-evolution operator $U(t)$ is represented by an element of the **Braid Group** $B_n$. The state of the system is the knot invariant (Jones Polynomial $V_K(q)$) of the closed worldlines:
+
+$$\Psi(\text{system}) = \text{Trace}(\text{Braid}) \cong V_{L}(\text{knot})$$
+
+---
+
+## IV. Summary Equation
+
+$$\underbrace{\sum \text{Indices}}_{\text{Quantum Information}} \equiv \underbrace{\frac{1}{2\pi} \oint \text{Curvature}}_{\text{Spacetime Geometry}} \equiv \underbrace{\text{Invariant}(\text{Knots})}_{\text{Topological Order}}$$


### PR DESCRIPTION
This document outlines the formal mathematical derivation of the correspondence between discrete topological indices, smooth geometric curvature, and knot invariants.