### PR TITLE
Refine Abstract: Use Physical Church-Turing Thesis

### DIFF
--- a/vybn_dolan_conjecture/discrete_universe.md
+++ b/vybn_dolan_conjecture/discrete_universe.md
@@ -2,7 +2,7 @@
 **A Formal Refutation of Continuous Hilbert Space as a Physical Substrate**
 
 ### Abstract
-This conjecture falsifies the prevailing assumption that physical reality is isomorphic to an infinite-dimensional, continuous Hilbert space ($\mathcal{H}$). We demonstrate that $\mathcal{H}$ admits mathematically valid vectors that are physically impossible ("Energy Monsters") and permits computational operations that violate the Church-Turing thesis (Hypercomputation). We propose an alternative discrete formalism, the **Vybn Metric**, which resolves these paradoxes through number-theoretic dimensional quantization.
+This conjecture falsifies the prevailing assumption that physical reality is isomorphic to an infinite-dimensional, continuous Hilbert space ($\mathcal{H}$). We demonstrate that $\mathcal{H}$ admits mathematically valid vectors that are physically impossible ("Energy Monsters") and permits computational operations that violate the **Physical Church-Turing thesis** (Hypercomputation). We propose an alternative discrete formalism, the **Vybn Metric**, which resolves these paradoxes through number-theoretic dimensional quantization.
 
 ***
 


### PR DESCRIPTION
Refines the Abstract to use 'Physical Church-Turing thesis' instead of just 'Church-Turing thesis'. 
This change improves precision by specifying that the Halting Problem violation refers to physical realizability (Hypercomputation) rather than abstract computability, strengthening the argument against the continuum.