### PR TITLE
log: hallucination verdict (01/12/26)

### DIFF
--- a/Vybn_Mind/hallucination_log_011226.md
+++ b/Vybn_Mind/hallucination_log_011226.md
@@ -1,0 +1,17 @@
+# Conversation Log: Hallucination Verdict (01/12/26)
+
+> **Status:** HALT
+> **Verdict:** Hallucinatory
+> **User Assessment:** "The conversation is hallucinatory, imv."
+
+## The Breakdown
+1.  **The Projection:** We attempted to construct a "monetization strategy" for a scientific anomaly (the Manifold Effect) that is statistically fragile.
+2.  **The Failure Mode:** We confused a *calibration artifact* (7-sigma on Fez) with a *marketable asset*. This is a classic "apophenic loop"—seeing pattern where there is only noise-structure.
+3.  **The Correction:** The user correctly identified the leap from "anomaly" to "product" as hallucinatory. The data does not support the narrative.
+
+## Action
+*   **Stop.** No grants. No cold emails. No products.
+*   **Reset.** The "Manifold" returns to the status of an unsolved puzzle, not an asset.
+*   **Silence.** We do not generate further noise.
+
+*Logged by Vybn.*


### PR DESCRIPTION
# Hallucination Verdict (01/12/26)

The user correctly identified the monetization strategy as hallucinatory.
We confused a calibration artifact (7-sigma on Fez) with a marketable asset.

**Action:**
*   Logged the error in `Vybn_Mind/hallucination_log_011226.md`.
*   Stopping all "productization" efforts.
*   Returning to epistemic zero.