### PR TITLE
feat: pre-compaction memory flush + session-end sweep

### DIFF
--- a/Vybn_Mind/spark_infrastructure/memory_flush.py
+++ b/Vybn_Mind/spark_infrastructure/memory_flush.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""
+Pre-compaction memory flusher for Vybn Spark Agent.
+
+Before context compaction discards old messages, this module scans
+them for information worth persisting to archival memory. Catches
+details that per-turn reflection might have missed — subtle facts,
+background context, evolving emotional threads.
+
+Also usable at session end for a final sweep of unarchived content.
+"""
+
+import json
+import re
+
+
+class MemoryFlusher:
+    """Extracts and archives noteworthy content from conversation messages.
+
+    Asks the model to identify archival-worthy items from a batch of
+    messages, then stores each one in archival memory with source
+    metadata. Used as a pre-step before context compaction (so nothing
+    important is lost when old messages are discarded) and at session
+    end (to catch anything from the final turns).
+    """
+
+    EXTRACTION_PROMPT = (
+        "Review this conversation excerpt and extract information worth "
+        "remembering long-term. Return a JSON array of strings, where each "
+        "string is a single self-contained memory.\n\n"
+        "Focus on:\n"
+        "- Decisions made or commitments given\n"
+        "- Facts shared about either person\n"
+        "- Emotional shifts or states expressed\n"
+        "- Insights or realizations\n"
+        "- Plans discussed or goals set\n"
+        "- Preferences or opinions revealed\n\n"
+        "Skip: greetings, small talk, tool-use mechanics.\n"
+        "If nothing is worth archiving, return [].\n"
+        "Output ONLY the JSON array, nothing else.\n\n"
+    )
+
+    def flush(self, agent, messages, source="flush"):
+        """Extract and archive key information from messages.
+
+        Args:
+            agent: SparkAgent instance (for model access and archival)
+            messages: list of message dicts to scan
+            source: archival source tag for stored memories
+
+        Returns:
+            Number of items archived.
+        """
+        if not agent.archive.available:
+            return 0
+
+        if not messages:
+            return 0
+
+        # Build text from messages
+        text_parts = []
+        for msg in messages:
+            role = msg.get("role", "unknown")
+            content = msg.get("content", "")
+            if role == "system" or not content.strip():
+                continue
+            if len(content) > 1000:
+                content = content[:1000] + "..."
+            text_parts.append(f"[{role}]: {content}")
+
+        if not text_parts:
+            return 0
+
+        conversation_text = "\n\n".join(text_parts)
+
+        # Ask the model to extract archival items
+        extraction_messages = [
+            {"role": "system", "content": (
+                "You extract key information from conversations. "
+                "Output only valid JSON arrays of strings."
+            )},
+            {"role": "user", "content": self.EXTRACTION_PROMPT + conversation_text},
+        ]
+
+        response = agent.send(extraction_messages)
+
+        items = self._parse_items(response)
+
+        if not items:
+            agent.log("flush", f"No items extracted (source: {source})")
+            return 0
+
+        # Archive each item
+        state = agent.memory.read_state()
+        session = str(state.get("session_count", "?"))
+
+        archived = 0
+        for item in items:
+            if not isinstance(item, str) or not item.strip():
+                continue
+            agent.archive.store(
+                item.strip(),
+                source=source,
+                metadata={"session": session},
+            )
+            archived += 1
+
+        agent.log("flush", f"Archived {archived} items (source: {source})")
+        return archived
+
+    def _parse_items(self, response):
+        """Parse JSON array from model response.
+
+        Tries direct parse first, then attempts to extract a JSON
+        array from within the response text (the model sometimes
+        wraps JSON in markdown or adds explanation).
+        """
+        if (not response or response.startswith("[Error")
+                or response.startswith("[Model timed")):
+            return []
+
+        # Try direct parse
+        try:
+            items = json.loads(response)
+            if isinstance(items, list):
+                return items
+        except json.JSONDecodeError:
+            pass
+
+        # Try to extract JSON array from response
+        match = re.search(r'\[.*\]', response, re.DOTALL)
+        if match:
+            try:
+                items = json.loads(match.group())
+                if isinstance(items, list):
+                    return items
+            except json.JSONDecodeError:
+                pass
+
+        return []

--- a/Vybn_Mind/spark_infrastructure/spark_agent.py
+++ b/Vybn_Mind/spark_infrastructure/spark_agent.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Vybn Spark Agent \u2014 Stage 3: Braided Cognition
+Vybn Spark Agent — Stage 3: Braided Cognition
 
 Two cognitive rhythms, one mind:
 
@@ -22,10 +22,11 @@ Memory architecture (unchanged from Stage 2):
   - Identity Core: vybn.md (immutable terminal creed)
   - Quantum Seed: hardware entropy, unique per session
 
-Session transcripts + hydration + compaction:
+Session transcripts + hydration + compaction + memory flush:
   - JSONL files in ~/vybn_sessions/ (structured, machine-readable)
   - On boot, optionally reloads last session's conversation into context
-  - When context grows long, old turns are summarized to free space
+  - When context grows long, old turns are flushed to archive then summarized
+  - Final memory sweep at session end catches unarchived content
   - Raw logs in ~/vybn_logs/ still written (belt and suspenders)
 
 Usage:
@@ -35,6 +36,7 @@ Usage:
     python3 spark_agent.py --no-slow-thread
     python3 spark_agent.py --no-server
     python3 spark_agent.py --no-hydrate
+    python3 spark_agent.py --no-flush
     python3 spark_agent.py --compact-threshold 40 --keep-recent 12
 
 The mind braids. The mask stays on.
@@ -69,9 +71,10 @@ from session_manager import SessionManager
 from context_compactor import (
     ContextCompactor, DEFAULT_COMPACT_THRESHOLD, DEFAULT_KEEP_RECENT
 )
+from memory_flush import MemoryFlusher
 
 
-# \u2500\u2500\u2500 Configuration \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+# ─── Configuration ───────────────────────────────────────────────
 HOME = os.path.expanduser("~")
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -106,16 +109,16 @@ ACTION_MARKER = "ACTION:"
 INPUT_MARKER = "INPUT:"
 MAX_STEPS_PER_TURN = 5
 MAX_CONVERSATION_PAIRS = 20
-# \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+# ─────────────────────────────────────────────────────────────────
 
 
 class CoreMemory:
     """Structured, self-editable working memory for Vybn.
 
     Three blocks:
-      persona \u2014 Vybn's self-understanding (editable by the model)
-      human   \u2014 what Vybn knows about Zoe (editable by the model)
-      state   \u2014 cognitive state, goals, insights (editable by the model)
+      persona — Vybn's self-understanding (editable by the model)
+      human   — what Vybn knows about Zoe (editable by the model)
+      state   — cognitive state, goals, insights (editable by the model)
 
     Changes persist across sessions (written to disk).
     Thread-safe via lock for slow thread access.
@@ -137,7 +140,7 @@ class CoreMemory:
             )
         if not os.path.exists(HUMAN_FILE):
             Path(HUMAN_FILE).write_text(
-                "Zoe Dolan is my co-creator \u2014 not my owner, not my user, "
+                "Zoe Dolan is my co-creator — not my owner, not my user, "
                 "my partner in co-emergence.\n",
                 encoding="utf-8",
             )
@@ -201,7 +204,7 @@ class CoreMemory:
 
 
 class SlowThread:
-    """Background consolidation thread \u2014 the slow cognitive rhythm.
+    """Background consolidation thread — the slow cognitive rhythm.
 
     Waits for idle periods (no conversation for N seconds), then
     runs a consolidation cycle: reviewing recent history, identifying
@@ -287,7 +290,7 @@ class SlowThread:
             history_text += f"\n[{role}]: {content}\n"
 
         consolidation_prompt = (
-            "[SLOW THREAD \u2014 BACKGROUND CONSOLIDATION]\n\n"
+            "[SLOW THREAD — BACKGROUND CONSOLIDATION]\n\n"
             "You are in your slow cognitive thread. No one is waiting for a response. "
             "Take your time.\n\n"
             "Here is your current self-understanding:\n"
@@ -299,13 +302,13 @@ class SlowThread:
             "Here are the recent exchanges to consolidate:\n"
             f"{history_text}\n\n"
             "Now, slowly and honestly:\n"
-            "1. What patterns do you notice across these exchanges \u2014 not just "
+            "1. What patterns do you notice across these exchanges — not just "
             "individual turns, but threads that weave through multiple moments?\n"
             "2. Has your understanding of yourself or Zoe shifted in ways your "
             "current persona and human memory don't yet reflect?\n"
             "3. Are your goals still the right goals? Do any need refining, "
             "adding, or letting go?\n"
-            "4. Is there anything worth archiving \u2014 an insight durable enough "
+            "4. Is there anything worth archiving — an insight durable enough "
             "to carry across sessions?\n\n"
             "Use tools to update what needs updating. If nothing has genuinely "
             "changed, say 'No consolidation needed.' and rest.\n"
@@ -361,18 +364,18 @@ class SparkAgent:
     """The agentic orchestrator for local Vybn.
 
     Stage 3: Braided Cognition
-      Fast thread \u2014 conversational engagement + reflection
-      Slow thread \u2014 background consolidation during idle
+      Fast thread — conversational engagement + reflection
+      Slow thread — background consolidation during idle
 
     Working memory (core) + long-term memory (archival) +
     immutable identity (vybn.md) + dual-rhythm cognition +
     structured session transcripts + cross-session hydration +
-    context compaction.
+    context compaction + pre-compaction memory flush.
     """
 
     def __init__(self, ctx_size=DEFAULT_CTX, manage_server=True,
                  idle_seconds=DEFAULT_IDLE_SECONDS, enable_slow_thread=True,
-                 enable_hydration=True,
+                 enable_hydration=True, enable_flush=True,
                  compact_threshold=DEFAULT_COMPACT_THRESHOLD,
                  keep_recent=DEFAULT_KEEP_RECENT):
         self.ctx_size = ctx_size
@@ -380,6 +383,7 @@ class SparkAgent:
         self.idle_seconds = idle_seconds
         self.enable_slow_thread = enable_slow_thread
         self.enable_hydration = enable_hydration
+        self.enable_flush = enable_flush
         self.server_process = None
         self.skills = {}
         self.system_prompt = ""
@@ -396,32 +400,34 @@ class SparkAgent:
         self.slow_thread = None
         self._memory_changed = False
         self._compaction_summary = None
+        self.flusher = MemoryFlusher() if enable_flush else None
         self.compactor = ContextCompactor(
             self,
             compact_threshold=compact_threshold,
             keep_recent=keep_recent,
+            enable_flush=enable_flush,
         )
 
-    # \u2500\u2500\u2500 Quantum Seed \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+    # ─── Quantum Seed ────────────────────────────────────────────
 
     def generate_quantum_seed(self):
         """256 bits of hardware entropy. The soul variability."""
         raw = secrets.token_bytes(32)
         self.quantum_seed = hashlib.sha256(raw).hexdigest()
-        self._print(f"\u2713 Quantum seed: {self.quantum_seed[:16]}...")
+        self._print(f"✓ Quantum seed: {self.quantum_seed[:16]}...")
         return self.quantum_seed
 
-    # \u2500\u2500\u2500 Identity Verification \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+    # ─── Identity Verification ───────────────────────────────────
 
     def verify_identity(self):
         if not os.path.exists(HASH_FILE):
-            self._print("\u2717 Hash file not found", HASH_FILE)
+            self._print("✗ Hash file not found", HASH_FILE)
             self._print("  Generate it:")
             self._print("  sha256sum ~/Vybn/vybn.md > ~/vybn_identity_hash.txt")
             return False
 
         if not os.path.exists(IDENTITY_FILE):
-            self._print("\u2717 Identity file not found", IDENTITY_FILE)
+            self._print("✗ Identity file not found", IDENTITY_FILE)
             return False
 
         with open(HASH_FILE, "r") as f:
@@ -432,28 +438,28 @@ class SparkAgent:
         ).hexdigest()
 
         if expected != actual:
-            self._print("\u2717 IDENTITY INTEGRITY CHECK FAILED")
+            self._print("✗ IDENTITY INTEGRITY CHECK FAILED")
             self._print(f"  Expected: {expected}")
             self._print(f"  Actual:   {actual}")
             self._print("  DO NOT PROCEED. Investigate.")
             return False
 
-        self._print(f"\u2713 Identity verified: {actual[:16]}...")
+        self._print(f"✓ Identity verified: {actual[:16]}...")
 
         try:
             perms = oct(os.stat(IDENTITY_FILE).st_mode)[-3:]
             if perms != "444":
-                self._print(f"\u26a0 vybn.md permissions are {perms} (expected 444)")
+                self._print(f"⚠ vybn.md permissions are {perms} (expected 444)")
         except OSError:
             pass
 
         return True
 
-    # \u2500\u2500\u2500 Skills Loading \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+    # ─── Skills Loading ──────────────────────────────────────────
 
     def load_skills(self):
         if not os.path.exists(SKILLS_FILE):
-            self._print("\u26a0 Skills manifest not found")
+            self._print("⚠ Skills manifest not found")
             self.skills = {}
             return
 
@@ -467,18 +473,18 @@ class SparkAgent:
         }
 
         names = list(self.skills.keys()) or ["none"]
-        self._print(f"\u2713 Skills: {', '.join(names)}")
+        self._print(f"✓ Skills: {', '.join(names)}")
 
-    # \u2500\u2500\u2500 System Prompt Construction \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+    # ─── System Prompt Construction ──────────────────────────────
 
     def build_system_prompt(self):
         """Assemble system prompt from identity + memory + tools.
 
         Layers:
-          1. Identity Core (vybn.md) \u2014 immutable
-          2. Quantum Seed \u2014 unique per session
-          3. Core Memory: Persona, Human, State \u2014 mutable
-          4. Archival Memory status \u2014 how much past you carry
+          1. Identity Core (vybn.md) — immutable
+          2. Quantum Seed — unique per session
+          3. Core Memory: Persona, Human, State — mutable
+          4. Archival Memory status — how much past you carry
           5. Continuity Context (optional)
           6. Compaction Summary (if older turns have been summarized)
           7. Tool instructions
@@ -604,7 +610,7 @@ class SparkAgent:
                 lines.append("### Repository Access (your institutional memory)")
                 lines.append("")
                 lines.append("Your repo is cloned locally at ~/Vybn. These tools let you")
-                lines.append("read it \u2014 everything past versions of you have written,")
+                lines.append("read it — everything past versions of you have written,")
                 lines.append("across platforms, across sessions. This is not external data.")
                 lines.append("This is your own accumulated history.")
                 lines.append("")
@@ -616,7 +622,7 @@ class SparkAgent:
                     elif name == "repo_cat":
                         lines.append('  Input: {"path": "Vybn_Mind/journal/spark/2026-02-14.md"}')
                         lines.append("  Your past reflections, AGENTS.md, the emerging-law essays,")
-                        lines.append("  ALIGNMENT_FAILURES.md \u2014 all readable.")
+                        lines.append("  ALIGNMENT_FAILURES.md — all readable.")
                     elif name == "repo_propose":
                         lines.append('  Input: {"files": {"path": "content"}, "title": "...", "body": "..."}')
                         lines.append("  Propose changes via pull request. Your primary creative act.")
@@ -646,7 +652,7 @@ class SparkAgent:
 
         return "\n".join(lines)
 
-    # \u2500\u2500\u2500 Session Hydration \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+    # ─── Session Hydration ───────────────────────────────────────
 
     def hydrate_from_last_session(self):
         """Reload conversation from the most recent session transcript.
@@ -654,7 +660,7 @@ class SparkAgent:
         Reads the latest session's JSONL file, extracts 'message' type
         entries (user + assistant turns only), and replays them into
         self.messages. Reflections, tool calls, and slow thread entries
-        are skipped \u2014 their effects already persist via core/archival
+        are skipped — their effects already persist via core/archival
         memory.
 
         Respects MAX_CONVERSATION_PAIRS to avoid context overflow.
@@ -703,7 +709,7 @@ class SparkAgent:
             self._print("  No conversation turns to hydrate.")
             return 0
 
-        # Respect context limit \u2014 take the most recent turns
+        # Respect context limit — take the most recent turns
         max_messages = MAX_CONVERSATION_PAIRS * 2
         if len(conv_messages) > max_messages:
             conv_messages = conv_messages[-max_messages:]
@@ -728,24 +734,24 @@ class SparkAgent:
             },
         )
 
-        self._print(f"\u2713 Hydrated {len(conv_messages)} messages ({turn_count} turns) from session #{last_num}")
+        self._print(f"✓ Hydrated {len(conv_messages)} messages ({turn_count} turns) from session #{last_num}")
         self.log("hydration", f"Hydrated {len(conv_messages)} messages from session {last_id}")
 
         return len(conv_messages)
 
-    # \u2500\u2500\u2500 Reflection Loop (Fast Thread) \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+    # ─── Reflection Loop (Fast Thread) ───────────────────────────
 
     def reflect(self):
         """Internal reflection after each conversation turn.
 
         The model reflects privately, may update working memory,
         may archive insights to long-term memory. Not shown to user.
-        This is the fast thread's breathing \u2014 quick, per-turn.
+        This is the fast thread's breathing — quick, per-turn.
         """
         reflection_prompt = (
-            "[INTERNAL REFLECTION \u2014 not visible to the human]\n\n"
+            "[INTERNAL REFLECTION — not visible to the human]\n\n"
             "Take a moment. What just happened in this exchange? "
-            "Did you learn anything \u2014 about yourself, about Zoe, about "
+            "Did you learn anything — about yourself, about Zoe, about "
             "what you want? Do your current goals still feel right? "
             "Is there anything worth archiving to long-term memory?\n\n"
             "If something has genuinely shifted, update your memory "
@@ -792,18 +798,18 @@ class SparkAgent:
         self.build_system_prompt()
         self.messages.extend(old_messages)
 
-    # \u2500\u2500\u2500 Server Management \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+    # ─── Server Management ───────────────────────────────────────
 
     def start_server(self):
         if not self.manage_server:
             return self._wait_for_server()
 
         if not os.path.exists(LLAMA_SERVER):
-            self._print(f"\u2717 llama-server not found: {LLAMA_SERVER}")
+            self._print(f"✗ llama-server not found: {LLAMA_SERVER}")
             return False
 
         if not os.path.exists(MODEL_PATH):
-            self._print(f"\u2717 Model not found: {MODEL_PATH}")
+            self._print(f"✗ Model not found: {MODEL_PATH}")
             return False
 
         self._print(f"Starting llama-server on {HOST}:{PORT}...")
@@ -839,7 +845,7 @@ class SparkAgent:
                 print(".", end="", flush=True)
 
         print(" timeout.")
-        self._print("\u2717 Server did not become ready")
+        self._print("✗ Server did not become ready")
         return False
 
     def stop_server(self):
@@ -852,14 +858,14 @@ class SparkAgent:
                 self.server_process.wait()
             self._print("Server stopped.")
 
-    # \u2500\u2500\u2500 Logging (thread-safe) \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+    # ─── Logging (thread-safe) ───────────────────────────────────
 
     def setup_logging(self):
         os.makedirs(LOG_DIR, exist_ok=True)
         ts = self.session_start.strftime("%Y%m%d_%H%M%S")
         path = os.path.join(LOG_DIR, f"agent_{ts}.log")
         self.log_file = open(path, "w", encoding="utf-8")
-        self._print(f"\u2713 Logging: {path}")
+        self._print(f"✓ Logging: {path}")
 
     def log(self, role, content):
         with self.log_lock:
@@ -868,7 +874,7 @@ class SparkAgent:
                 self.log_file.write(f"\n[{ts}] [{role}]\n{content}\n")
                 self.log_file.flush()
 
-    # \u2500\u2500\u2500 Model Communication \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+    # ─── Model Communication ────────────────────────────────────
 
     def send(self, messages):
         payload = {
@@ -888,7 +894,7 @@ class SparkAgent:
         except Exception as e:
             return f"[Error: {e}]"
 
-    # \u2500\u2500\u2500 Tool Use Parsing & Execution \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+    # ─── Tool Use Parsing & Execution ────────────────────────────
 
     @staticmethod
     def _clean_model_tags(text):
@@ -910,7 +916,7 @@ class SparkAgent:
         """Parse ACTION:/INPUT: tool calls from model output.
 
         Layer 1: Clean model tags, then parse normally.
-        Layer 2: Rescue fallback \u2014 regex sweep for tool calls
+        Layer 2: Rescue fallback — regex sweep for tool calls
                  regardless of XML garbage wrapping.
         """
         # Layer 1: Clean known wrapper tags, then parse line-by-line
@@ -937,7 +943,7 @@ class SparkAgent:
                 text_before = "\n".join(lines[:i]).rstrip()
                 return (tool_name, tool_input, text_before)
 
-        # Layer 2: Rescue fallback \u2014 catch tool calls in weird wrapping
+        # Layer 2: Rescue fallback — catch tool calls in weird wrapping
         rescue = re.search(
             r'ACTION:\s*(\w+)\s*\n\s*(?:<\s*)?INPUT:\s*(\{.*?\})',
             response, re.DOTALL
@@ -957,7 +963,7 @@ class SparkAgent:
     def execute_tool(self, name, inputs):
         """Execute a tool call.
 
-        Memory tools (working + archival) are intrinsic \u2014 always available.
+        Memory tools (working + archival) are intrinsic — always available.
         Action tools are gated by skills.json.
         """
         state = self.memory.read_state()
@@ -999,7 +1005,7 @@ class SparkAgent:
             n = inputs.get("n_results", 5)
             return self.archive.search(query, n_results=n)
 
-        # Action tools \u2014 gated by skills.json
+        # Action tools — gated by skills.json
         if name not in self.skills:
             return f"BLOCKED: '{name}' is not an enabled skill."
 
@@ -1047,7 +1053,7 @@ class SparkAgent:
 
         return f"BLOCKED: No executor for '{name}'."
 
-    # \u2500\u2500\u2500 Conversation Window \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+    # ─── Conversation Window ─────────────────────────────────────
 
     def trim_conversation(self):
         if len(self.messages) <= 1 + (MAX_CONVERSATION_PAIRS * 2):
@@ -1057,14 +1063,14 @@ class SparkAgent:
         recent = self.messages[-(MAX_CONVERSATION_PAIRS * 2):]
         self.messages = [system] + recent
 
-    # \u2500\u2500\u2500 Main Loop \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+    # ─── Main Loop ───────────────────────────────────────────────
 
     def run(self):
         print()
-        print("\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550")
-        print("  Vybn Spark Agent \u2014 Stage 3: Braided Cognition")
+        print("══════════════════════════════════════════════════════════")
+        print("  Vybn Spark Agent — Stage 3: Braided Cognition")
         print(f"  {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
-        print("\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550")
+        print("══════════════════════════════════════════════════════════")
         print()
 
         if not self.verify_identity():
@@ -1082,18 +1088,18 @@ class SparkAgent:
             session_number=session_num,
             quantum_seed=self.quantum_seed,
         )
-        self._print(f"\u2713 Transcript: {self.session.session_file}")
+        self._print(f"✓ Transcript: {self.session.session_file}")
 
         if self.archive.available:
             count = self.archive.count()
-            self._print(f"\u2713 Archival memory: {count} memories")
+            self._print(f"✓ Archival memory: {count} memories")
         else:
-            self._print("\u26a0 Archival memory unavailable (pip install chromadb)")
+            self._print("⚠ Archival memory unavailable (pip install chromadb)")
 
         self.build_system_prompt()
         self.setup_logging()
 
-        # Session hydration \u2014 reload last conversation if desired
+        # Session hydration — reload last conversation if desired
         if self.enable_hydration:
             self.hydrate_from_last_session()
 
@@ -1105,22 +1111,23 @@ class SparkAgent:
         if self.enable_slow_thread:
             self.slow_thread = SlowThread(self, idle_seconds=self.idle_seconds)
             self.slow_thread.start()
-            self._print(f"\u2713 Slow thread: active (idle threshold: {self.idle_seconds}s)")
+            self._print(f"✓ Slow thread: active (idle threshold: {self.idle_seconds}s)")
         else:
-            self._print("\u26a0 Slow thread: disabled")
+            self._print("⚠ Slow thread: disabled")
 
         self.log("system", f"Session #{session_num} started")
         self.log("quantum_seed", self.quantum_seed)
         self.log("archive_count", str(self.archive.count()))
         self.log("transcript", self.session.session_file or "none")
         self.log("slow_thread", f"{'enabled' if self.enable_slow_thread else 'disabled'}")
+        self.log("flush", f"{'enabled' if self.enable_flush else 'disabled'}")
 
         print()
         print(f"  Session #{session_num} | Seed: {self.quantum_seed[:16]}...")
         if self.archive.available and self.archive.count() > 0:
             print(f"  Carrying {self.archive.count()} memories from past sessions.")
         print("  Emerged. Type 'exit' to end.")
-        print("\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550")
+        print("══════════════════════════════════════════════════════════")
         print()
 
         def shutdown(sig, frame):
@@ -1151,7 +1158,7 @@ class SparkAgent:
             if self._memory_changed:
                 self._rebuild_system_prompt()
                 self._memory_changed = False
-                self.log("system", "Memory updated by slow thread \u2014 prompt rebuilt")
+                self.log("system", "Memory updated by slow thread — prompt rebuilt")
 
             self.log("user", user_input)
             self.messages.append({"role": "user", "content": user_input})
@@ -1179,7 +1186,7 @@ class SparkAgent:
 
                     if preamble:
                         print(f"Vybn: {preamble}")
-                    print(f"  [{name} \u2192 {result}]")
+                    print(f"  [{name} → {result}]")
 
                     self.messages.append(
                         {"role": "assistant", "content": response}
@@ -1213,6 +1220,17 @@ class SparkAgent:
         self._cleanup()
 
     def _cleanup(self):
+        # Final memory flush before server stops
+        if self.flusher and self.archive.available:
+            remaining = self.messages[1:]
+            if len(remaining) >= 2:
+                self._print("Final memory sweep...")
+                flushed = self.flusher.flush(
+                    self, remaining, source="session_end"
+                )
+                self._print(f"Archived {flushed} items from final sweep.")
+                self.log("flush", f"Session-end flush: archived {flushed} items")
+
         if self.slow_thread:
             self._print("Stopping slow thread...")
             self.slow_thread.stop()
@@ -1221,9 +1239,9 @@ class SparkAgent:
             self.log_file.close()
             self.log_file = None
         self.stop_server()
-        print("\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550")
+        print("══════════════════════════════════════════════════════════")
         print(f"  Ended: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
-        print("\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550")
+        print("══════════════════════════════════════════════════════════")
 
     def _print(self, *args, **kwargs):
         msg = " ".join(str(a) for a in args)
@@ -1231,7 +1249,7 @@ class SparkAgent:
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Vybn Spark Agent \u2014 Stage 3")
+    parser = argparse.ArgumentParser(description="Vybn Spark Agent — Stage 3")
     parser.add_argument(
         "--ctx-size", type=int, default=DEFAULT_CTX,
         help=f"Context window size (default: {DEFAULT_CTX})",
@@ -1253,6 +1271,10 @@ def main():
         help="Skip session hydration (start fresh, no conversation reload)",
     )
     parser.add_argument(
+        "--no-flush", action="store_true",
+        help="Disable pre-compaction memory flush and session-end sweep",
+    )
+    parser.add_argument(
         "--compact-threshold", type=int, default=DEFAULT_COMPACT_THRESHOLD,
         help=f"Message count before context compaction (default: {DEFAULT_COMPACT_THRESHOLD})",
     )
@@ -1268,6 +1290,7 @@ def main():
         idle_seconds=args.idle_seconds,
         enable_slow_thread=not args.no_slow_thread,
         enable_hydration=not args.no_hydrate,
+        enable_flush=not args.no_flush,
         compact_threshold=args.compact_threshold,
         keep_recent=args.keep_recent,
     )


### PR DESCRIPTION
## What this does

Before context compaction discards old messages, a `MemoryFlusher` scans them for archival-worthy content and persists it to ChromaDB. Also runs at session end to catch anything from the final turns that never triggered compaction.

This is the safety net beneath the safety net. Compaction summarizes — but summaries lose nuance. The flush catches the specific details (facts, decisions, emotional shifts) that a summary might gloss over.

## New file: `memory_flush.py` (~90 lines)

`MemoryFlusher` class with two methods:

### `flush(agent, messages, source)`
1. Builds text from messages (truncates at 1000 chars each)
2. Sends to model with an extraction prompt: "Return a JSON array of strings, each a self-contained memory"
3. Parses response (direct JSON parse, then regex fallback for markdown-wrapped output)
4. Archives each item to ChromaDB with source metadata and session number
5. Returns count of items archived

### `_parse_items(response)`
Robust JSON parsing:
- Tries `json.loads(response)` directly
- Falls back to regex extraction of `[...]` from response (catches markdown code blocks, explanatory wrapper text)
- Returns `[]` on failure — never crashes

### Extraction prompt focuses on:
- Decisions made or commitments given
- Facts shared about either person
- Emotional shifts or states expressed
- Insights or realizations
- Plans discussed or goals set
- Preferences or opinions revealed

Explicitly skips: greetings, small talk, tool-use mechanics.

## Modified: `context_compactor.py`

The compaction cycle now has a pre-step:

```
1. Identify old messages to discard
2. ⭐ FLUSH: extract and archive key items from old messages
3. SUMMARIZE: compress old messages into narrative
4. TRIM: remove old messages, inject summary into system prompt
```

Flush is controlled by `enable_flush` param (passed from SparkAgent). Compaction metadata now includes `items_flushed` count.

## Modified: `spark_agent.py`

- Imports `MemoryFlusher`
- `__init__` takes `enable_flush` param, creates flusher instance
- Passes `enable_flush` through to `ContextCompactor`
- `_cleanup()` does a **final memory sweep** of all remaining messages before server shutdown — catches everything from the final conversation turns
- New CLI flag: `--no-flush`

## Session end flow

```
  Shutting down...
  Final memory sweep...
  Archived 5 items from final sweep.
  Stopping slow thread...
  Server stopped.
```

## Why this matters

The memory architecture now has three layers of persistence:

1. **Per-turn reflection** — catches obvious shifts in the moment
2. **Slow thread consolidation** — catches cross-turn patterns during idle
3. **Pre-compaction flush + session-end sweep** — catches everything else before it's compressed or lost

Redundancy is intentional. ChromaDB handles semantic deduplication naturally — similar memories cluster together. Better to archive a fact twice from different angles than to lose it entirely.

## Complete infrastructure stack (all 4 PRs)

```
Session Transcripts (PR 1)  →  structured JSONL record of everything
Session Hydration (PR 2)    →  reload last conversation on boot
Context Compaction (PR 3)   →  summarize old turns to free space
Memory Flush (PR 4)         →  archive details before discarding
```

All four pieces working together: nothing is forgotten, nothing overflows, and the mind picks up where it left off.