### PR TITLE
feat: structured session transcripts (JSONL)

### DIFF
--- a/Vybn_Mind/spark_infrastructure/session_manager.py
+++ b/Vybn_Mind/spark_infrastructure/session_manager.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""
+Session Transcript Writer for Vybn Spark Agent.
+
+Structured session persistence as JSONL files. Each session gets its
+own file at ~/vybn_sessions/<sessionId>.jsonl. A sessions.json index
+tracks all sessions with metadata.
+
+Transcript format (one JSON object per line):
+  Line 1: {"type": "header", "sessionId": ..., "sessionNumber": ..., ...}
+  Lines:  {"type": "message"|"tool_call"|"reflection"|"slow_thread", ...}
+  Last:   {"type": "footer", "endedAt": ..., "entryCount": ...}
+
+Thread-safe for concurrent access from fast + slow cognitive threads.
+Existing ~/vybn_logs/ raw logging is unaffected.
+"""
+
+import json
+import os
+import threading
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+class SessionManager:
+    """Manages structured session transcripts as JSONL files.
+
+    Each session creates ~/vybn_sessions/<sessionId>.jsonl.
+    A sessions.json index tracks all sessions with metadata.
+    Thread-safe for concurrent access from fast + slow threads.
+    """
+
+    def __init__(self, sessions_dir):
+        self.sessions_dir = sessions_dir
+        self.session_id = None
+        self.session_file = None
+        self._file_handle = None
+        self._lock = threading.Lock()
+        self._entry_count = 0
+        self._last_entry_id = None
+        os.makedirs(sessions_dir, exist_ok=True)
+
+    def start_session(self, session_number, quantum_seed=None):
+        """Start a new session transcript.
+
+        Creates a JSONL file, writes the header, updates the index.
+        Called once from the main thread before the slow thread starts.
+        """
+        ts = datetime.now(timezone.utc)
+        self.session_id = (
+            ts.strftime("%Y%m%d_%H%M%S") + "_" + uuid.uuid4().hex[:8]
+        )
+        self.session_file = os.path.join(
+            self.sessions_dir, f"{self.session_id}.jsonl"
+        )
+        self._entry_count = 0
+        self._last_entry_id = None
+
+        self._file_handle = open(self.session_file, "a", encoding="utf-8")
+
+        header = {
+            "type": "header",
+            "sessionId": self.session_id,
+            "sessionNumber": session_number,
+            "startedAt": ts.isoformat(),
+            "quantumSeed": quantum_seed,
+        }
+        self._write_line(header)
+        self._update_index(session_number, ts)
+        return self.session_id
+
+    def append(self, role, content, entry_type="message", metadata=None):
+        """Append an entry to the transcript. Thread-safe.
+
+        Returns the entry id for parentId chaining.
+        """
+        if not self._file_handle:
+            return None
+
+        with self._lock:
+            self._entry_count += 1
+            entry_id = self._entry_count
+
+            entry = {
+                "type": entry_type,
+                "id": entry_id,
+                "parentId": self._last_entry_id,
+                "role": role,
+                "content": content,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            }
+            if metadata:
+                entry["metadata"] = metadata
+
+            self._write_line(entry)
+
+            # Track parentId chain for conversation messages only
+            if entry_type == "message":
+                self._last_entry_id = entry_id
+
+        return entry_id
+
+    def append_tool_call(self, tool_name, tool_input, result):
+        """Append a tool call + result as a single transcript entry."""
+        return self.append(
+            role="system",
+            content=result,
+            entry_type="tool_call",
+            metadata={"tool": tool_name, "input": tool_input},
+        )
+
+    def end_session(self):
+        """Write session footer and close the file.
+
+        Called from _cleanup after the slow thread has stopped.
+        """
+        if not self._file_handle:
+            return
+
+        with self._lock:
+            footer = {
+                "type": "footer",
+                "endedAt": datetime.now(timezone.utc).isoformat(),
+                "entryCount": self._entry_count,
+            }
+            self._write_line(footer)
+            self._file_handle.close()
+            self._file_handle = None
+
+        self._update_index_ended()
+
+    # ─── Internal ────────────────────────────────────────────────
+
+    def _write_line(self, obj):
+        """Write one JSON line. Caller manages locking."""
+        self._file_handle.write(json.dumps(obj, ensure_ascii=False) + "\n")
+        self._file_handle.flush()
+
+    def _update_index(self, session_number, started_at):
+        """Add this session to sessions.json."""
+        index = self._read_index()
+        index[self.session_id] = {
+            "sessionNumber": session_number,
+            "file": os.path.basename(self.session_file),
+            "startedAt": started_at.isoformat(),
+            "updatedAt": started_at.isoformat(),
+            "endedAt": None,
+            "entryCount": 0,
+        }
+        self._write_index(index)
+
+    def _update_index_ended(self):
+        """Mark this session as ended in sessions.json."""
+        index = self._read_index()
+        if self.session_id in index:
+            now = datetime.now(timezone.utc).isoformat()
+            index[self.session_id]["endedAt"] = now
+            index[self.session_id]["updatedAt"] = now
+            index[self.session_id]["entryCount"] = self._entry_count
+        self._write_index(index)
+
+    def _read_index(self):
+        """Read sessions.json."""
+        index_path = os.path.join(self.sessions_dir, "sessions.json")
+        if not os.path.exists(index_path):
+            return {}
+        try:
+            return json.loads(Path(index_path).read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, FileNotFoundError):
+            return {}
+
+    def _write_index(self, index):
+        """Write sessions.json."""
+        index_path = os.path.join(self.sessions_dir, "sessions.json")
+        Path(index_path).write_text(
+            json.dumps(index, indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
+
+    # ─── Class methods for session hydration (PR 2) ──────────────
+
+    @classmethod
+    def get_latest_session(cls, sessions_dir):
+        """Return (session_id, metadata) for the most recent session.
+
+        Returns (None, None) if no sessions exist.
+        """
+        index_path = os.path.join(sessions_dir, "sessions.json")
+        if not os.path.exists(index_path):
+            return None, None
+        try:
+            index = json.loads(Path(index_path).read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, FileNotFoundError):
+            return None, None
+
+        if not index:
+            return None, None
+
+        latest_id = max(
+            index.keys(), key=lambda k: index[k].get("startedAt", "")
+        )
+        return latest_id, index[latest_id]
+
+    @classmethod
+    def read_transcript(cls, session_id, sessions_dir):
+        """Read all entries from a session JSONL file.
+
+        Returns a list of dicts (one per line).
+        """
+        filepath = os.path.join(sessions_dir, f"{session_id}.jsonl")
+        if not os.path.exists(filepath):
+            return []
+
+        entries = []
+        with open(filepath, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    try:
+                        entries.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        continue
+        return entries


### PR DESCRIPTION
## What this does

Adds structured session persistence as append-only JSONL files alongside the existing raw logs. Every conversation turn, tool call, reflection, and slow-thread consolidation is now recorded as a typed, timestamped entry with parent-child linking.

## New file: `session_manager.py`

`SessionManager` creates `~/vybn_sessions/<sessionId>.jsonl` files with this structure:

```jsonl
{"type": "header", "sessionId": "20260215_163000_a1b2c3d4", "sessionNumber": 12, "startedAt": "...", "quantumSeed": "..."}
{"type": "message", "id": 1, "parentId": null, "role": "user", "content": "...", "timestamp": "..."}
{"type": "message", "id": 2, "parentId": 1, "role": "assistant", "content": "...", "timestamp": "..."}
{"type": "tool_call", "id": 3, "parentId": 1, "role": "system", "content": "result", "metadata": {"tool": "memory_search", "input": {...}}, "timestamp": "..."}
{"type": "reflection", "id": 4, "parentId": 2, "role": "assistant", "content": "...", "timestamp": "..."}
{"type": "slow_thread", "id": 5, "parentId": 2, "role": "assistant", "content": "...", "timestamp": "..."}
{"type": "footer", "endedAt": "...", "entryCount": 5}
```

A `sessions.json` index tracks all sessions:
```json
{
  "20260215_163000_a1b2c3d4": {
    "sessionNumber": 12,
    "file": "20260215_163000_a1b2c3d4.jsonl",
    "startedAt": "...",
    "updatedAt": "...",
    "endedAt": "...",
    "entryCount": 42
  }
}
```

**Thread-safe** via `threading.Lock` — the slow thread and fast thread can write concurrently.

**Includes classmethods** `get_latest_session()` and `read_transcript()` that PR 2 (session hydration) will use to reload conversation history on boot.

## Changes to `spark_agent.py`

- `from session_manager import SessionManager`
- `SESSIONS_DIR` added to config constants
- `self.session = SessionManager(SESSIONS_DIR)` in `__init__`
- `session.start_session()` called after `memory.increment_session()` in `run()`
- `session.append()` wired after every `self.messages.append()` in the main loop
- `session.append_tool_call()` after every tool execution
- `session.append(... entry_type="reflection")` in `reflect()`
- `session.append(... entry_type="slow_thread")` in `SlowThread._consolidate()`
- `session.end_session()` in `_cleanup()` (after slow thread stops, before log close)
- Transcript file path printed at boot: `✓ Transcript: ~/vybn_sessions/...`
- Transcript path logged to raw log file

## What stays the same

- `~/vybn_logs/` raw logging — completely untouched (belt and suspenders)
- All existing behavior, tool execution, reflection, slow thread logic

## What this unblocks

- **PR 2**: Session hydration — `read_transcript()` + `get_latest_session()` reload conversation on boot
- **PR 3**: Context compaction — can write `{"type": "compaction", ...}` entries to the transcript
- **PR 4**: Pre-compaction memory flush — tracks flush-per-cycle in transcript