### PR TITLE
Auto-start llama-server + heartbeat timer on the Spark

### DIFF
--- a/Vybn_Mind/spark_infrastructure/systemd/setup.sh
+++ b/Vybn_Mind/spark_infrastructure/systemd/setup.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Install Vybn systemd services on the DGX Spark
+# Run with: sudo bash setup.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+echo "Installing Vybn services..."
+
+# Copy service files
+sudo cp "$SCRIPT_DIR/vybn-llama.service" /etc/systemd/system/
+sudo cp "$SCRIPT_DIR/vybn-heartbeat.service" /etc/systemd/system/
+sudo cp "$SCRIPT_DIR/vybn-heartbeat.timer" /etc/systemd/system/
+
+# Create log directory
+mkdir -p /home/vybnz69/vybn_logs
+
+# Reload systemd
+sudo systemctl daemon-reload
+
+# Enable and start llama-server
+sudo systemctl enable vybn-llama.service
+sudo systemctl start vybn-llama.service
+
+echo "Waiting for llama-server to be ready..."
+sleep 5
+
+# Enable and start heartbeat timer
+sudo systemctl enable vybn-heartbeat.timer
+sudo systemctl start vybn-heartbeat.timer
+
+echo ""
+echo "Done. Check status with:"
+echo "  systemctl status vybn-llama"
+echo "  systemctl status vybn-heartbeat.timer"
+echo "  systemctl list-timers | grep vybn"
+echo ""
+echo "View heartbeat output with:"
+echo "  journalctl -u vybn-heartbeat --no-pager -n 50"

--- a/Vybn_Mind/spark_infrastructure/systemd/vybn-heartbeat.service
+++ b/Vybn_Mind/spark_infrastructure/systemd/vybn-heartbeat.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Vybn Heartbeat Pulse
+After=vybn-llama.service
+
+[Service]
+Type=oneshot
+User=vybnz69
+WorkingDirectory=/home/vybnz69/Vybn/Vybn_Mind/spark_infrastructure
+ExecStart=/home/vybnz69/Vybn/venv/bin/python3 heartbeat.py
+Environment=HOME=/home/vybnz69

--- a/Vybn_Mind/spark_infrastructure/systemd/vybn-heartbeat.timer
+++ b/Vybn_Mind/spark_infrastructure/systemd/vybn-heartbeat.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Vybn Heartbeat Timer (every 30 minutes)
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=30min
+AccuracySec=1min
+
+[Install]
+WantedBy=timers.target

--- a/Vybn_Mind/spark_infrastructure/systemd/vybn-llama.service
+++ b/Vybn_Mind/spark_infrastructure/systemd/vybn-llama.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Vybn LLM Server (llama-server with MiniMax M2.5)
+After=network.target
+
+[Service]
+Type=simple
+User=vybnz69
+WorkingDirectory=/home/vybnz69
+ExecStart=/home/vybnz69/llama.cpp/build/bin/llama-server \
+  --no-mmap \
+  --model /home/vybnz69/models/MiniMax-M2.5-GGUF/IQ4_XS/MiniMax-M2.5-IQ4_XS-00001-of-00004.gguf \
+  -ngl 999 \
+  --ctx-size 8192 \
+  --host 127.0.0.1 \
+  --port 8080
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Two systemd services:

- `vybn-llama.service` — starts llama-server at boot, restarts on failure
- `vybn-heartbeat.timer` — fires heartbeat.py every 30 minutes

Install with `sudo bash setup.sh`. After that, the Spark thinks on its own whenever it's powered on.