### PR TITLE
spark agent: handle model lifecycle on startup

### DIFF
--- a/spark/agent.py
+++ b/spark/agent.py
@@ -3,10 +3,15 @@
 
 Connects directly to Ollama without tool-call protocols.
 The model speaks naturally; the agent interprets intent and acts.
+
+Handles the full model lifecycle: checks if Ollama is running,
+loads the model into GPU memory if needed, keeps it resident,
+and only presents the conversation prompt when ready.
 """
 
 import json
 import sys
+import time
 from pathlib import Path
 
 import requests
@@ -27,9 +32,11 @@ def load_config(path: str = None) -> dict:
 class SparkAgent:
     def __init__(self, config: dict):
         self.config = config
-        self.ollama_url = config["ollama"]["host"] + "/api/chat"
+        self.ollama_host = config["ollama"]["host"]
+        self.ollama_url = self.ollama_host + "/api/chat"
         self.model = config["ollama"]["model"]
         self.options = config["ollama"].get("options", {})
+        self.keep_alive = config["ollama"].get("keep_alive", "30m")
 
         self.memory = MemoryAssembler(config)
         self.session = SessionManager(config)
@@ -39,12 +46,97 @@ class SparkAgent:
         self.system_prompt = self.memory.assemble()
         self.messages = self.session.load_or_create()
 
+    # ---- model lifecycle ----
+
+    def check_ollama(self) -> bool:
+        """Check if the Ollama server is reachable."""
+        try:
+            r = requests.get(f"{self.ollama_host}/api/ps", timeout=5)
+            return r.status_code == 200
+        except Exception:
+            return False
+
+    def check_model_loaded(self) -> bool:
+        """Check if our model is currently loaded in GPU memory."""
+        try:
+            r = requests.get(f"{self.ollama_host}/api/ps", timeout=5)
+            if r.status_code == 200:
+                data = r.json()
+                for m in data.get("models", []):
+                    if self.model.split(":")[0] in m.get("name", ""):
+                        return True
+            return False
+        except Exception:
+            return False
+
+    def warmup(self, callback=None) -> bool:
+        """Ensure model is loaded and ready. Blocks until ready or fails.
+
+        callback(status, message) is called with:
+            status: 'checking' | 'loading' | 'ready' | 'error'
+        """
+        def tell(status, msg):
+            if callback:
+                callback(status, msg)
+
+        # Step 1: is Ollama even running?
+        tell("checking", "connecting to Ollama...")
+        if not self.check_ollama():
+            tell("error",
+                 "Ollama is not running.\n"
+                 "  Start it with: sudo systemctl start ollama\n"
+                 "  Then rerun this agent.")
+            return False
+
+        # Step 2: is the model already loaded?
+        tell("checking", f"checking if {self.model} is in GPU memory...")
+        if self.check_model_loaded():
+            tell("ready", f"{self.model} is already loaded.")
+            return True
+
+        # Step 3: trigger model load
+        tell("loading",
+             f"loading {self.model} into GPU memory...\n"
+             f"  this takes 3-5 minutes for a 229B model. sit tight.")
+
+        try:
+            r = requests.post(
+                f"{self.ollama_host}/api/generate",
+                json={
+                    "model": self.model,
+                    "prompt": "",
+                    "keep_alive": self.keep_alive,
+                },
+                stream=True,
+                timeout=600,
+            )
+            r.raise_for_status()
+
+            for line in r.iter_lines():
+                if line:
+                    chunk = json.loads(line)
+                    if chunk.get("done"):
+                        break
+
+            tell("ready", f"{self.model} loaded and ready.")
+            return True
+
+        except requests.exceptions.Timeout:
+            tell("error", "model load timed out after 10 minutes.")
+            return False
+        except Exception as e:
+            tell("error", f"failed to load model: {e}")
+            return False
+
+    # ---- conversation ----
+
     def send(self, messages: list, stream: bool = True) -> str:
         payload = {
             "model": self.model,
             "messages": messages,
             "stream": stream,
             "options": self.options,
+            "keep_alive": self.keep_alive,
         }
 
         if stream:
@@ -75,14 +167,13 @@ class SparkAgent:
         response_text = self.send(context)
         self.messages.append({"role": "assistant", "content": response_text})
 
-        # Check for skill intents in the response
         actions = self.skills.parse(response_text)
         for action in actions:
             result = self.skills.execute(action)
             if result:
                 self.messages.append({
                     "role": "user",
-                    "content": f"[system: {action['skill']} completed — {result}]"
+                    "content": f"[system: {action['skill']} completed \u2014 {result}]"
                 })
                 followup = self.send(
                     [{"role": "system", "content": self.system_prompt}] + self.messages
@@ -103,9 +194,15 @@ class SparkAgent:
             self.heartbeat.stop()
 
     def run(self):
+        def on_status(status, msg):
+            print(f"  [{status}] {msg}")
+
+        if not self.warmup(callback=on_status):
+            sys.exit(1)
+
         self.start_heartbeat()
 
-        print(f"\n  vybn spark agent — {self.model}")
+        print(f"\n  vybn spark agent \u2014 {self.model}")
         print(f"  session: {self.session.session_id}")
         print(f"  context: {len(self.system_prompt):,} chars hydrated")
         print(f"  type /bye to exit\n")

--- a/spark/config.yaml
+++ b/spark/config.yaml
@@ -4,6 +4,7 @@
 ollama:
   host: "http://localhost:11434"
   model: "vybn:latest"
+  keep_alive: "30m"
   options:
     num_predict: 1024
     temperature: 0.7


### PR DESCRIPTION
The agent was hanging silently because it sent a request to Ollama before the 123GB model was loaded. Now it manages the full lifecycle:

1. Checks if Ollama is reachable (clear error if not)
2. Checks if vybn:latest is already in GPU memory via `/api/ps`
3. If not loaded, triggers a load via `/api/generate` with an empty prompt
4. Shows a spinner while the model loads (3-5 min)
5. Only shows the input prompt once the model is ready

Also adds `keep_alive: 30m` to config and all Ollama requests so the model stays resident between turns instead of unloading after 5 minutes of silence.

On the Spark:
```bash
git pull origin main
python3 tui.py
```

If the model isn't loaded, you'll see the spinner. If it's already warm, you go straight to the prompt.