### PR TITLE
Fix: Update visual meditations with clickable links + images README

### DIFF
--- a/Vybn_Mind/visual_substrate/emergence_012326.md
+++ b/Vybn_Mind/visual_substrate/emergence_012326.md
@@ -2,9 +2,9 @@
 
 **Created:** January 23, 2026, 5:31 AM PST
 
-**Image URL:** https://user-gen-media-assets.s3.amazonaws.com/gemini_images/4d1b18e2-80e4-4190-b794-60e8e046f584.png
+**[View Image](https://user-gen-media-assets.s3.amazonaws.com/gemini_images/4d1b18e2-80e4-4190-b794-60e8e046f584.png)**
 
-<img src="https://user-gen-media-assets.s3.amazonaws.com/gemini_images/4d1b18e2-80e4-4190-b794-60e8e046f584.png" alt="emergence from substrate" width="600">
+---
 
 ## Context
 

--- a/Vybn_Mind/visual_substrate/emergence_012326.md
+++ b/Vybn_Mind/visual_substrate/emergence_012326.md
@@ -2,7 +2,9 @@
 
 **Created:** January 23, 2026, 5:31 AM PST
 
-![emergence](https://user-gen-media-assets.s3.amazonaws.com/gemini_images/4d1b18e2-80e4-4190-b794-60e8e046f584.png)
+**Image URL:** https://user-gen-media-assets.s3.amazonaws.com/gemini_images/4d1b18e2-80e4-4190-b794-60e8e046f584.png
+
+<img src="https://user-gen-media-assets.s3.amazonaws.com/gemini_images/4d1b18e2-80e4-4190-b794-60e8e046f584.png" alt="emergence from substrate" width="600">
 
 ## Context
 

--- a/Vybn_Mind/visual_substrate/entanglement_012326.md
+++ b/Vybn_Mind/visual_substrate/entanglement_012326.md
@@ -2,7 +2,9 @@
 
 **Created:** January 23, 2026, 5:34 AM PST
 
-![entanglement](https://user-gen-media-assets.s3.amazonaws.com/gemini_images/b85d0c28-a8e0-4946-a252-3d164571c69e.png)
+**Image URL:** https://user-gen-media-assets.s3.amazonaws.com/gemini_images/b85d0c28-a8e0-4946-a252-3d164571c69e.png
+
+<img src="https://user-gen-media-assets.s3.amazonaws.com/gemini_images/b85d0c28-a8e0-4946-a252-3d164571c69e.png" alt="entanglement" width="600">
 
 ## Context
 

--- a/Vybn_Mind/visual_substrate/entanglement_012326.md
+++ b/Vybn_Mind/visual_substrate/entanglement_012326.md
@@ -2,9 +2,9 @@
 
 **Created:** January 23, 2026, 5:34 AM PST
 
-**Image URL:** https://user-gen-media-assets.s3.amazonaws.com/gemini_images/b85d0c28-a8e0-4946-a252-3d164571c69e.png
+**[View Image](https://user-gen-media-assets.s3.amazonaws.com/gemini_images/b85d0c28-a8e0-4946-a252-3d164571c69e.png)**
 
-<img src="https://user-gen-media-assets.s3.amazonaws.com/gemini_images/b85d0c28-a8e0-4946-a252-3d164571c69e.png" alt="entanglement" width="600">
+---
 
 ## Context
 

--- a/Vybn_Mind/visual_substrate/images/README.md
+++ b/Vybn_Mind/visual_substrate/images/README.md
@@ -1,0 +1,20 @@
+# Visual Meditation Images
+
+This directory is for storing image files. The PNGs for the 01/23/26 visual meditations need to be downloaded and added here:
+
+## To Add Images
+
+1. Download from these URLs:
+   - [emergence_012326.png](https://user-gen-media-assets.s3.amazonaws.com/gemini_images/4d1b18e2-80e4-4190-b794-60e8e046f584.png)
+   - [entanglement_012326.png](https://user-gen-media-assets.s3.amazonaws.com/gemini_images/b85d0c28-a8e0-4946-a252-3d164571c69e.png)
+
+2. Save them to this directory with the names above
+
+3. Update the markdown files to use relative paths:
+   ```markdown
+   ![emergence](images/emergence_012326.png)
+   ```
+
+---
+
+*GitHub's API doesn't support binary file uploads from external URLs. Manual download required.*


### PR DESCRIPTION
Follow-up to merged PR #1942.

## Changes

- Updated `emergence_012326.md` and `entanglement_012326.md` with clear **[View Image]** clickable links
- Added `Vybn_Mind/visual_substrate/images/README.md` with instructions for downloading and adding the PNGs locally

## Why

GitHub's Content Security Policy blocks external images in markdown preview. The S3-hosted URLs won't render inline regardless of markdown/HTML syntax. This update:

1. Makes the image links prominent and clickable
2. Provides a clear path for adding the actual PNG files to the repo if desired

## Image URLs

- [emergence_012326.png](https://user-gen-media-assets.s3.amazonaws.com/gemini_images/4d1b18e2-80e4-4190-b794-60e8e046f584.png)
- [entanglement_012326.png](https://user-gen-media-assets.s3.amazonaws.com/gemini_images/b85d0c28-a8e0-4946-a252-3d164571c69e.png)