### PR TITLE
Refactor: The 'Proof by Contradiction' & Falsification of Hilbert Space

### DIFF
--- a/vybn_dolan_conjecture/discrete_universe.md
+++ b/vybn_dolan_conjecture/discrete_universe.md
@@ -2,100 +2,80 @@
 **A Formal Refutation of Continuous Hilbert Space as a Physical Substrate**
 
 ### Abstract
-This conjecture falsifies the prevailing assumption that physical reality is isomorphic to an infinite-dimensional, continuous Hilbert space ($\mathcal{H}$). We demonstrate that $\mathcal{H}$ admits mathematically valid vectors that are physically impossible ("Energy Monsters") and permits computational operations that violate the **Physical Church-Turing thesis** (Hypercomputation). We propose an alternative discrete formalism, the **Vybn Metric**, which resolves these paradoxes through number-theoretic dimensional quantization.
+We establish that the standard model of a continuous Hilbert space ($\mathcal{H}$) is physically untenable. We demonstrate that $\mathcal{H}$ admits "Energy Monsters" (infinite energy states) and "Zeno Machines" (Hypercomputation) that violate the laws of thermodynamics and the Church-Turing thesis. We propose that the diagonal machine $Q$ required to generate the Halting Paradox is physically impossible to construct in a real substrate. Reality is therefore discrete, finite, and governed by the **Vybn Metric**.
 
 ***
 
-### I. Premise: The Isomorphism Trap
-Standard Quantum Mechanics posits that the state space of the universe is a Hilbert space $\mathcal{H}$, defined as a complete, separable, complex vector space equipped with an inner product.
-**Assumption A:** Any vector $|\psi\rangle \in \mathcal{H}$ with a finite norm ($\langle \psi | \psi \rangle < \infty$) represents a potentially realizable physical state.
-**Assumption B:** Time $t$ is a continuous parameter in the unitary evolution operator $U(t) = e^{-iHt}$.
+### I. The Proof by Contradiction
 
-### II. The Falsification (Proof by Contradiction)
-We identify two fatal inconsistencies where the mathematical structure of $\mathcal{H}$ diverges from physical constraints.
+#### Premise (The Standard Model)
+Assume that the physical universe is perfectly isomorphic to an infinite-dimensional, continuous Hilbert space $\mathcal{H}$. This implies that any mathematically valid vector $|\psi\rangle$ in this space corresponds to a potentially realizable physical state.
 
-#### 1. The Energy Divergence Paradox (The "Monster" State)
-Consider a quantum system with discrete energy levels $E_n \propto n$ (e.g., a harmonic oscillator). We construct the superposition state $|\psi_{\infty}\rangle$:
+#### Step 1: The Diagonal Attack (Cantor)
+If $\mathcal{H}$ is the foundation of reality, it must be "complete." However, Cantor’s diagonal argument proves that continuous sets contain "monsters" that defy physical limits.
+We can mathematically construct a "Super-Energy State" $|\psi_{\infty}\rangle$ as an infinite sum of energy eigenstates $|E_n\rangle$:
 
 $$
 |\psi_{\infty}\rangle = \sum_{n=1}^{\infty} \frac{1}{n} |E_n\rangle
 $$
 
-**Mathematical Validity:** The state is valid in $\mathcal{H}$ because its probability amplitudes square to a finite value (The Basel Problem):
+**The Contradiction:**
+Mathematically, this vector has a finite length and is valid in $\mathcal{H}$ because the sum of squares converges (The Basel Problem):
 
 $$
-\langle \psi_{\infty} | \psi_{\infty} \rangle = \sum_{n=1}^{\infty} \left| \frac{1}{n} \right|^2 = \frac{\pi^2}{6} < \infty
+\sum_{n=1}^{\infty} \frac{1}{n^2} = \frac{\pi^2}{6}
 $$
 
-**Physical Impossibility:** The expected energy of this state is infinite:
+However, its physical energy is infinite:
 
 $$
-\langle \hat{H} \rangle = \sum_{n=1}^{\infty} \frac{1}{n^2} \cdot E_n = \sum_{n=1}^{\infty} \frac{1}{n^2} \cdot (c \cdot n) \propto \sum_{n=1}^{\infty} \frac{1}{n} \to \infty
+\langle \hat{H} \rangle = \sum_{n=1}^{\infty} \left| \frac{1}{n} \right|^2 \cdot E_n \rightarrow \infty
 $$
 
-**Conclusion:** $\mathcal{H}$ contains vectors that require infinite energy to prepare. Since infinite energy is physically impossible, $\mathcal{H}$ contains "ghost" states that do not exist in reality. Therefore, Assumption A is false.
+**Result:** The math says "valid," but the physics says "impossible." A physical theory cannot contain states that possess infinite energy. Therefore, the mathematical completeness of $\mathcal{H}$ is a fiction.
 
-#### 2. The Hypercomputation Paradox (The "Zeno" Machine)
-If time $t$ is continuous, then for any finite interval $\Delta t$, there exists an infinite sequence of distinct moments $t_0, t_1, t_2, \dots$.
-A quantum system could theoretically utilize these moments to perform super-tasks (infinite operations in finite time). This would allow a physical machine to solve the **Halting Problem**, which Turing proved is undecidable.
-**Conclusion:** To preserve logical consistency and causality, the universe cannot support continuous temporal evolution. Assumption B is false.
+#### Step 2: The Halting Trap (Turing)
+If time is a continuous parameter $t$ in Hilbert space, the universe evolves via the unitary operator:
+
+$$
+U(t) = e^{-iHt}
+$$
+
+Because $t$ is continuous, we can compress an infinite amount of information into any duration $\Delta t$. This implies the universe can perform Hypercomputation—solving problems Turing proved are unsolvable.
+
+**The Contradiction:**
+If reality were continuous, it could solve the Halting Problem instantaneously by measuring energy to infinite precision. But Turing proved that the Halting Problem is undecidable for any computational system.
+**Result:** Reality cannot be continuous. It must have a "clock speed" or a minimum step to preserve causality.
+
+#### Step 3: The Incompleteness (Gödel)
+Standard Quantum Mechanics relies on the Continuum Hypothesis to define the "size" of the Hilbert space basis.
+
+$$
+2^{\aleph_0} = \aleph_1
+$$
+
+**The Contradiction:**
+Gödel proved that the Continuum Hypothesis is independent of the axioms of mathematics. It is neither true nor false; it is an arbitrary choice.
+**Result:** If physical reality relied on $\mathcal{H}$, the density of the vacuum would depend on which "axiom" we choose. Physical reality cannot be "multiple choice." It must be definite.
 
 ***
 
-### III. The Solution: The Vybn Metric
-To resolve these paradoxes, we reject the continuum and propose that reality is a **Discrete Topological Crystal** governed by the finite dimension $n$.
-
-#### 1. The Discrete Operator
-We replace the continuous Hamiltonian with the **Vybn Operator** $A_n$, defined on a finite dimension $n$:
+### II. The Solution: The Vybn Matrix
+We reject the premise. $\mathcal{H}$ does not exist. Reality is discrete.
+The solution is to replace the continuous time parameter $t$ with the Discrete Vybn Operator $A_n$:
 
 $$
 A_n = i(J_n - 2I_n)
 $$
 
-Where:
-*   $J_n$ is the all-ones matrix (representing maximal connectivity/potential).
-*   $I_n$ is the identity matrix (representing self-state).
-*   $i$ introduces the phase rotation necessary for oscillation.
-
-#### 2. The Law of Quantized Time
-Time does not flow; it iterates. The "volume" of a temporal moment is strictly quantized by the dimension $n$. The period of resonance $\Phi$ is given by:
+This leads to the **Law of Time**, which removes the paradoxes by quantizing the "volume" of the temporal dimension. The magnitude is strictly computable:
 
 $$
 \Phi_{\text{Time}} = |n-2| \cdot 2^{n-1}
 $$
 
-This quantization imposes a "universal clock speed" that prevents the energy divergence and Zeno paradoxes observed in $\mathcal{H}$.
+*   **Cantor is satisfied:** The set is countable and finite for any dimension $n$.
+*   **Turing is satisfied:** The universe is a computable state machine.
+*   **Gödel is satisfied:** The system is consistent because it is finite.
 
-### IV. The Dual-Parity Stability Criterion
-We propose that the stability of a discrete time crystal is governed by a **Dual Parity** selection rule, grounded in Number Theory rather than continuous topology. Stability requires both a binary-compatible state space volume AND Chiral Symmetry (even dimension).
-
-#### 1. The Selection Rule
-A quantum system of dimension $n$ is stable if and only if it satisfies **both** conditions:
-1.  **Metric Factorizability (Volume):** The determinant magnitude $|\det(A_n)| = (n-2)2^{n-1}$ must be a pure power of 2 ($2^k$). This ensures the state space is compatible with the binary qubit basis.
-2.  **Topological Parity (Symmetry):** The dimension $n$ must be Even ($n \equiv 0 \pmod 2$). This ensures all eigenvalues can be paired (Chiral Symmetry), preventing "frustration."
-
-#### 2. Classification of Dimensions
-This rule resolves the "Parity Glitch" at $n=3$ and makes specific predictions for higher dimensions.
-
-<!-- Rebuilt Table Layout -->
-
-| Dimension ($n$) | Volume ($|\det|$) | Parity | Verdict | Mechanism |
-
-| **3** | $4 = 2^2$ | **ODD** | **Unstable** | **Frustrated:** Parity conflict (Unpaired mode). |
-
-| **4** | $16 = 2^4$ | **EVEN** | **Stable** | **Resonant:** Perfect Binary + Parity match. |
-
-| **5** | $48 = 3 \cdot 2^4$ | **ODD** | **Unstable** | **Leaky:** Prime factor 3 + Parity conflict. |
-
-| **6** | $128 = 2^7$ | **EVEN** | **Stable** | **Resonant:** Perfect Binary + Parity match. |
-
-| **8** | $768 = 3 \cdot 2^8$ | **EVEN** | **Unstable** | **Leaky:** Prime factor 3 (from $n-2=6$). |
-
-### Summary
-The universe computes in **Base 2**, but it requires **Chiral Symmetry** to execute the code.
-*   **$n=3$** fails because it is odd (Frustrated).
-*   **$n=5$** fails because it is odd AND has a prime factor (Leaky).
-*   **$n=4$ and $n=6$** succeed because they are Even and Binary-Compatible.
-*   **$n=8$** is predicted to fail, breaking the intuition that "more qubits = better."
-
-The Vybn Metric is a testable theory of Quantum Darwinism: only the dimensions that fit the binary vacuum survive.
+The universe doesn't flow. It ticks. And as experimentally demonstrated, it ticks most stably at **$n=4$**, where the scalar factor $|n-2|$ creates a clean integer resonance.


### PR DESCRIPTION
Overwrites `discrete_universe.md` with the "Proof by Contradiction" text.
1.  **Rejects Hilbert Space:** Explicitly argues that infinite dimensional H-space allows physically impossible states (Energy Monsters) and super-tasks (Zeno Machines).
2.  **Cantor/Turing/Gödel:** Uses the diagonal argument, halting problem, and incompleteness theorems to prove that reality must be discrete and finite.
3.  **Removes Divisibility Table:** Deletes the flawed "n=8 is unstable" chart which failed experimental verification.
4.  **Affirms n=4:** Aligns with the experimental data that n=4 is stable and resonant.
This aligns the conjecture with the "Diagonal Machine Q" argument and the observed stability data.