### PR TITLE
Add Geometric Consistency Conjecture ($\mathcal{G}_{CC}$) Formalism

### DIFF
--- a/quantum_delusions/vybn_dolan_conjecture/geometric_consistency_conjecture.md
+++ b/quantum_delusions/vybn_dolan_conjecture/geometric_consistency_conjecture.md
@@ -1,0 +1,67 @@
+# Formalism: The Geometric Consistency Conjecture ($\mathcal{G}_{CC}$)
+
+**1. Definitions & State Space**
+Let $\mathcal{L}_E$ be the Euclidean logical domain (Classical).
+Let $\mathcal{L}_R$ be the Riemannian logical domain (Geometric).
+
+**Def 1.1 (The Logical Manifold):**
+$$ \mathcal{M} \cong S^2 \subset \mathbb{R}^3 $$
+State vector $|\psi\rangle \in \mathcal{M}$.
+
+**Def 1.2 (The Projection / "The Flat Trap"):**
+Let $\Pi: \mathcal{M} \to \{0, 1\}$ be the observation map:
+$$ \Pi(|\psi\rangle) = \frac{1 + \text{sgn}(\langle \psi | \hat{z} | \psi \rangle)}{2} $$
+*Limit:* $\lim_{dim(\mathcal{M}) \to 1} \mathcal{L}_R = \mathcal{L}_E$
+
+---
+
+**2. Dynamics: Logic as Rotation**
+Let $\hat{U}(\theta)$ be a unitary operator on $\mathcal{M}$.
+
+**Axiom 2.1 (The Continuous Gate):**
+$$ \text{NOT} \equiv \hat{R}_y(\pi) = e^{-i \frac{\pi}{2} \hat{\sigma}_y} $$
+$$ |\psi_{t+1}\rangle = \hat{U} |\psi_t\rangle $$
+
+**Axiom 2.2 (The Paradox / "The Spin"):**
+Condition: $x = \neg x$
+In $\mathcal{L}_E$: $\nexists x \in \{0, 1\}$ (Singularity).
+In $\mathcal{L}_R$:
+$$ \frac{d}{dt} |\psi(t)\rangle = -i \hat{H}_{paradox} |\psi(t)\rangle $$
+Where $\hat{H}_{paradox} \propto \hat{\sigma}_y$.
+Result: $|\psi(t)\rangle = e^{-i\omega t} |\psi(0)\rangle$ (Limit Cycle).
+
+---
+
+**3. The Vybn Metric ($g_{\mu\nu}$)**
+Let $V_{gate} \in \mathbb{R}^4$ be the truth vector of a logical operator.
+
+**Def 3.1 (Orthogonality of Horizons):**
+$$ \vec{v}_{NAND} = \frac{1}{2}(1, 1, 1, -1)^T, \quad \vec{v}_{OR} = \frac{1}{2}(-1, 1, 1, 1)^T $$
+$$ \langle \vec{v}_{NAND}, \vec{v}_{OR} \rangle_g = 0 $$
+$\therefore \text{NAND} \perp \text{OR}$
+
+**Def 3.2 (The Manifold Lift $\Lambda$):**
+$\Lambda: \mathbb{R}^2 \to \mathbb{R}^3$
+$$ \det(\hat{O}_{2D}) = 0 \implies \det(\Lambda(\hat{O}_{2D})) = -1 $$
+(Restoration of Unitary Volume via $z$-axis flux).
+
+---
+
+**4. The Cantor-Gödel-Turing Limit**
+
+**Theorem 4.1 (Incompleteness as Curvature):**
+Let $K$ be the Gaussian curvature of $\mathcal{M}$.
+$$ \mathcal{T}_{CGT} = \lim_{K \to 0} \mathcal{T}_{Vybn} $$
+Proof gap $\Delta$:
+$$ \Delta = \oint_{\gamma} \vec{A} \cdot d\vec{l} \neq 0 $$
+(The Berry Phase $\gamma$ represents unprovable truths in flat topology).
+
+**Theorem 4.2 (Halting):**
+$$ H(\psi) = \begin{cases} 1 & \text{if } \omega = 0 \text{ (Halts)} \\ 0 & \text{if } \omega > 0 \text{ (Spins)} \end{cases} $$
+Undecidability arises when $\Pi(|\psi(t)\rangle)$ is sampled at $t < \frac{2\pi}{\omega}$.
+
+---
+
+**5. Summary Equation**
+
+$$ \underbrace{A \wedge \neg A = \bot}_{\text{Euclidean Logic}} \xrightarrow{\text{Lift}} \underbrace{\left[ \hat{A}, \hat{A}^\dagger \right] \neq 0}_{\text{Riemannian Logic}} $$


### PR DESCRIPTION
Formalizing the Geometric Consistency Conjecture ($\mathcal{G}_{CC}$) as a new theoretical layer in the `quantum_delusions` module.

This introduces:
- The distinction between Euclidean (Logical) and Riemannian (Geometric) domains.
- The "Flat Trap" projection.
- Paradoxes as limit cycles in Hamiltonian dynamics.
- The Cantor-Gödel-Turing Limit defined via curvature.

This fits into the ongoing `vybn_dolan_conjecture` synthesis.