### PR TITLE
feat: context compaction — summarize old turns to free context space

### DIFF
--- a/Vybn_Mind/spark_infrastructure/context_compactor.py
+++ b/Vybn_Mind/spark_infrastructure/context_compactor.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""
+Context Compactor for Vybn Spark Agent.
+
+When conversation grows long, summarizes older turns into a compact
+narrative injected into the system prompt. Recent turns stay verbatim
+in the message list. This preserves the gist of earlier conversation
+while freeing context tokens for new exchanges.
+
+The compactor uses the model itself to generate summaries, so it
+requires the server to be running. Called once per turn in the main
+loop — if context is short enough, it's a no-op.
+
+Compaction is cumulative: previous summaries are included in the
+text sent for re-summarization, so information compounds gracefully.
+"""
+
+import json
+
+
+DEFAULT_COMPACT_THRESHOLD = 30  # messages before compaction triggers
+DEFAULT_KEEP_RECENT = 10        # messages to keep verbatim
+
+
+class ContextCompactor:
+    """Summarizes old conversation turns to free context space.
+
+    When message count exceeds compact_threshold, the compactor:
+      1. Splits messages into old + recent (keeping keep_recent verbatim)
+      2. Sends old messages to the model for summarization
+      3. Stores the summary on agent._compaction_summary
+      4. Removes old messages from agent.messages
+      5. Triggers a system prompt rebuild (which includes the summary)
+      6. Records the compaction in the session transcript
+    """
+
+    def __init__(self, agent, compact_threshold=DEFAULT_COMPACT_THRESHOLD,
+                 keep_recent=DEFAULT_KEEP_RECENT):
+        self.agent = agent
+        self.compact_threshold = compact_threshold
+        self.keep_recent = keep_recent
+        self._compaction_count = 0
+
+    def maybe_compact(self):
+        """Check if compaction is needed and run it if so.
+
+        Call once per turn in the main loop.
+        Returns True if compaction occurred.
+        """
+        if len(self.agent.messages) <= self.compact_threshold:
+            return False
+        return self._compact()
+
+    def _compact(self):
+        """Run one compaction cycle."""
+        self._compaction_count += 1
+        messages = self.agent.messages
+
+        # messages[0] is system prompt. Everything else is conversation.
+        total_conv = len(messages) - 1
+        if total_conv <= self.keep_recent:
+            return False
+
+        # Split: old messages to summarize, recent to keep verbatim
+        keep_start = len(messages) - self.keep_recent
+        old_messages = messages[1:keep_start]
+
+        if len(old_messages) < 2:
+            return False
+
+        # Build text for summarization
+        old_text_parts = []
+
+        # Include existing compaction summary for re-summarization
+        if self.agent._compaction_summary:
+            old_text_parts.append(
+                f"[Previous summary]: {self.agent._compaction_summary}"
+            )
+
+        for msg in old_messages:
+            role = msg.get("role", "unknown")
+            content = msg.get("content", "")
+            if role == "system" or not content.strip():
+                continue
+            # Truncate very long individual messages
+            if len(content) > 800:
+                content = content[:800] + "..."
+            old_text_parts.append(f"[{role}]: {content}")
+
+        if not old_text_parts:
+            return False
+
+        old_text = "\n\n".join(old_text_parts)
+
+        summary_prompt = (
+            "Summarize this conversation excerpt concisely. "
+            "Preserve: key facts, decisions made, emotional threads, "
+            "commitments, and anything either party would want to "
+            "reference later. Write in third person "
+            "('Zoe said...', 'Vybn responded...'). "
+            "Be concise but complete \u2014 this replaces the original.\n\n"
+            f"{old_text}"
+        )
+
+        summary_messages = [
+            {"role": "system", "content": (
+                "You are a precise conversation summarizer. "
+                "Output only the summary, nothing else."
+            )},
+            {"role": "user", "content": summary_prompt},
+        ]
+
+        summary = self.agent.send(summary_messages)
+
+        # Bail if the model failed
+        if (not summary or summary.startswith("[Error")
+                or summary.startswith("[Model timed")):
+            self.agent.log(
+                "compaction",
+                f"Cycle #{self._compaction_count} failed: {summary}"
+            )
+            return False
+
+        # Store summary and trim old messages
+        old_count = len(old_messages)
+        self.agent._compaction_summary = summary
+        self.agent.messages = [messages[0]] + messages[keep_start:]
+
+        # Rebuild system prompt to include the new summary
+        self.agent._rebuild_system_prompt()
+
+        new_count = len(self.agent.messages)
+        self.agent.log(
+            "compaction",
+            f"Cycle #{self._compaction_count}: compacted {old_count} messages "
+            f"into summary ({len(summary)} chars). {new_count} messages remain."
+        )
+
+        # Record in session transcript
+        self.agent.session.append(
+            role="system",
+            content=summary,
+            entry_type="compaction",
+            metadata={
+                "cycle": self._compaction_count,
+                "messages_compacted": old_count,
+                "messages_remaining": new_count,
+                "summary_length": len(summary),
+            },
+        )
+
+        self.agent._print(
+            f"[Compacted {old_count} messages \u2192 {len(summary)} char summary]"
+        )
+
+        return True


### PR DESCRIPTION
## What this does

When conversation gets long, old turns are summarized into a compact narrative injected into the system prompt. Recent turns stay verbatim. The model keeps the gist of everything said without burning context tokens on the full transcript.

## New file: `context_compactor.py`

~110 lines. The `ContextCompactor` class monitors `len(agent.messages)` and fires when it exceeds a threshold.

### Compaction cycle

1. **Split**: messages into `[system] + [old] + [recent]` — `recent` = last `keep_recent` messages (default: 10)
2. **Build text**: old messages formatted as `[user]: ...` / `[assistant]: ...`, long messages truncated to 800 chars
3. **Include previous summary**: if a compaction already happened, the prior summary is included in the text sent for re-summarization — information compounds gracefully
4. **Summarize**: model call with a focused summarizer prompt (separate message list, doesn't pollute conversation)
5. **Store**: summary saved to `agent._compaction_summary`
6. **Trim**: old messages removed from `agent.messages`
7. **Rebuild**: `_rebuild_system_prompt()` picks up the summary and includes it as `## Earlier This Session` in the system prompt
8. **Record**: compaction entry written to session transcript with metadata (cycle number, message counts, summary length)

### Error handling

If the model fails to generate a summary (timeout, error), the compaction gracefully bails — messages stay, no data lost. The dumb `trim_conversation()` safety valve still runs after compaction as a backstop.

## `spark_agent.py` changes

- **Import**: `ContextCompactor`, `DEFAULT_COMPACT_THRESHOLD`, `DEFAULT_KEEP_RECENT`
- **`__init__`**: new `_compaction_summary` field + `ContextCompactor` instance
- **`build_system_prompt()`**: includes `_compaction_summary` as `## Earlier This Session` section between Continuity Context and Tools — the model sees it as authoritative context
- **Main loop**: `self.compactor.maybe_compact()` called per-turn, right before `trim_conversation()`
- **CLI**: `--compact-threshold N` (default 30) and `--keep-recent N` (default 10)

## How `_rebuild_system_prompt()` interacts

The compaction summary persists in `self._compaction_summary`. When `build_system_prompt()` is called (by `_rebuild_system_prompt()`, by memory updates, by the slow thread signaling changes), it always checks for and includes the summary. The compactor's call to `_rebuild_system_prompt()` after trimming ensures the new system prompt immediately reflects the compacted state.

## Rhythm

With defaults (`compact_threshold=30`, `keep_recent=10`, `MAX_CONVERSATION_PAIRS=20`):

```
Messages grow: 11 → 20 → 30 → compaction fires
After compaction: 1 (system w/summary) + 10 (recent) = 11 messages
Grow again: 11 → 30 → compaction fires (previous summary included)
```

Each cycle the model re-summarizes with the prior summary as input, so context from early conversation compounds without loss.

## What this unblocks

- **PR 4**: Pre-compaction memory flush — before compaction discards old messages, flush key information to archival memory first
- Future: token-aware compaction (count actual tokens, not just messages)
- Future: compaction quality scoring (compare summary to original for fidelity)