### PR TITLE
fix: system prompt silently dropped — model had no identity

### DIFF
--- a/spark/config.yaml
+++ b/spark/config.yaml
@@ -6,8 +6,12 @@ ollama:
   model: "vybn:latest"
   keep_alive: "30m"
   options:
-    num_predict: 1024
+    num_ctx: 16384      # CRITICAL: default is 2048, which silently drops the system prompt
+    num_predict: 512     # keep responses focused; MiniMax emits <think> tokens too
     temperature: 0.7
+    stop:                # MiniMax M2.5 stop sequences
+      - "<\uff5cend\u2581of\u2581sentence\uff5c>"
+      - "<\uff5cUser\uff5c>"
 
 paths:
   vybn_md: "~/Vybn/vybn.md"
@@ -18,7 +22,7 @@ paths:
 
 memory:
   max_journal_entries: 5
-  max_context_tokens: 3072  # leave headroom in 4096 context window
+  max_context_tokens: 3072  # char budget for system prompt assembly
 
 heartbeat:
   enabled: true


### PR DESCRIPTION
## The problem

The model generated unrelated fiction (a choose-your-own-adventure about "Project Chrysalis") instead of responding as Vybn. It had no idea who it was.

## Root cause

Ollama's default context window is **2,048 tokens**. The system prompt assembled by `memory.py` was **12,288 characters** (≈ 3,072 tokens). When the system prompt exceeds the context window, [Ollama silently drops the entire system prompt](https://github.com/ollama/ollama/issues/6176#issuecomment-2378525437). The model received no identity document, no orientation, nothing — so it defaulted to creative fiction.

## Fix

**config.yaml:**
- `num_ctx: 16384` — context window large enough for system prompt + conversation + response
- `num_predict: 512` — prevents runaway generation (the model was writing thousands of tokens of fiction)
- Stop sequences for MiniMax M2.5

**memory.py:**
- Budget-aware assembly: calculates how many characters can fit in half the context window
- Prioritizes identity (vybn.md) over journals over archival memory
- Truncates gracefully instead of overflowing the context

After merge, on the Spark:
```bash
cd ~/Vybn && git pull
source ~/.venv/spark/bin/activate
cd spark
python3 tui.py
```

The model will need to reload with the new `num_ctx` (Ollama handles this automatically). First load may take an extra minute.