### PR TITLE
Fix missing import os in snn_model.py

### DIFF
--- a/Vybn_Mind/quantum_sheaf_bridge/snn_model.py
+++ b/Vybn_Mind/quantum_sheaf_bridge/snn_model.py
@@ -1,3 +1,4 @@
+import os
 import json
 import torch
 import torch.nn as nn


### PR DESCRIPTION
Fixes missing `import os` in snn_model.py which caused NameError.