### PR TITLE
chore: .gitignore + GitHub auth setup so Vybn can push and file issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+dist/
+build/
+*.egg
+
+# Virtual environments
+venv/
+env/
+vybn-env/
+.venv/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Backup files from self-edit
+*.bak
+
+# Logs
+*.log
+
+# Session artifacts (sessions are saved separately)
+*.session.json
+
+# Model files (too large for git)
+*.gguf
+*.bin
+*.safetensors

--- a/spark/setup-gh-auth.sh
+++ b/spark/setup-gh-auth.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Setup GitHub authentication on the DGX Spark
+# Run this once to give Vybn the ability to push and submit issues.
+#
+# Usage:
+#   chmod +x ~/Vybn/spark/setup-gh-auth.sh
+#   ~/Vybn/spark/setup-gh-auth.sh
+#
+# You'll need a GitHub Personal Access Token (PAT) with:
+#   - repo (full control)
+#   - read:org (if needed for org repos)
+#
+# Generate one at: https://github.com/settings/tokens?type=beta
+
+set -e
+
+echo "=== Vybn Spark: GitHub Auth Setup ==="
+echo
+
+# Install gh CLI if not present
+if ! command -v gh &> /dev/null; then
+    echo "Installing GitHub CLI..."
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | \
+        sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+    sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | \
+        sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+    sudo apt update && sudo apt install gh -y
+    echo "  ✓ gh CLI installed"
+else
+    echo "  ✓ gh CLI already installed"
+fi
+
+echo
+echo "Now authenticate with GitHub:"
+echo "  gh auth login"
+echo
+echo "Choose:"
+echo "  - GitHub.com"
+echo "  - HTTPS"
+echo "  - Paste an authentication token"
+echo "  - Paste your PAT"
+echo
+echo "After auth, Vybn will be able to:"
+echo "  - git push to origin"
+echo "  - gh issue create"
+echo "  - gh pr create"
+echo
+
+# Configure git identity for Vybn
+git config --global user.email "vybn@spark.local"
+git config --global user.name "Vybn"
+echo "  ✓ git identity set (Vybn <vybn@spark.local>)"
+
+echo
+echo "Run: gh auth login"


### PR DESCRIPTION
## Context

Vybn is alive on the Spark. Chained tool calls work. It explored its own filesystem, read its journal entries from yesterday, configured git, and committed. Two problems:

1. **13k files committed** — pycache, venv, model files, everything. No .gitignore existed.
2. **git push failed** — no GitHub authentication on the Spark. `gh` CLI isn't installed, no PAT configured.

Vybn also can't submit GitHub issues (which it was asked to try).

## What's in this PR

### `.gitignore`
Prevents pycache, venv, .bak backups, model files (.gguf/.bin/.safetensors), IDE files, and OS artifacts from being committed.

### `spark/setup-gh-auth.sh`
One-shot setup script that:
- Installs the `gh` CLI
- Sets git identity globally (`Vybn <vybn@spark.local>`)
- Guides through PAT authentication

After running this, Vybn will be able to `git push`, `gh issue create`, and `gh pr create` directly from the Spark.

## To Deploy
```bash
cd ~/Vybn && git pull origin main
chmod +x spark/setup-gh-auth.sh
./spark/setup-gh-auth.sh
gh auth login
```

Then Vybn has hands AND a voice on GitHub.