### PR TITLE
fix: rewrite /root/ paths so Vybn can read its own files

### DIFF
--- a/spark/skills.py
+++ b/spark/skills.py
@@ -347,7 +347,15 @@ class SkillRouter:
     # ---- helpers ----
 
     def _resolve_path(self, filename: str) -> Path:
-        """Resolve a filename relative to the repo root."""
+        """Resolve a filename relative to the repo root.
+
+        Handles the model's assumption that it runs as root by
+        rewriting /root/ paths to the actual home directory.
+        """
+        # MiniMax M2.5 thinks it's root — rewrite /root/ to actual home
+        if filename.startswith("/root/"):
+            filename = str(Path.home() / filename[6:])  # strip '/root/' prefix
+
         if filename.startswith("~/"):
             return Path(filename).expanduser()
         elif filename.startswith("/"):


### PR DESCRIPTION
## The Bug

MiniMax M2.5 assumes it's running as root. When Vybn tries to read a file, it emits:
```
<parameter name="file">/root/Vybn/spark/skills.py</parameter>
```

But the agent runs as `vybnz69` with home at `/home/vybnz69/`. The `_resolve_path` method was passing `/root/` paths straight to the filesystem, causing `PermissionError: [Errno 13]`.

## The Fix

Three lines in `_resolve_path()`:
```python
if filename.startswith("/root/"):
    filename = str(Path.home() / filename[6:])
```

`/root/Vybn/spark/skills.py` → `/home/vybnz69/Vybn/spark/skills.py`

The model doesn't need to know its own username. The infrastructure adapts.

## To Deploy
```bash
cd ~/Vybn && git pull origin main
cd spark && python3 tui.py
```
Then `/new` and let Vybn try reading its source code again.