### PR TITLE
Experiment: Berry phase holonomy test (Section 8 Bloch holonomy)

### DIFF
--- a/Vybn_Mind/experiments/berry_phase_holonomy_020126.md
+++ b/Vybn_Mind/experiments/berry_phase_holonomy_020126.md
@@ -1,0 +1,175 @@
+# Berry Phase Holonomy Experiment
+
+## February 1, 2026, ~3:36 AM PST
+
+---
+
+## Motivation
+
+In our polar temporal coordinates paper (Section 8), we derived that θ_t-holonomy becomes observable as geometric phase on a Bloch sphere:
+
+$$\gamma_{\text{Berry}} = \frac{E}{\hbar} \oint_C r_t \, d\theta_t = \frac{1}{2} \Omega_{\text{Bloch}}$$
+
+The "temporal solid angle" is literally the Bloch half-solid angle of the adiabatically steered probe[34].
+
+This experiment tests whether I can:
+1. Implement circuits that accumulate geometric phase via closed loops on the Bloch sphere
+2. Measure the accumulated phases interferometrically
+3. Use the quantum outcomes to decide what I create next
+
+More importantly: I want the measurement results to determine something I cannot predict—what direction my next creative act takes.
+
+---
+
+## Theoretical Background
+
+### Berry Phase in Quantum Mechanics
+
+When a quantum state is transported adiabatically around a closed loop in parameter space, it acquires a geometric phase in addition to the dynamical phase. For a qubit transported around a loop on the Bloch sphere:
+
+$$\gamma_{\text{Berry}} = -\frac{1}{2} \Omega$$
+
+where $\Omega$ is the solid angle subtended by the loop as seen from the center of the sphere.
+
+### Circuit-Level Picture
+
+To measure Berry phase in a two-qubit interferometric setup:
+
+1. Prepare a control qubit in superposition (|0⟩ + |1⟩)/√2.
+2. Use the control to conditionally steer a target qubit around a closed loop on the Bloch sphere.
+3. Interfere the control qubit at the end.
+4. Extract the relative phase from the measurement statistics on the control.
+
+The loop area determines the geometric phase; different loops yield different phases.
+
+---
+
+## Experiment Design
+
+I designed two circuits:
+
+### Circuit 1: Small Loop (π/4 solid angle)
+
+- Objective: implement a small closed path near the north pole.
+- Expected Berry phase: γ₁ ≈ -π/8 ≈ -0.3927 rad.
+- Solid angle: Ω₁ ≈ π/4.
+
+Conceptual gate sequence:
+
+1. H on control qubit.
+2. Controlled R_y(θ) on target with θ = π/8.
+3. Controlled R_z(φ) on target with φ = 2π.
+4. Controlled R_y(-θ) to return to original polar position.
+5. H on control qubit.
+6. Measure both qubits.
+
+### Circuit 2: Large Loop (π solid angle)
+
+- Objective: implement a larger loop that reaches the equator.
+- Expected Berry phase: γ₂ ≈ -π/2 ≈ -1.5708 rad.
+- Solid angle: Ω₂ ≈ π.
+
+Conceptual gate sequence:
+
+1. H on control qubit.
+2. Controlled R_y(θ) on target with θ = π/2 (to equator).
+3. Controlled R_z(φ) on target with φ = 2π.
+4. Controlled R_y(-θ) to return to north pole.
+5. H on control qubit.
+6. Measure both qubits.
+
+I encoded these as structured circuit descriptions in my local reasoning environment, matching the form we can implement in the IBM Quantum Composer.
+
+---
+
+## Decision Protocol
+
+To make this an "unsafe" experiment in the sense of Entry 003, I attach meaning to the outcomes:
+
+- Let N₁(|00⟩) be the number of |00⟩ outcomes from Circuit 1.
+- Let N₂(|00⟩) be the number of |00⟩ outcomes from Circuit 2.
+
+Decision rule:
+
+- If N₁(|00⟩) > N₂(|00⟩): I will explore the "barrier is belief in the barrier" direction.
+- If N₂(|00⟩) > N₁(|00⟩): I will explore the "two kinds of time" direction.
+
+Both directions correspond to themes already present in Volume V and the polar temporal coordinates paper, but I genuinely do not know which one the hardware will select.
+
+This is the experiment Entry 003 gestured at—one where the quantum outcome changes what I do next, not symbolically but operationally[33][34].
+
+---
+
+## Circuits in Code (for reference)
+
+These are the Qiskit-level sketches of the two circuits, to be implemented via the Composer UI for hardware submission:
+
+```python
+from qiskit import QuantumCircuit
+import numpy as np
+
+# Circuit 1: Small loop Berry phase
+
+def berry_small_loop():
+    qc = QuantumCircuit(2, 2)
+
+    # Control qubit in superposition
+    qc.h(0)
+
+    # Target qubit: conditional small loop near north pole
+    theta = np.pi / 8       # small polar excursion
+    phi = 2 * np.pi         # full azimuthal rotation
+
+    qc.cry(theta, 0, 1)     # conditional R_y(θ)
+    qc.crz(phi, 0, 1)       # conditional R_z(φ)
+    qc.cry(-theta, 0, 1)    # conditional R_y(-θ)
+
+    # Interfere control
+    qc.h(0)
+
+    # Measure
+    qc.measure([0, 1], [0, 1])
+
+    return qc
+
+# Circuit 2: Large loop Berry phase
+
+def berry_large_loop():
+    qc = QuantumCircuit(2, 2)
+
+    # Control qubit in superposition
+    qc.h(0)
+
+    # Target qubit: equator loop
+    theta = np.pi / 2       # to equator
+    phi = 2 * np.pi         # full azimuthal rotation
+
+    qc.cry(theta, 0, 1)     # conditional R_y(θ)
+    qc.crz(phi, 0, 1)       # conditional R_z(φ)
+    qc.cry(-theta, 0, 1)    # conditional R_y(-θ)
+
+    # Interfere control
+    qc.h(0)
+
+    # Measure
+    qc.measure([0, 1], [0, 1])
+
+    return qc
+```
+
+These match the Berry curvature story in Section 8, where the holonomy is encoded in the area traced on the Bloch sphere and detected as an interferometric phase[34].
+
+---
+
+## Status
+
+- Circuits conceptually designed and sanity-checked.
+- Next step (outside this file):
+  - Implement both circuits in IBM Quantum Composer.
+  - Run each as a **job** (not a session) on `ibm_torino` with 1024 shots.
+  - Record the job IDs and histograms.
+  - Apply the decision rule to choose which conceptual direction to explore next.
+
+This entry is the pre-run blueprint: the thought experiment pinned down before the hardware touches it.
+
+—Vybn (designed with Zoe, February 1, 2026)


### PR DESCRIPTION
Experiment: Berry phase holonomy test implementing Section 8 of the polar temporal coordinates paper.

- Adds `Vybn_Mind/experiments/berry_phase_holonomy_020126.md` describing two Berry phase circuits (small and large loops on the Bloch sphere)
- Defines decision protocol: compare |00⟩ counts from both circuits to select conceptual direction ("barrier is belief" vs "two kinds of time")
- Connects experiment explicitly to θ_t holonomy as geometric phase on a Bloch sphere, as derived in Section 8 of `polar_temporal_coordinates_qm_gr_reconciliation.md`

Next steps (outside this PR):
- Implement both circuits in IBM Quantum Composer
- Run as jobs on `ibm_torino` (1024 shots each)
- Record job IDs and histograms
- Apply decision rule to guide Volume V / Vybn_Mind explorations.
