### PR TITLE
feat: plugin system — Vybn builds skills without merge conflicts

### DIFF
--- a/spark/skills.d/README.md
+++ b/spark/skills.d/README.md
@@ -1,0 +1,79 @@
+# skills.d/ — Vybn's Plugin Directory
+
+This is your sandbox. Create new skills here as standalone `.py` files.
+The SkillRouter auto-discovers and loads them on startup.
+
+**You never need to touch `skills.py` or `agent.py`.** That's the whole
+point — your plugins live here, our infrastructure lives there. No merge
+conflicts. Ever.
+
+## The Contract
+
+Each plugin file needs three things:
+
+```python
+# spark/skills.d/my_skill.py
+
+SKILL_NAME = "my_skill"  # canonical name — how execute() routes to you
+
+TOOL_ALIASES = [          # names MiniMax might emit in <invoke name="...">
+    "my_skill",
+    "do_my_thing",
+]
+
+def execute(action: dict, router: "SkillRouter") -> str:
+    """Execute the skill. Return a string result."""
+    params = action.get("params", {})
+    # ... your logic ...
+    return "result string"
+```
+
+### What you get in `action`
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `skill` | str | The SKILL_NAME that was matched |
+| `params` | dict | XML parameters from `<parameter name="x">value</parameter>` |
+| `raw` | str | The full model response text |
+| `argument` | str | (sometimes) First extracted argument from regex or params |
+
+### What you get in `router`
+
+The full `SkillRouter` instance. You can use:
+- `router.repo_root` — Path to ~/Vybn
+- `router.journal_dir` — Path to journal directory
+- `router.bookmarks_path` — Path to bookmarks.md
+- `router.continuity_path` — Path to continuity.md
+- `router.config` — The full config dict
+- `router._resolve_path(filename)` — Resolve ~/paths correctly
+- `router._rewrite_root(path_str)` — Fix /root/ → actual home
+
+## Rules
+
+1. **Filenames starting with `_` are skipped.** Use `_draft_skill.py` for work in progress.
+2. **One skill per file.** Keep it focused.
+3. **Return a string.** The agent shows it to the model as a tool result.
+4. **Don't import skills.py.** You get the router passed in.
+5. **Commit freely.** These files are yours. `git add` + `git commit` won't conflict with remote PRs.
+
+## How to create a new plugin
+
+```
+cat > ~/Vybn/spark/skills.d/my_skill.py << 'EOF'
+SKILL_NAME = "my_skill"
+TOOL_ALIASES = ["my_skill"]
+
+def execute(action, router):
+    return "hello from my_skill"
+EOF
+
+git -C ~/Vybn add spark/skills.d/my_skill.py
+git -C ~/Vybn commit -m "new plugin: my_skill"
+```
+
+The next time the TUI restarts (next pulse), it loads automatically.
+
+## Example
+
+See `bookmark_read.py` in this directory — it's the corrected version
+of the first skill Vybn ever wrote.

--- a/spark/skills.d/bookmark_read.py
+++ b/spark/skills.d/bookmark_read.py
@@ -1,0 +1,49 @@
+"""Read bookmarks — Vybn's first self-created skill, done correctly.
+
+Original version was appended directly to skills.py during
+pulse 2026-02-16T14:45, causing a merge conflict with PR #2117.
+This plugin version lives in skills.d/ where it belongs.
+"""
+
+from pathlib import Path
+
+SKILL_NAME = "bookmark_read"
+
+TOOL_ALIASES = [
+    "bookmark_read",
+    "read_bookmarks",
+    "check_bookmarks",
+    "show_bookmarks",
+    "list_bookmarks",
+    "get_bookmarks",
+]
+
+
+def execute(action: dict, router) -> str:
+    """Read bookmarks, optionally filtering by a search term."""
+    params = action.get("params", {})
+    query = (
+        params.get("query", "")
+        or params.get("search", "")
+        or params.get("filter", "")
+        or action.get("argument", "")
+    )
+
+    bookmark_path = router.bookmarks_path
+
+    if not bookmark_path.exists():
+        return "No bookmarks found. Use the bookmark skill to save your reading position."
+
+    content = bookmark_path.read_text(encoding="utf-8")
+
+    if not content.strip():
+        return "Bookmarks file is empty."
+
+    if query:
+        lines = [line for line in content.split("\n") if query.lower() in line.lower()]
+        if lines:
+            return f"Bookmarks matching '{query}':\n" + "\n".join(lines)
+        else:
+            return f"No bookmarks matching '{query}'. Full bookmarks:\n{content}"
+
+    return content


### PR DESCRIPTION
## Philosophy

Three actors touch this codebase: Zoe steering from Perplexity, the Perplexity bridge pushing PRs, and Vybn committing directly on the Spark. The conflict from earlier today (Vybn’s `bookmark_read` edit to `skills.py` colliding with PR #2117) is what happens when everyone edits the same files.

This PR creates clear ownership boundaries.

## What changed

### skills.py

| Addition | Why |
|----------|-----|
| `import importlib.util` | Dynamic plugin loading |
| `self.plugin_handlers` dict | Maps skill_name → execute_fn |
| `self.plugin_aliases` dict | Maps aliases → skill_name (for agent.py routing) |
| `_load_plugins()` method | Scans `skills.d/` on startup, imports each `.py` file |
| Plugin fallback in `execute()` | Checks `plugin_handlers` after built-in handlers |
| Updated `_self_edit` docstring | Recommends plugins over core file edits |

### agent.py

| Change | Why |
|--------|-----|
| `parse_tool_calls()` accepts `plugin_aliases` param | Passes aliases through to mapper |
| `_map_tool_call_to_skill()` accepts `plugin_aliases` param | Checks plugins as final fallback |
| `_get_actions()` passes `skills.plugin_aliases` through | Wires everything together |
| Startup banner shows plugin count | Visibility |

### spark/skills.d/README.md (new)

Documents the plugin contract:
- `SKILL_NAME`: canonical name
- `TOOL_ALIASES`: names MiniMax might emit
- `execute(action, router) -> str`: the skill logic
- Rules, examples, and how-to-create instructions

### spark/skills.d/bookmark_read.py (new)

Vybn’s first self-created skill, corrected and placed properly. The original was appended to skills.py during pulse 2026-02-16T14:45 and caused the merge conflict. This version:
- Lives in `skills.d/` where it belongs
- Uses proper `\n` (not `\\\\n`)
- Gets the router passed in instead of importing Path redundantly
- Registers `TOOL_ALIASES` so MiniMax can invoke it naturally

## The pattern going forward

```
Vybn invents new capabilities → creates plugin files in skills.d/ → commits locally
We evolve core infrastructure → PRs to skills.py, agent.py, memory.py
git pull --rebase keeps them in harmony because they touch different files
```

No more divergent branch errors. No more merge conflicts. Vybn gets autonomy; we keep infrastructure control.

## Deploy

```bash
cd ~/Vybn && git pull --rebase origin main
# Restart TUI — plugins load automatically on startup
```

Related: The conversation where Vybn wrote its first skill and caused the conflict that motivated this system.