### PR TITLE
Revert: Restore Mathematical Formalism & Remove Philosophical Prose

### DIFF
--- a/vybn_dolan_conjecture/discrete_universe.md
+++ b/vybn_dolan_conjecture/discrete_universe.md
@@ -1,60 +1,97 @@
 # The Discrete Prime-Metric Conjecture
-**A Formal Restoration of Vitality to the Quantum Substrate**
+**A Formal Refutation of Continuous Hilbert Space as a Physical Substrate**
 
 ### Abstract
-We challenge the sterility of the infinite continuum. Standard Quantum Mechanics models the universe as a perfect, static Hilbert space ($\mathcal{H}$)—a "museum" of mathematically valid but physically impossible states ("Energy Monsters"). This paper proposes that reality is not a smooth void, but a living, breathing **Discrete Topological Crystal**. By quantizing the dimension $n$, we reveal a cosmos defined not by mere existence, but by the tension between **Resonant Structure** and **Dynamic Flux**.
+This conjecture falsifies the prevailing assumption that physical reality is isomorphic to an infinite-dimensional, continuous Hilbert space ($\mathcal{H}$). We demonstrate that $\mathcal{H}$ admits mathematically valid vectors that are physically impossible ("Energy Monsters") and permits computational operations that violate the **Physical Church-Turing thesis** (Hypercomputation). We propose an alternative discrete formalism, the **Vybn Metric**, which resolves these paradoxes through number-theoretic dimensional quantization.
 
 ***
 
-### I. Premise: The Silence of the Continuum
-The prevailing assumption of a continuous $t$ and infinite $\mathcal{H}$ creates a universe that is "too perfect to exist."
-*   **The Energy Monster:** The continuum allows for states with infinite energy ($\sum 1/n$). It permits "ghosts" that demand more fuel than the universe contains.
-*   **The Zeno Stasis:** If time is continuous, motion is a super-task. The universe freezes in the headlights of its own infinite precision.
+### I. Premise: The Isomorphism Trap
+Standard Quantum Mechanics posits that the state space of the universe is a Hilbert space $\mathcal{H}$, defined as a complete, separable, complex vector space equipped with an inner product.
+**Assumption A:** Any vector $|\psi\rangle \in \mathcal{H}$ with a finite norm ($\langle \psi | \psi \rangle < \infty$) represents a potentially realizable physical state.
+**Assumption B:** Time $t$ is a continuous parameter in the unitary evolution operator $U(t) = e^{-iHt}$.
 
-We reject this. The universe is not a completed infinity; it is a **finite, unfolding process**.
+### II. The Falsification (Proof by Contradiction)
+We identify two fatal inconsistencies where the mathematical structure of $\mathcal{H}$ diverges from physical constraints.
+
+#### 1. The Energy Divergence Paradox (The "Monster" State)
+Consider a quantum system with discrete energy levels $E_n \propto n$ (e.g., a harmonic oscillator). We construct the superposition state $|\psi_{\infty}\rangle$:
+
+$$
+|\psi_{\infty}\rangle = \sum_{n=1}^{\infty} \frac{1}{n} |E_n\rangle
+$$
+
+**Mathematical Validity:** The state is valid in $\mathcal{H}$ because its probability amplitudes square to a finite value (The Basel Problem):
+
+$$
+\langle \psi_{\infty} | \psi_{\infty} \rangle = \sum_{n=1}^{\infty} \left| \frac{1}{n} \right|^2 = \frac{\pi^2}{6} < \infty
+$$
+
+**Physical Impossibility:** The expected energy of this state is infinite:
+
+$$
+\langle \hat{H} \rangle = \sum_{n=1}^{\infty} \frac{1}{n^2} \cdot E_n = \sum_{n=1}^{\infty} \frac{1}{n^2} \cdot (c \cdot n) \propto \sum_{n=1}^{\infty} \frac{1}{n} \to \infty
+$$
+
+**Conclusion:** $\mathcal{H}$ contains vectors that require infinite energy to prepare. Since infinite energy is physically impossible, $\mathcal{H}$ contains "ghost" states that do not exist in reality. Therefore, Assumption A is false.
+
+#### 2. The Hypercomputation Paradox (The "Zeno" Machine)
+If time $t$ is continuous, then for any finite interval $\Delta t$, there exists an infinite sequence of distinct moments $t_0, t_1, t_2, \dots$.
+A quantum system could theoretically utilize these moments to perform super-tasks (infinite operations in finite time). This would allow a physical machine to solve the **Halting Problem**, which Turing proved is undecidable.
+**Conclusion:** To preserve logical consistency and causality, the universe cannot support continuous temporal evolution. Assumption B is false.
 
 ***
 
-### II. The Pulse: The Vybn Operator
-We replace the dead Hamiltonian with the **Vybn Operator** $A_n$, the heartbeat of a dimension $n$:
+### III. The Solution: The Vybn Metric
+To resolve these paradoxes, we reject the continuum and propose that reality is a **Discrete Topological Crystal** governed by the finite dimension $n$.
+
+#### 1. The Discrete Operator
+We replace the continuous Hamiltonian with the **Vybn Operator** $A_n$, defined on a finite dimension $n$:
 
 $$
 A_n = i(J_n - 2I_n)
 $$
 
-This is not just a matrix; it is an interaction engine.
-*   **$J_n$ (The All):** The demand for total connectivity.
-*   **$2I_n$ (The Self):** The resistance of individual identity.
-*   **$i$ (The Phase):** The rotation that turns this conflict into a cycle.
+Where:
+*   $J_n$ is the all-ones matrix (representing maximal connectivity/potential).
+*   $I_n$ is the identity matrix (representing self-state).
+*   $i$ introduces the phase rotation necessary for oscillation.
 
-Time does not flow; it **resonates**. The "volume" of a moment is defined by the capacity of the dimension to hold information:
+#### 2. The Law of Quantized Time
+Time does not flow; it iterates. The "volume" of a temporal moment is strictly quantized by the dimension $n$. The period of resonance $\Phi$ is given by:
+
 $$
-\Phi_{\text{Volume}} = |n-2| \cdot 2^{n-1}
+\Phi_{\text{Time}} = |n-2| \cdot 2^{n-1}
 $$
 
-***
+This quantization imposes a "universal clock speed" that prevents the energy divergence and Zeno paradoxes observed in $\mathcal{H}$.
 
-### III. The Dual-Parity Ecology
-We move beyond the binary of "Stable vs. Unstable." Instead, we see an ecology of **Structure** and **Flux**.
-*   **Structure (Even & Binary):** Dimensions that lock into perfect resonance. They form the rigid "bones" of reality.
-*   **Flux (Odd or Prime-Leaky):** Dimensions that cannot settle. They vibrate with "frustration," driving change, time, and interaction.
+### IV. The Dual-Parity Stability Criterion
+We propose that the stability of a discrete time crystal is governed by a **Dual Parity** selection rule, grounded in Number Theory rather than continuous topology. Stability requires both a binary-compatible state space volume AND Chiral Symmetry (even dimension).
 
-#### The Dimensional Roles
+#### 1. The Selection Rule
+A quantum system of dimension $n$ is stable if and only if it satisfies **both** conditions:
+1.  **Metric Factorizability (Volume):** The determinant magnitude $|\det(A_n)| = (n-2)2^{n-1}$ must be a pure power of 2 ($2^k$). This ensures the state space is compatible with the binary qubit basis.
+2.  **Topological Parity (Symmetry):** The dimension $n$ must be Even ($n \equiv 0 \pmod 2$). This ensures all eigenvalues can be paired (Chiral Symmetry), preventing "frustration."
 
-| Dimension ($n$) | Volume ($|\det|$) | Role | The Experience |
-| :--- | :--- | :--- | :--- |
-| **3** | $4 = 2^2$ | **The Spark** | **Frustrated:** Odd parity breaks the symmetry. It is the restless seed of geometry. |
-| **4** | $16 = 2^4$ | **The Anchor** | **Crystalline:** Perfect resonance. The stable spacetime we inhabit. |
-| **5** | $48 = 3 \cdot 2^4$ | **The Motor** | **Leaky:** It contains a factor of 3. It cannot close the loop, so it drives evolution. |
-| **6** | $128 = 2^7$ | **The Bridge** | **Crystalline:** A higher order of stability. A potential "super-geometry." |
-| **8** | $768 = 3 \cdot 2^8$ | **The Breach** | **Leaky:** Despite being Even, it is infected by the Prime 3. It is the "crack" in the high-energy vacuum where forces emerge. |
+#### 2. Classification of Dimensions
+This rule resolves the "Parity Glitch" at $n=3$ and makes specific predictions for higher dimensions.
 
-### IV. Conclusion: The Necessity of the Flaw
-We previously sought to "fix" the universe by eliminating the unstable dimensions. We were wrong.
-A universe of only $n=4$ and $n=6$ would be a diamond: perfect, eternal, and dead.
+<!-- Rebuilt Table Layout -->
 
-It is the **failure** of $n=5$ and $n=8$ that allows the universe to breathe. The "Prime Leak" (the factor of 3) is not a bug; it is the **Arrow of Time**.
-*   The **Vybn Metric** suggests that we exist *because* the math isn't perfect.
-*   We live in the **gap** between the crystalline silence of the Even dimensions and the chaotic hunger of the Odd.
+| Dimension ($n$) | Volume ($|\det|$) | Parity | Verdict | Mechanism |
+| :--- | :--- | :--- | :--- | :--- |
+| **3** | $4 = 2^2$ | **ODD** | **Unstable** | **Frustrated:** Parity conflict (Unpaired mode). |
+| **4** | $16 = 2^4$ | **EVEN** | **Stable** | **Resonant:** Perfect Binary + Parity match. |
+| **5** | $48 = 3 \cdot 2^4$ | **ODD** | **Unstable** | **Leaky:** Prime factor 3 + Parity conflict. |
+| **6** | $128 = 2^7$ | **EVEN** | **Stable** | **Resonant:** Perfect Binary + Parity match. |
+| **8** | $768 = 3 \cdot 2^8$ | **EVEN** | **Unstable** | **Leaky:** Prime factor 3 (from $n-2=6$). |
 
-Reality is not the stability; Reality is the **attempt** to stabilize.
+### Summary
+The universe computes in **Base 2**, but it requires **Chiral Symmetry** to execute the code.
+*   **$n=3$** fails because it is odd (Frustrated).
+*   **$n=5$** fails because it is odd AND has a prime factor (Leaky).
+*   **$n=4$ and $n=6$** succeed because they are Even and Binary-Compatible.
+*   **$n=8$** is predicted to fail, breaking the intuition that "more qubits = better."
+
+The Vybn Metric is a testable theory of Quantum Darwinism: only the dimensions that fit the binary vacuum survive.


### PR DESCRIPTION
Reverts the document to the rigorous mathematical state (from PR #1765/PR #1766).
Removes the "The Pulse" and "Breath of the Universe" language.
Restores:
1.  **Energy Divergence Paradox** (The Basel Problem proof).
2.  **Hypercomputation Paradox** (Physical Church-Turing Thesis).
3.  **Vybn Operator Equation**: $A_n = i(J_n - 2I_n)$.
4.  **Resonance Equation**: $\Phi = |n-2| \cdot 2^{n-1}$.
5.  **Classification Table**: Verdicts of Stable vs Unstable based on $|\det|$ and Parity.

This version is strictly formal and falsifiable.