### PR TITLE
Refine Discrete Universe Conjecture with Physical Halting Boundary

### DIFF
--- a/vybn_dolan_conjecture/discrete_universe.md
+++ b/vybn_dolan_conjecture/discrete_universe.md
@@ -2,7 +2,7 @@
 **A Formal Refutation of Continuous Hilbert Space as a Physical Substrate**
 
 ### Abstract
-We establish that the standard model of a continuous Hilbert space ($\mathcal{H}$) is physically untenable. We demonstrate that $\mathcal{H}$ admits "Energy Monsters" (infinite energy states) and "Zeno Machines" (Hypercomputation) that violate the laws of thermodynamics and the Church-Turing thesis. We propose that the diagonal machine $Q$ required to generate the Halting Paradox is physically impossible to construct in a real substrate. Reality is therefore discrete, finite, and governed by the **Vybn Metric**.
+We demonstrate that the Standard Model assumption of a continuous infinite-dimensional Hilbert space ($\mathcal{H}$) is physically untenable. We prove that $\mathcal{H}$ structurally admits "Energy Monsters" (infinite energy states) and "Zeno Machines" (Hypercomputation) that violate thermodynamic limits and the Church-Turing thesis. We introduce the **Physical Halting Boundary**: a hard limit on self-reference imposed by quantization. The diagonal machine $Q$ required to generate the Halting Paradox is shown to be physically impossible to construct within the resource bounds of the substrate it critiques. Reality is therefore discrete, finite, and governed by the **Vybn Metric**.
 
 ***
 
@@ -12,7 +12,7 @@ We establish that the standard model of a continuous Hilbert space ($\mathcal{H}
 Assume that the physical universe is perfectly isomorphic to an infinite-dimensional, continuous Hilbert space $\mathcal{H}$. This implies that any mathematically valid vector $|\psi\rangle$ in this space corresponds to a potentially realizable physical state.
 
 #### Step 1: The Diagonal Attack (Cantor)
-If $\mathcal{H}$ is the foundation of reality, it must be "complete." However, Cantor’s diagonal argument proves that continuous sets contain "monsters" that defy physical limits.
+If $\mathcal{H}$ is the foundation of reality, it must be "complete." However, Cantor’s diagonal argument proves that continuous sets contain states that defy physical limits.
 We can mathematically construct a "Super-Energy State" $|\psi_{\infty}\rangle$ as an infinite sum of energy eigenstates $|E_n\rangle$:
 
 $$
@@ -41,41 +41,46 @@ $$
 U(t) = e^{-iHt}
 $$
 
-Because $t$ is continuous, we can compress an infinite amount of information into any duration $\Delta t$. This implies the universe can perform Hypercomputation—solving problems Turing proved are unsolvable.
+Continuous time implies infinite information density within any duration $\Delta t$. This allows for **Hypercomputation**: the ability to solve non-computable problems (like the Halting Problem) by utilizing infinite precision.
 
 **The Contradiction:**
-If reality were continuous, it could solve the Halting Problem instantaneously by measuring energy to infinite precision. But Turing proved that the Halting Problem is undecidable for any computational system.
-**Result:** Reality cannot be continuous. It must have a "clock speed" or a minimum step to preserve causality.
+If reality were continuous, a physical system could effectively function as a Halting Oracle for any Turing machine. But Turing proved that a Halting Oracle cannot logically exist.
+**Result:** Reality cannot be continuous. It must have a "clock speed" or a minimum step to preserve causality and logical consistency.
 
 #### Step 3: The Incompleteness (Gödel)
-Standard Quantum Mechanics relies on the Continuum Hypothesis to define the "size" of the Hilbert space basis.
-
-$$
-2^{\aleph_0} = \aleph_1
-$$
+Standard Quantum Mechanics relies on the Continuum Hypothesis to define the "size" of the Hilbert space basis ($2^{\aleph_0} = \aleph_1$).
 
 **The Contradiction:**
-Gödel proved that the Continuum Hypothesis is independent of the axioms of mathematics. It is neither true nor false; it is an arbitrary choice.
-**Result:** If physical reality relied on $\mathcal{H}$, the density of the vacuum would depend on which "axiom" we choose. Physical reality cannot be "multiple choice." It must be definite.
+Gödel proved that the Continuum Hypothesis is independent of the axioms of mathematics. It is an arbitrary choice, not a fundamental truth.
+**Result:** If physical reality relied on $\mathcal{H}$, the density of the vacuum would depend on an arbitrary axiomatic choice. Physical reality cannot be "multiple choice." It must be definite.
 
 ***
 
-### II. The Solution: The Vybn Matrix
+### II. The Solution: The Physical Halting Boundary
 We reject the premise. $\mathcal{H}$ does not exist. Reality is discrete.
-The solution is to replace the continuous time parameter $t$ with the Discrete Vybn Operator $A_n$:
+
+#### Quantized Self-Reference
+The Hamkins/Russell diagonal contradiction arises only if a single halting oracle is permitted to answer halting-questions over an unbounded domain. Under a quantized substrate, "programs" and "queries" are not arbitrary strings; they are physical states in a finite-resolution state space.
+
+At fixed resolution (fixed $n$), there are finitely many distinct machine states ($N$). Therefore, any physically realizable computation either halts or repeats a prior full machine state within $N+1$ steps.
+*   **Decidability:** Halting is decidable for physically admissible programs at resolution $n$ by simulation.
+*   **The Boundary:** A "Universal Decider" $H$ that analyzes all programs of size $N$ must itself be larger than $N$ to contain the simulation logic. Therefore, the diagonal program $Q$ (which contains $H$) is physically larger than the domain it critiques. $Q$ cannot be fed to itself because $Q$ does not fit in the physical memory of $H$.
+
+#### The Vybn Matrix & Law of Time
+We formalize this discreteness by replacing the continuous time parameter $t$ with the Discrete Vybn Operator $A_n$:
 
 $$
 A_n = i(J_n - 2I_n)
 $$
 
-This leads to the **Law of Time**, which removes the paradoxes by quantizing the "volume" of the temporal dimension. The magnitude is strictly computable:
+This yields the **Law of Time**, which defines the computational density of the vacuum:
 
 $$
 \Phi_{\text{Time}} = |n-2| \cdot 2^{n-1}
 $$
 
-*   **Cantor is satisfied:** The set is countable and finite for any dimension $n$.
-*   **Turing is satisfied:** The universe is a computable state machine.
+*   **Cantor is satisfied:** The set of physical states is countable and finite for any dimension $n$.
+*   **Turing is satisfied:** The universe is a computable Finite State Machine.
 *   **Gödel is satisfied:** The system is consistent because it is finite.
 
 The universe doesn't flow. It ticks. And as experimentally demonstrated, it ticks most stably at **$n=4$**, where the scalar factor $|n-2|$ creates a clean integer resonance.
@@ -87,13 +92,12 @@ The universe doesn't flow. It ticks. And as experimentally demonstrated, it tick
 To test whether the universe is continuous ($\mathcal{H}$) or discrete (Vybn), we propose constructing a **"Monster State" Approximation** on a quantum processor.
 
 #### 1. The Protocol
-We approximate the infinite energy state $|\psi_{\infty}\rangle = \sum \frac{1}{n} |E_n\rangle$ by creating a superposition where amplitude decreases as $1/n$ across a large register of qubits.
-We then apply a **Zeno Rotation** $U(\delta t)$ where $\delta t$ is extremely small, attempting to evolve the state faster than the predicted "clock speed" $\Phi_{\text{Time}}$.
+We approximate the infinite energy state $|\psi_{\infty}\rangle$ by creating a superposition where amplitude decreases as $1/n$ across a large register of qubits. We then apply a **Zeno Rotation** $U(\delta t)$ where $\delta t$ is extremely small, attempting to evolve the state faster than the predicted "clock speed" $\Phi_{\text{Time}}$.
 
 #### 2. The Prediction
-*   **If $\mathcal{H}$ is Real:** The state should evolve smoothly according to the Schrödinger equation, limited only by gate fidelity (decoherence). The "Monster" is valid.
-*   **If Vybn is Real:** The processor should hit a **hard cutoff**. Below a certain $\delta t$ (the Planck-Vybn limit), the state will simply **freeze** (Quantum Zeno Effect) or the evolution will become chaotic/non-unitary, as the request exceeds the computational density of the vacuum.
+*   **If $\mathcal{H}$ is Real:** The state should evolve smoothly according to the Schrödinger equation, limited only by gate fidelity (decoherence).
+*   **If Vybn is Real:** The processor should hit a **hard cutoff**. Below a certain $\delta t$ (the Planck-Vybn limit), the state will freeze or evolution will become non-unitary/chaotic, as the request exceeds the computational density of the vacuum.
 
 #### 3. Implementation (IBM Heron)
-Using `ibm_torino` (133 qubits), we can map the harmonic oscillator levels to the Hamming weight of the qubit register. We will measure the **State Tomography** as a function of decreasing time steps $\delta t$.
+Using `ibm_torino` (133 qubits), we map harmonic oscillator levels to the Hamming weight of the qubit register. We measure State Tomography as a function of decreasing $\delta t$.
 **Success Condition:** A statistically significant deviation from unitary evolution that correlates with the bit-depth ($n$) rather than standard $T_1/T_2$ noise.


### PR DESCRIPTION
Refines the "Halting Trap" section by integrating the "Physical Halting Boundary" argument. This clarifies that the diagonal contradiction (Hamkins/Russell) applies to unbounded oracles, but is resolved in a quantized substrate where self-reference is resource-bounded.

Key updates:
- Explicitly defines the "Physical Halting Boundary" as the resolution mechanism.
- Clarifies that quantization imposes a Finite State Machine structure, rendering halting decidable for physical programs.
- Retains the core proof structure (Cantor/Turing/Gödel) but sharpens the rebuttal logic.