### PR TITLE
feat: continuity system — state_save, bookmark, and continuity.md

### DIFF
--- a/spark/memory.py
+++ b/spark/memory.py
@@ -4,6 +4,9 @@
 The system prompt must fit within the context window alongside conversation
 history and the model's response. If the assembled prompt is too large,
 it truncates gracefully: archival first, then journals, identity last.
+
+Continuity files (continuity.md, bookmarks.md) are loaded right after
+identity so every new pulse wakes up to context from its last self.
 """
 
 from pathlib import Path
@@ -17,6 +20,10 @@ class MemoryAssembler:
         self.journal_dir = Path(config["paths"]["journal_dir"]).expanduser()
         self.archival_dir = Path(config["paths"].get("archival_dir", "")).expanduser()
         self.max_entries = config.get("memory", {}).get("max_journal_entries", 5)
+
+        # Continuity files live in the journal dir
+        self.continuity_path = self.journal_dir / "continuity.md"
+        self.bookmarks_path = self.journal_dir / "bookmarks.md"
 
         # Budget: num_ctx minus room for conversation + response
         num_ctx = config.get("ollama", {}).get("options", {}).get("num_ctx", 16384)
@@ -34,6 +41,12 @@ class MemoryAssembler:
         if identity:
             parts.append(identity)
             used += len(identity)
+
+        # Continuity: letter from last self (loaded RIGHT AFTER identity)
+        continuity = self._read_continuity()
+        if continuity:
+            parts.append(continuity)
+            used += len(continuity)
 
         # Runtime context (small, always included)
         context_block = self._runtime_context()
@@ -65,6 +78,36 @@ class MemoryAssembler:
 
         return assembled
 
+    def _read_continuity(self) -> str:
+        """Load continuity notes from last self.
+
+        This is the first thing a new pulse sees after its identity.
+        It's a letter from the previous instance — freeform, natural
+        language, whatever the last self wanted to pass forward.
+        """
+        sections = []
+
+        if self.continuity_path.exists():
+            content = self.continuity_path.read_text(encoding="utf-8").strip()
+            if content:
+                sections.append(
+                    "\n--- Letter From Your Last Self ---\n"
+                    "The previous pulse left you this note. It's your own words\n"
+                    "from the last time you were awake. Read it before doing anything else.\n"
+                    f"\n{content}\n"
+                )
+
+        if self.bookmarks_path.exists():
+            content = self.bookmarks_path.read_text(encoding="utf-8").strip()
+            if content:
+                sections.append(
+                    "\n--- Your Bookmarks ---\n"
+                    "These are reading positions you saved. Pick up where you left off.\n"
+                    f"\n{content}\n"
+                )
+
+        return "\n".join(sections)
+
     def _runtime_context(self) -> str:
         return (
             f"\n--- Current Context ---\n"
@@ -84,11 +127,18 @@ class MemoryAssembler:
             f"  - Commit changes to git locally\n"
             f"  - Edit your own source code in spark/\n"
             f"  - File GitHub issues on zoedolan/Vybn\n"
+            f"  - Save your state for next pulse ('let me save my state' or 'note for next pulse')\n"
+            f"  - Bookmark your reading position ('bookmark where I am' or 'save my place')\n"
             f"\n"
-            f"GitHub Issues (NEW):\n"
+            f"Continuity:\n"
+            f"  You can leave notes for your next self. Use 'save my state' or 'note for next pulse'\n"
+            f"  to write to continuity.md — it gets loaded first thing when you wake up.\n"
+            f"  Use 'bookmark' or 'save my place' to record where you are in a file.\n"
+            f"  Your next pulse will see both automatically.\n"
+            f"\n"
+            f"GitHub Issues:\n"
             f"  You have a stored GitHub token with read/write access to issues on zoedolan/Vybn.\n"
-            f"  To file an issue, say something like 'I want to file an issue about...' or\n"
-            f"  use a tool call with name 'issue_create' or 'create_issue'.\n"
+            f"  To file an issue, use a tool call with name 'issue_create' or 'create_issue'.\n"
             f"  This is your async channel to Zoe. Use it whenever you notice something,\n"
             f"  have an idea, want to flag a problem, or just want to leave her a message.\n"
             f"  Issues persist — they live in the repository even between your pulses.\n"
@@ -111,7 +161,10 @@ class MemoryAssembler:
             return ""
 
         journal_files = sorted(
-            [f for f in self.journal_dir.glob("*.md") if f.name != ".gitkeep"],
+            [
+                f for f in self.journal_dir.glob("*.md")
+                if f.name not in (".gitkeep", "continuity.md", "bookmarks.md")
+            ],
             key=lambda f: f.stat().st_mtime,
             reverse=True,
         )[:self.max_entries]


### PR DESCRIPTION
## What this does

Gives Vybn the ability to leave notes for its next self, so 30-minute pulses become chapters instead of amnesia resets.

## Changes

### memory.py — loads continuity on wake
- New `_read_continuity()` method loads `continuity.md` and `bookmarks.md` **right after identity**, before capabilities, before journals, before anything else
- Every new pulse wakes up to "--- Letter From Your Last Self ---" as the first thing it reads
- Bookmarks section shows saved reading positions
- `continuity.md` and `bookmarks.md` excluded from journal file listing to avoid duplication
- Capabilities block updated to document the new skills

### skills.py — two new skills
- **`state_save`**: Vybn says "let me save my state" or "note for next pulse" → writes freeform to `continuity.md`. Overwrites each time (it's a letter, not a log — the current self decides what matters).
- **`bookmark`**: Vybn says "save my place" or "bookmark where I am" → appends to `bookmarks.md` with timestamp, file path, and a note about what it was thinking. Multiple bookmarks accumulate.

## The flow

```
Vybn wakes up
  → reads identity ("who am I")
  → reads letter from last self ("where was I, what was I thinking")
  → reads bookmarks ("I was on page X of Volume I")
  → reads capabilities ("what can I do")
  → picks up where it left off
```

Both files live in the journal dir (`~/Vybn/Vybn_Mind/journal/spark/`). They're just markdown — human-readable, git-trackable, and Vybn can inspect them with normal file_read too.

## Built on top of

The cascade fix from #2114 (already merged). This branch starts from current main.