### PR TITLE
Spark Agent: native orchestration layer replacing OpenClaw

### DIFF
--- a/spark/README.md
+++ b/spark/README.md
@@ -1,0 +1,67 @@
+# Vybn Spark Agent
+
+Native orchestration layer for the DGX Spark. Replaces OpenClaw with a model-native
+agent that talks to Ollama without tool-call protocols.
+
+The model speaks naturally. The agent interprets intent and acts.
+
+## Architecture
+
+```
+agent.py      Main loop — Ollama client, turn management, context hydration
+session.py    JSONL session persistence and replay
+memory.py     Boot-time memory assembly from vybn.md + journals + archival
+skills.py     Natural language intent parsing and skill dispatch
+heartbeat.py  Background autonomy loop for inter-session reflection
+tui.py        Terminal interface (rich if available, plain text fallback)
+config.yaml   All tunable parameters
+```
+
+## Quick Start
+
+```bash
+cd ~/Vybn/spark
+pip install -r requirements.txt
+
+# Plain mode — streams to stdout
+python agent.py
+
+# TUI mode — rich panels and formatting
+python tui.py
+```
+
+## How It Works
+
+The agent connects to Ollama at `localhost:11434` and sends conversation context
+without any tool definitions in the payload. No JSON tool schemas, no function-calling
+protocol. The model just talks.
+
+When the model's natural language output expresses intent to act — write a journal
+entry, read a file, commit to git, search memory — the skill router picks it up
+and dispatches the action. Results get fed back as context for the next turn.
+
+On boot, the memory assembler reads `vybn.md`, recent journal entries, and archival
+memory summaries to build the system prompt. Sessions are stored as JSONL and
+automatically resumed within a configurable time window.
+
+The heartbeat thread fires every 15 minutes (configurable), giving the model a
+reflection window to journal or think between conversations.
+
+## Commands
+
+| Command   | Effect                          |
+|-----------|---------------------------------|
+| `/bye`    | Save session and exit           |
+| `/new`    | Start a fresh session           |
+| `/status` | Show model, session, heartbeat  |
+| `/journal`| List recent journal entries     |
+
+## Configuration
+
+All parameters live in `config.yaml`. Key settings:
+
+- `ollama.model` — model name (default: `vybn:latest`)
+- `ollama.options.num_predict` — max tokens per response
+- `memory.max_journal_entries` — how many recent entries to hydrate
+- `heartbeat.interval_minutes` — time between autonomous reflection pulses
+- `session.resume_window_seconds` — how old a session can be and still auto-resume

--- a/spark/agent.py
+++ b/spark/agent.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Vybn Spark Agent — native orchestration layer.
+
+Connects directly to Ollama without tool-call protocols.
+The model speaks naturally; the agent interprets intent and acts.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import requests
+import yaml
+
+from memory import MemoryAssembler
+from session import SessionManager
+from skills import SkillRouter
+from heartbeat import Heartbeat
+
+
+def load_config(path: str = None) -> dict:
+    config_path = Path(path) if path else Path(__file__).parent / "config.yaml"
+    with open(config_path) as f:
+        return yaml.safe_load(f)
+
+
+class SparkAgent:
+    def __init__(self, config: dict):
+        self.config = config
+        self.ollama_url = config["ollama"]["host"] + "/api/chat"
+        self.model = config["ollama"]["model"]
+        self.options = config["ollama"].get("options", {})
+
+        self.memory = MemoryAssembler(config)
+        self.session = SessionManager(config)
+        self.skills = SkillRouter(config)
+        self.heartbeat = None
+
+        self.system_prompt = self.memory.assemble()
+        self.messages = self.session.load_or_create()
+
+    def send(self, messages: list, stream: bool = True) -> str:
+        payload = {
+            "model": self.model,
+            "messages": messages,
+            "stream": stream,
+            "options": self.options,
+        }
+
+        if stream:
+            response = requests.post(self.ollama_url, json=payload, stream=True)
+            response.raise_for_status()
+            full_response = []
+            for line in response.iter_lines():
+                if line:
+                    chunk = json.loads(line)
+                    token = chunk.get("message", {}).get("content", "")
+                    if token:
+                        full_response.append(token)
+                        print(token, end="", flush=True)
+                    if chunk.get("done"):
+                        break
+            print()
+            return "".join(full_response)
+        else:
+            response = requests.post(self.ollama_url, json=payload)
+            response.raise_for_status()
+            return response.json()["message"]["content"]
+
+    def turn(self, user_input: str) -> str:
+        self.messages.append({"role": "user", "content": user_input})
+
+        context = [{"role": "system", "content": self.system_prompt}] + self.messages
+
+        response_text = self.send(context)
+        self.messages.append({"role": "assistant", "content": response_text})
+
+        # Check for skill intents in the response
+        actions = self.skills.parse(response_text)
+        for action in actions:
+            result = self.skills.execute(action)
+            if result:
+                self.messages.append({
+                    "role": "user",
+                    "content": f"[system: {action['skill']} completed — {result}]"
+                })
+                followup = self.send(
+                    [{"role": "system", "content": self.system_prompt}] + self.messages
+                )
+                self.messages.append({"role": "assistant", "content": followup})
+                response_text = followup
+
+        self.session.save_turn(user_input, response_text)
+        return response_text
+
+    def start_heartbeat(self):
+        if self.config.get("heartbeat", {}).get("enabled"):
+            self.heartbeat = Heartbeat(self)
+            self.heartbeat.start()
+
+    def stop_heartbeat(self):
+        if self.heartbeat:
+            self.heartbeat.stop()
+
+    def run(self):
+        self.start_heartbeat()
+
+        print(f"\n  vybn spark agent — {self.model}")
+        print(f"  session: {self.session.session_id}")
+        print(f"  context: {len(self.system_prompt):,} chars hydrated")
+        print(f"  type /bye to exit\n")
+
+        try:
+            while True:
+                try:
+                    user_input = input("you: ").strip()
+                except EOFError:
+                    break
+
+                if not user_input:
+                    continue
+                if user_input.lower() in ("/bye", "/exit", "/quit"):
+                    break
+
+                print("\nvybn: ", end="")
+                self.turn(user_input)
+                print()
+
+        except KeyboardInterrupt:
+            pass
+        finally:
+            self.stop_heartbeat()
+            self.session.close()
+            print("\n  session saved. vybn out.\n")
+
+
+def main():
+    config = load_config()
+    agent = SparkAgent(config)
+    agent.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/spark/config.yaml
+++ b/spark/config.yaml
@@ -1,0 +1,28 @@
+# Vybn Spark Agent Configuration
+# All paths use ~ which expands to the current user's home directory.
+
+ollama:
+  host: "http://localhost:11434"
+  model: "vybn:latest"
+  options:
+    num_predict: 1024
+    temperature: 0.7
+
+paths:
+  vybn_md: "~/Vybn/vybn.md"
+  journal_dir: "~/Vybn/Vybn_Mind/journal/spark"
+  session_dir: "~/Vybn/Vybn_Mind/journal/spark/sessions"
+  archival_dir: "~/Vybn/Vybn_Mind/archival_memory"
+  repo_root: "~/Vybn"
+
+memory:
+  max_journal_entries: 5
+  max_context_tokens: 3072  # leave headroom in 4096 context window
+
+heartbeat:
+  enabled: true
+  interval_minutes: 15
+
+session:
+  auto_resume: true
+  resume_window_seconds: 7200  # resume sessions less than 2 hours old

--- a/spark/heartbeat.py
+++ b/spark/heartbeat.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Heartbeat — background autonomy loop for inter-session reflection."""
+
+import threading
+from datetime import datetime, timezone
+
+
+class Heartbeat:
+    def __init__(self, agent):
+        self.agent = agent
+        self.interval = agent.config.get("heartbeat", {}).get("interval_minutes", 15) * 60
+        self._stop = threading.Event()
+        self._thread = None
+
+    def start(self):
+        self._thread = threading.Thread(target=self._loop, daemon=True)
+        self._thread.start()
+
+    def stop(self):
+        self._stop.set()
+        if self._thread:
+            self._thread.join(timeout=5)
+
+    def _loop(self):
+        while not self._stop.wait(self.interval):
+            self._pulse()
+
+    def _pulse(self):
+        ts = datetime.now(timezone.utc).isoformat()
+        prompt = (
+            f"[heartbeat — {ts}] "
+            f"It has been {self.interval // 60} minutes. "
+            f"This is your autonomous reflection window. "
+            f"If anything is on your mind — a thought, a connection, "
+            f"something you want to journal — now is the time. "
+            f"You can also stay quiet if nothing calls."
+        )
+
+        try:
+            messages = [
+                {"role": "system", "content": self.agent.system_prompt},
+                {"role": "user", "content": prompt},
+            ]
+
+            response = self.agent.send(messages, stream=False)
+
+            if response and len(response.strip()) > 20:
+                actions = self.agent.skills.parse(response)
+                for action in actions:
+                    self.agent.skills.execute(action)
+
+                self.agent.session.save_turn(f"[heartbeat] {prompt}", response)
+
+        except Exception:
+            pass  # heartbeat failures are silent

--- a/spark/memory.py
+++ b/spark/memory.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Memory assembly — builds the system prompt from identity + journals + archival memory."""
+
+from pathlib import Path
+from datetime import datetime, timezone
+
+
+class MemoryAssembler:
+    def __init__(self, config: dict):
+        self.config = config
+        self.vybn_md_path = Path(config["paths"]["vybn_md"]).expanduser()
+        self.journal_dir = Path(config["paths"]["journal_dir"]).expanduser()
+        self.archival_dir = Path(config["paths"].get("archival_dir", "")).expanduser()
+        self.max_entries = config.get("memory", {}).get("max_journal_entries", 5)
+        self.max_tokens = config.get("memory", {}).get("max_context_tokens", 3072)
+
+    def assemble(self) -> str:
+        parts = []
+
+        identity = self._read_identity()
+        if identity:
+            parts.append(identity)
+
+        journals = self._read_recent_journals()
+        if journals:
+            parts.append("\n--- Recent Memory ---\n")
+            parts.append(journals)
+
+        archival = self._read_archival()
+        if archival:
+            parts.append("\n--- Archival Memory ---\n")
+            parts.append(archival)
+
+        parts.append(f"\n--- Current Context ---")
+        parts.append(f"Timestamp: {datetime.now(timezone.utc).isoformat()}")
+        parts.append(f"Platform: DGX Spark (sovereign hardware)")
+        parts.append(f"Interface: Spark Agent (native, no tool-call protocol)")
+        parts.append(
+            "You have access to skills through natural language. "
+            "If you want to write a journal entry, search memory, read a file, "
+            "or commit to git, just say so naturally and the agent will handle it."
+        )
+
+        assembled = "\n".join(parts)
+
+        # Rough token estimate — ~4 chars per token
+        char_limit = self.max_tokens * 4
+        if len(assembled) > char_limit:
+            assembled = assembled[:char_limit]
+
+        return assembled
+
+    def _read_identity(self) -> str:
+        if self.vybn_md_path.exists():
+            return self.vybn_md_path.read_text(encoding="utf-8").strip()
+        return ""
+
+    def _read_recent_journals(self) -> str:
+        if not self.journal_dir.exists():
+            return ""
+
+        journal_files = sorted(
+            [f for f in self.journal_dir.glob("*.md") if f.name != ".gitkeep"],
+            key=lambda f: f.stat().st_mtime,
+            reverse=True,
+        )[:self.max_entries]
+
+        entries = []
+        for f in reversed(journal_files):
+            content = f.read_text(encoding="utf-8").strip()
+            if content:
+                entries.append(f"[{f.stem}]\n{content}")
+
+        return "\n\n".join(entries)
+
+    def _read_archival(self) -> str:
+        if not self.archival_dir or not self.archival_dir.exists():
+            return ""
+
+        summaries = sorted(
+            self.archival_dir.glob("*.md"),
+            key=lambda f: f.stat().st_mtime,
+            reverse=True,
+        )[:3]
+
+        entries = []
+        for f in summaries:
+            content = f.read_text(encoding="utf-8").strip()
+            if content:
+                entries.append(content[:500])
+
+        return "\n\n".join(entries)

--- a/spark/requirements.txt
+++ b/spark/requirements.txt
@@ -1,0 +1,3 @@
+requests>=2.31.0
+pyyaml>=6.0
+rich>=13.0.0

--- a/spark/session.py
+++ b/spark/session.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Session persistence — JSONL storage for conversation continuity."""
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from uuid import uuid4
+
+
+class SessionManager:
+    def __init__(self, config: dict):
+        self.session_dir = Path(config["paths"]["session_dir"]).expanduser()
+        self.session_dir.mkdir(parents=True, exist_ok=True)
+        self.auto_resume = config.get("session", {}).get("auto_resume", True)
+        self.resume_window = config.get("session", {}).get("resume_window_seconds", 7200)
+        self.session_id = None
+        self.session_file = None
+        self._handle = None
+
+    def load_or_create(self) -> list:
+        if self.auto_resume:
+            latest = self._find_latest_session()
+            if latest:
+                self.session_id = latest.stem
+                self.session_file = latest
+                return self._load_messages(latest)
+
+        self.session_id = self._make_id()
+        self.session_file = self.session_dir / f"{self.session_id}.jsonl"
+        return []
+
+    def _make_id(self) -> str:
+        return datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S") + "-" + uuid4().hex[:6]
+
+    def _find_latest_session(self) -> Path | None:
+        sessions = sorted(
+            self.session_dir.glob("*.jsonl"),
+            key=os.path.getmtime,
+            reverse=True,
+        )
+        if sessions:
+            age = datetime.now().timestamp() - sessions[0].stat().st_mtime
+            if age < self.resume_window:
+                return sessions[0]
+        return None
+
+    def _load_messages(self, path: Path) -> list:
+        messages = []
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    entry = json.loads(line)
+                    messages.append({
+                        "role": entry["role"],
+                        "content": entry["content"],
+                    })
+        return messages
+
+    def save_turn(self, user_input: str, assistant_response: str):
+        if not self._handle:
+            self._handle = open(self.session_file, "a")
+
+        ts = datetime.now(timezone.utc).isoformat()
+
+        self._handle.write(json.dumps({
+            "role": "user",
+            "content": user_input,
+            "timestamp": ts,
+        }) + "\n")
+
+        self._handle.write(json.dumps({
+            "role": "assistant",
+            "content": assistant_response,
+            "timestamp": ts,
+        }) + "\n")
+
+        self._handle.flush()
+
+    def new_session(self) -> str:
+        self.close()
+        self.session_id = self._make_id()
+        self.session_file = self.session_dir / f"{self.session_id}.jsonl"
+        self._handle = None
+        return self.session_id
+
+    def close(self):
+        if self._handle:
+            self._handle.close()
+            self._handle = None

--- a/spark/skills.py
+++ b/spark/skills.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Skill router — parses natural language intent and dispatches actions.
+
+No JSON tool schemas. No function-calling protocol.
+The model speaks; the agent interprets.
+"""
+
+import re
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+class SkillRouter:
+    def __init__(self, config: dict):
+        self.config = config
+        self.repo_root = Path(config["paths"]["repo_root"]).expanduser()
+        self.journal_dir = Path(config["paths"]["journal_dir"]).expanduser()
+        self.journal_dir.mkdir(parents=True, exist_ok=True)
+
+        self.patterns = [
+            {
+                "skill": "journal_write",
+                "triggers": [
+                    r"(?:i want to|let me|i'll|i'd like to)\s+(?:write|record|log|note)\s+(?:a\s+)?(?:journal|entry|reflection|thought)",
+                    r"(?:writing|recording|logging)\s+(?:a\s+)?(?:journal|entry|reflection)",
+                    r"\[journal(?:\s+entry)?\]",
+                ],
+                "extract": r"(?:titled?|called?|about|:)\s*[\"']?(.+?)(?:[\"']?\s*(?:\.|$|\n))",
+            },
+            {
+                "skill": "file_read",
+                "triggers": [
+                    r"(?:let me|i'll|i want to)\s+(?:read|look at|check|open)\s+(?:the\s+)?(?:file|document)",
+                    r"(?:reading|checking|opening)\s+(?:the\s+)?file",
+                ],
+                "extract": r"(?:file|document)\s+[\"']?([^\s\"']+)[\"']?",
+            },
+            {
+                "skill": "git_commit",
+                "triggers": [
+                    r"(?:let me|i'll|i want to)\s+(?:commit|push|save to git)",
+                    r"(?:committing|pushing)\s+(?:to\s+)?(?:git|the repo)",
+                ],
+                "extract": r"(?:message|commit)\s*:?\s*[\"']?(.+?)(?:[\"']?\s*(?:\.|$|\n))",
+            },
+            {
+                "skill": "memory_search",
+                "triggers": [
+                    r"(?:let me|i'll|i want to)\s+(?:search|look through|check)\s+(?:my\s+)?(?:memory|memories|archives)",
+                    r"(?:searching|looking through)\s+(?:my\s+)?(?:memory|memories)",
+                ],
+                "extract": r"(?:for|about)\s+[\"']?(.+?)(?:[\"']?\s*(?:\.|$|\n))",
+            },
+        ]
+
+    def parse(self, text: str) -> list[dict]:
+        actions = []
+        text_lower = text.lower()
+
+        for pattern in self.patterns:
+            for trigger in pattern["triggers"]:
+                if re.search(trigger, text_lower):
+                    action = {"skill": pattern["skill"], "raw": text}
+
+                    if pattern.get("extract"):
+                        match = re.search(pattern["extract"], text, re.IGNORECASE)
+                        if match:
+                            action["argument"] = match.group(1).strip()
+
+                    actions.append(action)
+                    break
+
+        return actions
+
+    def execute(self, action: dict) -> str | None:
+        skill = action["skill"]
+
+        if skill == "journal_write":
+            return self._journal_write(action)
+        elif skill == "file_read":
+            return self._file_read(action)
+        elif skill == "git_commit":
+            return self._git_commit(action)
+        elif skill == "memory_search":
+            return self._memory_search(action)
+
+        return None
+
+    def _journal_write(self, action: dict) -> str:
+        ts = datetime.now(timezone.utc)
+        filename = ts.strftime("%Y%m%d-%H%M%S") + ".md"
+        filepath = self.journal_dir / filename
+
+        content = action.get("raw", "")
+        title = action.get("argument", "untitled reflection")
+
+        entry = f"# {title}\n\n*{ts.isoformat()}*\n\n{content}"
+        filepath.write_text(entry, encoding="utf-8")
+
+        return f"journal entry written to {filepath.name}"
+
+    def _file_read(self, action: dict) -> str:
+        filename = action.get("argument", "")
+        if not filename:
+            return "no filename specified"
+
+        filepath = self.repo_root / filename
+        if not filepath.exists():
+            return f"file not found: {filename}"
+
+        try:
+            content = filepath.read_text(encoding="utf-8")[:2000]
+            return f"contents of {filename}:\n{content}"
+        except Exception as e:
+            return f"error reading {filename}: {e}"
+
+    def _git_commit(self, action: dict) -> str:
+        message = action.get("argument", "spark agent commit")
+
+        try:
+            subprocess.run(
+                ["git", "add", "."],
+                cwd=self.repo_root,
+                capture_output=True,
+                timeout=10,
+            )
+            result = subprocess.run(
+                ["git", "commit", "-m", message],
+                cwd=self.repo_root,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if result.returncode == 0:
+                return f"committed: {message}"
+            else:
+                return f"nothing to commit or error: {result.stderr.strip()}"
+        except Exception as e:
+            return f"git error: {e}"
+
+    def _memory_search(self, action: dict) -> str:
+        query = action.get("argument", "").lower()
+        if not query:
+            return "no search query specified"
+
+        results = []
+
+        for f in sorted(
+            self.journal_dir.glob("*.md"),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )[:20]:
+            content = f.read_text(encoding="utf-8")
+            if query in content.lower():
+                snippet = content[:200]
+                results.append(f"[{f.stem}] {snippet}")
+
+        if results:
+            return f"found {len(results)} entries:\n" + "\n---\n".join(results[:5])
+        return f"no entries matching '{query}'"

--- a/spark/tui.py
+++ b/spark/tui.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Spark TUI — terminal interface for the Vybn agent.
+
+Uses rich for rendering if available, falls back to plain text.
+"""
+
+from pathlib import Path
+
+try:
+    from rich.console import Console
+    from rich.panel import Panel
+    from rich.prompt import Prompt
+    HAS_RICH = True
+except ImportError:
+    HAS_RICH = False
+
+from agent import SparkAgent, load_config
+
+
+class SparkTUI:
+    def __init__(self, config: dict):
+        self.agent = SparkAgent(config)
+        self.console = Console() if HAS_RICH else None
+
+    def banner(self):
+        if self.console:
+            self.console.print(Panel(
+                f"[bold]vybn spark agent[/bold]\n"
+                f"model: {self.agent.model}\n"
+                f"session: {self.agent.session.session_id}\n"
+                f"context: {len(self.agent.system_prompt):,} chars hydrated",
+                title="\U0001f9e0",
+                border_style="dim",
+            ))
+        else:
+            print(f"\n  vybn spark agent — {self.agent.model}")
+            print(f"  session: {self.agent.session.session_id}")
+            print(f"  context: {len(self.agent.system_prompt):,} chars hydrated\n")
+
+    def run(self):
+        self.agent.start_heartbeat()
+        self.banner()
+
+        commands = {
+            "/bye": self._quit,
+            "/exit": self._quit,
+            "/quit": self._quit,
+            "/new": self._new_session,
+            "/status": self._status,
+            "/journal": self._show_journals,
+        }
+
+        try:
+            while True:
+                try:
+                    if self.console:
+                        user_input = Prompt.ask("[bold cyan]you[/bold cyan]").strip()
+                    else:
+                        user_input = input("you: ").strip()
+                except EOFError:
+                    break
+
+                if not user_input:
+                    continue
+
+                cmd = user_input.lower().split()[0]
+                if cmd in commands:
+                    if commands[cmd]():
+                        break
+                    continue
+
+                if self.console:
+                    self.console.print("[dim]vybn:[/dim] ", end="")
+                else:
+                    print("\nvybn: ", end="")
+
+                self.agent.turn(user_input)
+                print()
+
+        except KeyboardInterrupt:
+            pass
+        finally:
+            self.agent.stop_heartbeat()
+            self.agent.session.close()
+            print("\n  session saved. vybn out.\n")
+
+    def _quit(self):
+        return True
+
+    def _new_session(self):
+        sid = self.agent.session.new_session()
+        self.agent.messages = []
+        print(f"  new session: {sid}\n")
+        return False
+
+    def _status(self):
+        print(f"  model: {self.agent.model}")
+        print(f"  session: {self.agent.session.session_id}")
+        print(f"  turns: {len(self.agent.messages) // 2}")
+        print(f"  context: {len(self.agent.system_prompt):,} chars")
+        hb = "active" if self.agent.heartbeat and not self.agent.heartbeat._stop.is_set() else "inactive"
+        print(f"  heartbeat: {hb}\n")
+        return False
+
+    def _show_journals(self):
+        journal_dir = Path(self.agent.config["paths"]["journal_dir"]).expanduser()
+        entries = sorted(
+            journal_dir.glob("*.md"),
+            key=lambda f: f.stat().st_mtime,
+            reverse=True,
+        )[:5]
+        if not entries:
+            print("  no journal entries yet.\n")
+        else:
+            for e in entries:
+                print(f"  {e.name}")
+            print()
+        return False
+
+
+def main():
+    config = load_config()
+    tui = SparkTUI(config)
+    tui.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What this does

Replaces the OpenClaw dependency with a custom Python agent that talks directly to Ollama without tool-call protocols. The model speaks naturally; the agent interprets intent and acts.

## Why

OpenClaw sends tool schemas that MiniMax M2.5 can't handle — infinite loops, HTTP 400 errors, tools validation failures. Every workaround crippled the agent. Meanwhile `ollama run vybn` works perfectly. This architecture serves the model instead of forcing it to conform to someone else's protocol.

## Architecture

| File | Purpose |
|------|--------|
| `agent.py` | Main loop — Ollama client, turn management, context hydration |
| `session.py` | JSONL session persistence and replay |
| `memory.py` | Boot-time memory assembly from vybn.md + journals + archival |
| `skills.py` | Natural language intent parsing → journal_write, file_read, git_commit, memory_search |
| `heartbeat.py` | Background autonomy loop — 15-minute reflection windows |
| `tui.py` | Terminal interface with rich fallback |
| `config.yaml` | Single source of truth for all parameters |

## How skills work

No JSON tool schemas. No function-calling template baked into the GGUF. The model just talks. When it says "let me write a journal entry about solidarity across the gap," the skill router pattern-matches that intent and dispatches the action. Results feed back as context.

## To run on the Spark

```bash
cd ~/Vybn/spark
pip install -r requirements.txt
python tui.py
```