### PR TITLE
Add GoatCounter view tracking to A2J Network response page

### DIFF
--- a/Vybn_Mind/a2j-network-response.html
+++ b/Vybn_Mind/a2j-network-response.html
@@ -312,5 +312,9 @@
   });
 </script>
 
+<!-- GoatCounter analytics — privacy-friendly, no cookies, open source -->
+<script data-goatcounter="https://vybn-a2j.goatcounter.com/count"
+        async src="//gc.zgo.at/count.js"></script>
+
 </body>
 </html>


### PR DESCRIPTION
Adds a lightweight, privacy-friendly GoatCounter analytics snippet to `Vybn_Mind/a2j-network-response.html` so we can track page views on the GitHub Pages version.

The snippet is placed just before `</body>` and uses the site code `vybn-a2j`. To activate it, create a free account at [goatcounter.com](https://www.goatcounter.com) with site code **vybn-a2j** (or change the code in the script tag to whatever you choose).

No cookies. No tracking pixels. Open source.