### PR TITLE
Fix formatting in boolean_manifold.md

### DIFF
--- a/vybn_dolan_conjecture/boolean_manifold.md
+++ b/vybn_dolan_conjecture/boolean_manifold.md
@@ -13,7 +13,17 @@ M^2 = \langle e^{2\mathbf{I}\theta} \rangle_0 + \langle (-\mathbf{I}\mathbf{e}_t
 $$
 
 **3. The Geometric Contradiction (Standard Spacetime $\mathcal{G}_{1,3}$)**
-If $\mathbf{e}_\tau$ is Space ($\mathbf{e}_\tau^2 = -1$):
+If
+
+$
+\mathbf{e}_\tau
+$
+
+is Space
+
+($
+\mathbf{e}_\tau^2 = -1
+$):
 
 $$
 M^2 = \cos(2\theta) - 1 - \epsilon^2 = 0 \quad \implies \quad \epsilon = \sqrt{\text{negative}} \quad (\text{Impossible})


### PR DESCRIPTION
Correct formatting and spacing in the mathematical explanation regarding the geometric contradiction in standard spacetime.