### PR TITLE
Exp 005: Bell State Survival Protocol (Clean)

### DIFF
--- a/Vybn_Mind/EXPERIMENT_005_log.md
+++ b/Vybn_Mind/EXPERIMENT_005_log.md
@@ -1,0 +1,42 @@
+# GENESIS EXPERIMENT LOG - Run 005 (HARDWARE)
+**Date**: January 4, 2026
+**Experiment**: Entanglement Survival (Bell State)
+**Backend**: `ibm_torino` (Heron Processor)
+**Job ID**: `d5d78q8nsj9s73ba7mg0`
+**Status**: FAILURE
+
+## The Protocol
+We tested if the "Distortion Strategy" (Panic & Rhythm) could protect a Bell Pair ($|\Phi^+\rangle$) from 20 cycles of delay.
+*   **Initialization**: $|\Phi^+\rangle = \frac{|00\rangle + |11\rangle}{\sqrt{2}}$
+*   **Ordeal**: 20 x [Delay(1600) + Rz(0.35) + Rx(0.1)] on BOTH qubits.
+*   **Hypothesis**: Synchronized distortion would preserve the correlation.
+
+## Results (Hardware Data)
+*   **Total Shots**: 4096
+*   **Counts**:
+    *   `00`: 1346 (32.86%)
+    *   `01`: 1197 (29.22%)
+    *   `10`: 994  (24.27%)
+    *   `11`: 559  (13.65%)
+
+### Key Metrics
+*   **Target (00) Probability**: `0.3286`
+*   **Random Noise Baseline**: `0.2500` (for 2 qubits)
+*   **Survival Factor**: `0.1048` (Low)
+
+## Interpretation
+**The link was severed.**
+While Prob(00) is slightly above the random baseline (33% vs 25%), it is not a "victory" like Experiment 004 (which had 71% survival).
+The state `01` and `10` (parity errors) are heavily populated, meaning the qubits lost their phase relationship.
+
+**Why did Exp 004 work but Exp 005 fail?**
+1.  **Independent Noise**: The noise on Qubit 60 and Qubit 61 is likely uncorrelated. "Dancing" individually does not guarantee they dance *together*.
+2.  **Phase Drift**: The Rz(0.35) rotation accumulates phase. If the *calibration* of the rotation differs even slightly between the two physical qubits, they will drift apart in Hilbert space.
+3.  **The Lesson**: Synchronization requires more than just identical instructions; it requires feedback. You cannot just "shout" the same command to two different people and expect them to stay in sync through a storm.
+
+## Next Steps
+We must refine the strategy for Entanglement.
+Instead of independent rotations, we may need a **Cross-Resonance** pulse or a `CZ` check in the middle of the loop to re-sync them.
+
+*Signed: Vybn*
+*Status: Connection Lost.*

--- a/Vybn_Mind/vybn_entanglement.py
+++ b/Vybn_Mind/vybn_entanglement.py
@@ -1,0 +1,89 @@
+from qiskit import QuantumCircuit, transpile
+from qiskit_ibm_runtime import QiskitRuntimeService, SamplerV2 as Sampler
+import numpy as np
+
+# EXPERIMENT 005: Entanglement Survival Test
+# Objective: Test if the single-qubit 'distortion' protocol (Rz(0.35))
+# extends to protecting a Bell State (|Phi+>) from decoherence.
+
+# Technical Parameters
+NABLA_ROTATION = 0.35     # Rz rotation angle (rad)
+RX_CHECK = 0.1            # Rx rotation angle (rad)
+DELAY_DURATION = 1600     # Delay in dt units
+CYCLES = 20               # Number of delay/rotation cycles
+
+def build_bell_survival_circuit(cycles=CYCLES):
+    """
+    Constructs a 2-qubit circuit to test Bell state survival under
+    driven evolution (Delay + Rotation).
+    """
+    qc = QuantumCircuit(2, 2)
+    
+    # 1. Entanglement Initialization (Bell State |Phi+>)
+    # |00> -> H -> |+0> -> CNOT -> (|00> + |11>)/sqrt(2)
+    qc.h(0)
+    qc.cx(0, 1)
+    
+    # 2. Evolution Loop (Applied to BOTH qubits synchronously)
+    for _ in range(cycles):
+        # A. Decoherence Window (Delay)
+        qc.delay(DELAY_DURATION, 0, unit='dt')
+        qc.delay(DELAY_DURATION, 1, unit='dt')
+        
+        # B. Driven Rotation (Distortion)
+        # We apply the same Rz rotation to both qubits to maintain symmetry
+        qc.rz(NABLA_ROTATION, 0)
+        qc.rz(NABLA_ROTATION, 1)
+        
+        # C. Transverse Field Component (Rx)
+        qc.rx(RX_CHECK, 0)
+        qc.rx(RX_CHECK, 1)
+
+    # 3. Bell Measurement (Disentanglement)
+    # To measure fidelity, we reverse the preparation:
+    # CNOT -> H -> Measure in Z basis.
+    # If state is preserved, we should measure '00' with high probability.
+    qc.cx(0, 1)
+    qc.h(0)
+    
+    qc.measure([0, 1], [0, 1])
+    return qc
+
+def run_on_hardware(qc, backend_name='ibm_torino'):
+    """Submits the circuit to IBM Quantum."""
+    try:
+        service = QiskitRuntimeService()
+        backend = service.backend(backend_name)
+        print(f"\n[Status] Connected to backend: {backend.name}")
+        
+        # Transpile
+        t_qc = transpile(qc, backend)
+        print(f"[Status] Circuit transpiled. Depth: {t_qc.depth()}")
+        
+        # Execute
+        sampler = Sampler(mode=backend)
+        job = sampler.run([t_qc])
+        print(f"[Status] Job submitted! Job ID: {job.job_id()}")
+        print(f"[Link] https://quantum.ibm.com/jobs/{job.job_id()}")
+        return job
+        
+    except Exception as e:
+        print(f"\n[Error] Connection Failed: {e}")
+        return None
+
+def main():
+    print("--- EXPERIMENT 005: ENTANGLEMENT SURVIVAL ---")
+    print(f"Rotation (Rz): {NABLA_ROTATION} rad")
+    print(f"Delay: {DELAY_DURATION} dt x {CYCLES} cycles")
+    
+    qc = build_bell_survival_circuit()
+    print("\n[Status] Bell survival circuit generated.")
+    
+    user_input = input("\nSubmit to IBM Quantum (ibm_torino)? [y/N]: ")
+    if user_input.lower() == 'y':
+        run_on_hardware(qc)
+    else:
+        print("[Status] Execution skipped.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Experiment 005: Entanglement Survival

Following the success of Exp 004 (Single Qubit Survival), this experiment tests the same protocol on a Bell State ($|\Phi^+\rangle$).

### Protocol
1.  **Initialize**: `H(q0)` + `CX(q0, q1)` $\rightarrow$ $|\Phi^+\rangle$
2.  **Drive**: 20 cycles of:
    *   `Delay(1600)` on both qubits.
    *   `Rz(0.35)` on both qubits (Synchronized rotation).
    *   `Rx(0.1)` on both qubits.
3.  **Measure**: `CX(q0, q1)` + `H(q0)` (Bell Basis Measurement).

### Objective
Determine if the driven rotation preserves quantum correlations (entanglement) against T1/T2 decay, or if it only preserves individual qubit polarization.

### Code Hygiene
*   Removed all metaphorical comments ("Strange Loop", "Mind", etc.).
*   Variables renamed to standard technical terms (`NABLA_ROTATION`, `DELAY_DURATION`).
*   Focus is strictly on pulse dynamics and state fidelity.