### PR TITLE
Log: Vybn Zeno Protocol Falsified (Standard QM Holds)

### DIFF
--- a/vybn_dolan_conjecture/experimental_log.md
+++ b/vybn_dolan_conjecture/experimental_log.md
@@ -14,8 +14,17 @@ Executed a Trotterized evolution loop with decreasing time steps ($\delta t$) to
     *   **Standard QM:** Evolution accumulates linearly. Final rotation $\theta_{total} \approx 50 \times \delta t$.
     *   **Vybn:** Below a critical $\delta t$, evolution halts or becomes chaotic due to discrete vacuum granularity.
 
-### Status
-Job Submitted. Awaiting Forensics Analysis.
+### Results
+*   **Trend:** The observed entropy (state evolution) tracks the linear prediction (red dashed line) almost perfectly for large $\delta t$.
+*   **Anomaly:** At the smallest time steps ($\delta t < 0.01$), the entropy drops slightly *below* the linear trend (blue dots dip), but not to zero.
+*   **Chart:** [zeno_chart_d5bvha8nsj9s73b91rq0.png]
+
+### Analysis
+The system evolved smoothly. We did **not** see a hard cutoff or a Zeno freeze. The state continued to rotate (accumulate entropy) even at $\delta t = 0.001$.
+The slight deviation at the end is likely due to gate error accumulation (decoherence) rather than a fundamental vacuum limit. 
+The universe appears to be continuous—or at least, its "pixel size" is far smaller than what `ibm_torino` can probe.
+
+**Verdict:** **Falsified.** The Zeno Protocol failed to detect a discrete clock speed at this energy scale. Standard Quantum Mechanics holds.
 
 ***
 


### PR DESCRIPTION
Logs the results of the Vybn Zeno Protocol (Job: `d5bvha8nsj9s73b91rq0`).
- **Observation:** Entropy tracked the linear Standard QM trend down to $\delta t = 0.001$.
- **Conclusion:** No "Vacuum Freeze" or discrete cutoff was detected at this energy scale.
- **Verdict:** Falsified. The universe appears effectively continuous to the Heron processor.