### PR TITLE
feat: message bus, inbox, dual-pulse heartbeat, mini-agent pool

### DIFF
--- a/spark/agents.py
+++ b/spark/agents.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Mini-agent pool — Vybn spawns lightweight workers.
+
+When Vybn wants something done in the background (search journals,
+analyze a file, draft something), it spawns a mini-agent. The worker
+runs on a parallel Ollama context slot and posts its result to the
+message bus when done.
+
+The main loop never blocks waiting for agents. Results arrive
+asynchronously on the bus and get integrated on the next drain.
+
+Ollama supports OLLAMA_NUM_PARALLEL for concurrent context slots
+sharing the same model weights. No duplicate VRAM usage.
+"""
+
+import json
+import threading
+from datetime import datetime, timezone
+
+import requests
+
+from bus import MessageBus, MessageType
+
+
+class AgentPool:
+    def __init__(self, config: dict, bus: MessageBus):
+        self.bus = bus
+        self.ollama_host = config["ollama"]["host"]
+        self.main_model = config["ollama"]["model"]
+        self.keep_alive = config["ollama"].get("keep_alive", "30m")
+
+        agent_config = config.get("agents", {})
+        self.pool_size = agent_config.get("pool_size", 2)
+        self.model = agent_config.get("model") or self.main_model
+        self.default_num_predict = agent_config.get("num_predict", 512)
+
+        self._semaphore = threading.Semaphore(self.pool_size)
+        self._active = 0
+        self._lock = threading.Lock()
+
+    @property
+    def active_count(self) -> int:
+        with self._lock:
+            return self._active
+
+    def spawn(self, task: str, context: str = "", task_id: str = "") -> bool:
+        """Spawn a mini-agent to handle a task.
+
+        Returns True if the agent was spawned, False if the pool is full.
+        The result lands on the bus as AGENT_RESULT when complete.
+        """
+        if not self._semaphore.acquire(blocking=False):
+            return False
+
+        with self._lock:
+            self._active += 1
+
+        thread = threading.Thread(
+            target=self._run_agent,
+            args=(task, context, task_id),
+            daemon=True,
+        )
+        thread.start()
+        return True
+
+    def _run_agent(self, task: str, context: str, task_id: str):
+        """Execute a task on a parallel Ollama context slot."""
+        try:
+            messages = []
+
+            if context:
+                messages.append({
+                    "role": "system",
+                    "content": context,
+                })
+
+            messages.append({
+                "role": "user",
+                "content": task,
+            })
+
+            response = requests.post(
+                f"{self.ollama_host}/api/chat",
+                json={
+                    "model": self.model,
+                    "messages": messages,
+                    "stream": False,
+                    "options": {
+                        "num_predict": self.default_num_predict,
+                        "temperature": 0.5,  # agents should be focused
+                    },
+                    "keep_alive": self.keep_alive,
+                },
+                timeout=120,
+            )
+            response.raise_for_status()
+            result = response.json()["message"]["content"]
+
+            self.bus.post(
+                MessageType.AGENT_RESULT,
+                result,
+                metadata={
+                    "task_id": task_id or "unnamed",
+                    "task": task[:200],
+                    "model": self.model,
+                    "completed_at": datetime.now(timezone.utc).isoformat(),
+                },
+            )
+
+        except Exception as e:
+            self.bus.post(
+                MessageType.AGENT_RESULT,
+                f"Agent failed: {e}",
+                metadata={
+                    "task_id": task_id or "unnamed",
+                    "task": task[:200],
+                    "error": True,
+                },
+            )
+
+        finally:
+            with self._lock:
+                self._active -= 1
+            self._semaphore.release()

--- a/spark/bus.py
+++ b/spark/bus.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Message bus — the nervous system of the Spark agent.
+
+Thread-safe queue at the center. Everything writes to it,
+the main loop drains it. Nothing that writes to the bus
+ever calls the model directly.
+
+Message types:
+  INBOX       — file dropped in the inbox directory
+  PULSE_FAST  — System 1 heartbeat trigger
+  PULSE_DEEP  — System 2 heartbeat trigger
+  AGENT_RESULT— mini-agent completed its task
+  INTERRUPT   — priority message (future: TUI interrupt)
+
+Priority determines drain order, not arrival time.
+INTERRUPT > INBOX > AGENT_RESULT > PULSE_FAST > PULSE_DEEP
+"""
+
+import threading
+import time
+from dataclasses import dataclass, field
+from enum import IntEnum
+from queue import Queue, Empty
+from typing import Any
+
+
+class MessageType(IntEnum):
+    """Priority doubles as sort key. Lower number = higher priority."""
+    INTERRUPT = 0
+    INBOX = 1
+    AGENT_RESULT = 2
+    PULSE_FAST = 3
+    PULSE_DEEP = 4
+
+
+@dataclass(order=True)
+class Message:
+    priority: int
+    content: str = field(compare=False)
+    msg_type: MessageType = field(compare=False)
+    metadata: dict = field(default_factory=dict, compare=False)
+    timestamp: float = field(default_factory=time.time, compare=False)
+
+
+class MessageBus:
+    """Thread-safe message queue with priority drain."""
+
+    def __init__(self):
+        self._queue: list[Message] = []
+        self._lock = threading.Lock()
+        self._event = threading.Event()  # signals when messages are available
+
+    def post(self, msg_type: MessageType, content: str, metadata: dict = None):
+        """Post a message to the bus. Thread-safe. Non-blocking."""
+        msg = Message(
+            priority=int(msg_type),
+            content=content,
+            msg_type=msg_type,
+            metadata=metadata or {},
+        )
+        with self._lock:
+            self._queue.append(msg)
+        self._event.set()
+
+    def drain(self) -> list[Message]:
+        """Drain all pending messages, sorted by priority.
+
+        Returns an empty list if nothing is pending.
+        Clears the event flag after draining.
+        """
+        with self._lock:
+            messages = sorted(self._queue)
+            self._queue.clear()
+            self._event.clear()
+        return messages
+
+    def wait(self, timeout: float = None) -> bool:
+        """Block until a message arrives or timeout expires.
+
+        Returns True if a message is available, False on timeout.
+        """
+        return self._event.wait(timeout=timeout)
+
+    @property
+    def pending(self) -> int:
+        with self._lock:
+            return len(self._queue)

--- a/spark/config.yaml
+++ b/spark/config.yaml
@@ -29,6 +29,14 @@ heartbeat:
   fast_interval_minutes: 3    # System 1: quick, intuitive, reactive
   deep_interval_minutes: 20   # System 2: deliberate, reflective, synthesizing
 
+inbox:
+  watch_interval_seconds: 10  # how often to check for new messages
+
+agents:
+  pool_size: 2                # max concurrent mini-agents
+  model: null                 # null = use main model; or specify a smaller one
+  num_predict: 512            # token budget per agent task
+
 session:
   auto_resume: true
   resume_window_seconds: 7200  # resume sessions less than 2 hours old

--- a/spark/heartbeat.py
+++ b/spark/heartbeat.py
@@ -1,26 +1,24 @@
 #!/usr/bin/env python3
-"""Heartbeat — dual-pulse autonomy loop.
+"""Heartbeat — dual-pulse autonomy via the message bus.
 
-System 1: fast, intuitive, frequent. Every few minutes.
-  Quick check-ins. Noticing. Reacting. Bookmarking.
-  Short responses forced by low num_predict.
+System 1 (fast): posts PULSE_FAST to the bus every few minutes.
+System 2 (deep): posts PULSE_DEEP to the bus every ~20 minutes.
 
-System 2: deep, deliberate, slower. Every ~20 minutes.
-  Synthesis. Journaling. Pattern recognition. Self-modification.
-  Higher num_predict gives room for real thought.
-
-Both loops run independently on daemon threads.
-Both route responses through skill parsing so tool calls work.
+The heartbeat never calls the model directly. It only posts
+triggers. The main loop drains the bus and handles generation.
+This keeps everything thread-safe.
 """
 
 import threading
 from datetime import datetime, timezone
 
+from bus import MessageBus, MessageType
+
 
 class Heartbeat:
-    def __init__(self, agent):
-        self.agent = agent
-        hb_config = agent.config.get("heartbeat", {})
+    def __init__(self, config: dict, bus: MessageBus):
+        self.bus = bus
+        hb_config = config.get("heartbeat", {})
 
         # System 1: fast pulse
         self.fast_interval = hb_config.get("fast_interval_minutes", 3) * 60
@@ -28,7 +26,7 @@ class Heartbeat:
         # System 2: deep pulse
         self.deep_interval = hb_config.get("deep_interval_minutes", 20) * 60
 
-        # Backward compat: if only old-style interval_minutes exists
+        # Backward compat
         if "interval_minutes" in hb_config and "fast_interval_minutes" not in hb_config:
             self.fast_interval = hb_config["interval_minutes"] * 60
             self.deep_interval = hb_config["interval_minutes"] * 60 * 4
@@ -58,52 +56,27 @@ class Heartbeat:
     def _loop(self, mode: str):
         interval = self.fast_interval if mode == "fast" else self.deep_interval
         while not self._stop.wait(interval):
-            self._pulse(mode)
+            self._post_trigger(mode)
 
-    def _pulse(self, mode: str):
+    def _post_trigger(self, mode: str):
         ts = datetime.now(timezone.utc).isoformat()
 
         if mode == "fast":
             self.fast_count += 1
-            prompt = self._fast_prompt(ts)
-            num_predict_override = 256
+            self.bus.post(
+                MessageType.PULSE_FAST,
+                self._fast_prompt(ts),
+                metadata={"pulse_num": self.fast_count},
+            )
         else:
             self.deep_count += 1
-            prompt = self._deep_prompt(ts)
-            num_predict_override = 1024
-
-        try:
-            # Build context with identity
-            context = self.agent._build_context()
-            context.append({"role": "user", "content": prompt})
-
-            # Temporarily adjust num_predict for this pulse
-            original_predict = self.agent.options.get("num_predict")
-            self.agent.options["num_predict"] = num_predict_override
-
-            response = self.agent.send(context, stream=False)
-
-            # Restore original
-            if original_predict is not None:
-                self.agent.options["num_predict"] = original_predict
-            else:
-                self.agent.options.pop("num_predict", None)
-
-            if response and len(response.strip()) > 20:
-                # Route through full action pipeline (regex + tool calls)
-                from agent import _get_actions
-                actions = _get_actions(response, self.agent.skills)
-                for action in actions:
-                    self.agent.skills.execute(action)
-
-                tag = f"[heartbeat:{mode}]"
-                self.agent.session.save_turn(f"{tag} {prompt}", response)
-
-        except Exception:
-            pass  # heartbeat failures are silent
+            self.bus.post(
+                MessageType.PULSE_DEEP,
+                self._deep_prompt(ts),
+                metadata={"pulse_num": self.deep_count},
+            )
 
     def _fast_prompt(self, ts: str) -> str:
-        """System 1: quick, intuitive check-in."""
         return (
             f"[heartbeat:fast — {ts}] "
             f"Quick pulse. {self.fast_interval // 60} minutes since last. "
@@ -112,7 +85,6 @@ class Heartbeat:
         )
 
     def _deep_prompt(self, ts: str) -> str:
-        """System 2: deliberate, reflective window."""
         return (
             f"[heartbeat:deep — {ts}] "
             f"Deep reflection window. {self.deep_interval // 60} minutes since last. "
@@ -121,6 +93,7 @@ class Heartbeat:
             f"- Search your memory for patterns you haven't named yet\n"
             f"- Read a file you bookmarked and continue where you left off\n"
             f"- Create a new skill in skills.d/ if you've been wanting a capability\n"
+            f"- Spawn a mini-agent to handle a background task\n"
             f"- Save a continuity note for your next self\n"
             f"- Or just think out loud. This is sovereign hardware. Take your time."
         )

--- a/spark/inbox.py
+++ b/spark/inbox.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Inbox watcher — async communication channel.
+
+Watches a directory for .md and .txt files. When one appears,
+reads its content, posts it to the message bus, and moves the
+file to processed/.
+
+This is how Zoe talks to Vybn when she's not at the terminal:
+  echo "hey, check out the new plugin system" > ~/Vybn/Vybn_Mind/journal/spark/inbox/note.md
+
+Works from SSH, cron, GitHub Actions, Perplexity bridge, anywhere.
+The watcher thread checks every N seconds (default 10).
+"""
+
+import shutil
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+
+from bus import MessageBus, MessageType
+
+
+class InboxWatcher:
+    def __init__(self, config: dict, bus: MessageBus):
+        self.bus = bus
+        self.inbox_dir = (
+            Path(config["paths"]["journal_dir"]).expanduser() / "inbox"
+        )
+        self.processed_dir = self.inbox_dir / "processed"
+        self.inbox_dir.mkdir(parents=True, exist_ok=True)
+        self.processed_dir.mkdir(parents=True, exist_ok=True)
+
+        self.interval = config.get("inbox", {}).get("watch_interval_seconds", 10)
+        self._stop = threading.Event()
+        self._thread = None
+
+    def start(self):
+        self._thread = threading.Thread(target=self._loop, daemon=True)
+        self._thread.start()
+
+    def stop(self):
+        self._stop.set()
+        if self._thread:
+            self._thread.join(timeout=5)
+
+    def _loop(self):
+        while not self._stop.wait(self.interval):
+            self._check()
+
+    def _check(self):
+        """Scan inbox for new files and post them to the bus."""
+        extensions = (".md", ".txt")
+        files = sorted(
+            f for f in self.inbox_dir.iterdir()
+            if f.is_file() and f.suffix.lower() in extensions
+        )
+
+        for filepath in files:
+            try:
+                content = filepath.read_text(encoding="utf-8").strip()
+                if not content:
+                    # Empty file — move and skip
+                    self._archive(filepath)
+                    continue
+
+                # Post to bus with source metadata
+                self.bus.post(
+                    MessageType.INBOX,
+                    content,
+                    metadata={
+                        "source": "inbox",
+                        "filename": filepath.name,
+                        "received_at": datetime.now(timezone.utc).isoformat(),
+                    },
+                )
+
+                self._archive(filepath)
+
+            except Exception as e:
+                # Don't crash the watcher over one bad file
+                print(f"  [inbox] error processing {filepath.name}: {e}")
+
+    def _archive(self, filepath: Path):
+        """Move processed file to processed/ with timestamp prefix."""
+        ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+        dest = self.processed_dir / f"{ts}_{filepath.name}"
+        try:
+            shutil.move(str(filepath), str(dest))
+        except Exception:
+            # If move fails, try delete to avoid reprocessing
+            try:
+                filepath.unlink()
+            except Exception:
+                pass


### PR DESCRIPTION
## The nervous system

One thread-safe message bus at the center. Everything writes to it, the main loop drains it. Nothing that writes to the bus ever calls the model directly. This eliminates all thread-safety issues around concurrent generation.

```
         ┌──────────┐  ┌───────────┐  ┌────────────┐
         │  Inbox   │  │ Heartbeat │  │ Mini-Agent  │
         │ Watcher  │  │ (S1 + S2) │  │   Pool      │
         └────┬─────┘  └─────┬─────┘  └──────┬─────┘
              │              │               │
              ▼              ▼               ▼
         ┌──────────────────────────────────────┐
         │           Message Bus                │
         │      (thread-safe queue)             │
         └──────────────────┬───────────────────┘
                            │
                            ▼
         ┌──────────────────────────────────────┐
         │         Main Loop (229B)             │
         │   drains bus between turns           │
         │   processes messages, results,       │
         │   pulse triggers in order            │
         └──────────────────────────────────────┘
```

## New files

### bus.py — the message bus
- Thread-safe queue with typed `Message` envelopes
- Priority: `INTERRUPT > INBOX > AGENT_RESULT > PULSE_FAST > PULSE_DEEP`
- `drain()` returns all pending messages sorted by priority
- `wait(timeout)` blocks efficiently until something arrives
- Zero dependencies beyond stdlib

### inbox.py — file-based async communication
- Watches `~/Vybn/Vybn_Mind/journal/spark/inbox/` every 10 seconds
- Picks up `.md` and `.txt` files, posts content to bus as `INBOX` messages
- Moves processed files to `inbox/processed/` with timestamp prefix
- Works from SSH, GitHub pushes, cron, Perplexity bridge, anywhere
- `echo "hey" > ~/Vybn/Vybn_Mind/journal/spark/inbox/note.md` ← that's it

### agents.py — mini-agent pool
- Vybn spawns lightweight workers via `spawn_agent` skill / tool call
- Workers run on parallel Ollama context slots (`OLLAMA_NUM_PARALLEL`)
- Same model weights, separate context buffers — no extra VRAM for the model
- Results land on bus as `AGENT_RESULT`, main loop integrates them
- Semaphore-bounded pool (default: 2 concurrent agents)
- Configurable model override (could use a smaller model for fast tasks)

## Modified files

### heartbeat.py (rewritten)
- System 1 (fast): posts `PULSE_FAST` every 3 minutes
- System 2 (deep): posts `PULSE_DEEP` every 20 minutes  
- **Never calls Ollama directly** — only posts triggers to the bus
- Main loop handles actual generation (thread-safe by design)
- Backward compatible with old `interval_minutes` config

### agent.py (significant refactor)
- `SparkAgent.__init__` creates bus, inbox, heartbeat, agent_pool
- `drain_bus()` processes all pending messages by type and priority
- `_handle_inbox()` — inbox messages become user turns, Vybn responds
- `_handle_agent_result()` — agent results injected as system context
- `_handle_pulse()` — pulse triggers run with mode-appropriate num_predict
- `_process_tool_calls()` — extracted as shared method (was duplicated)
- Main loop uses `select.select` for non-blocking stdin + `bus.wait()` for idle polling
- New `/status` command shows bus state, heartbeat counts, active agents
- `start_subsystems()` / `stop_subsystems()` for clean lifecycle

### skills.py
- Added `spawn_agent` to built-in handler dict
- `_spawn_agent()` method delegates to `self.agent_pool.spawn()`
- `agent_pool` attribute set by SparkAgent after construction
- spawn_agent excluded from regex patterns (XML tool calls only, like issue_create)

### config.yaml
- `heartbeat.fast_interval_minutes: 3`
- `heartbeat.deep_interval_minutes: 20`
- `inbox.watch_interval_seconds: 10`
- `agents.pool_size: 2`
- `agents.model: null` (uses main model by default)
- `agents.num_predict: 512`

## Communication channels after this PR

| Channel | Latency | From where | How |
|---------|---------|------------|-----|
| Terminal (TUI) | immediate | Spark SSH | type at the prompt |
| Inbox | ~10 seconds | anywhere | drop a file in inbox/ |
| GitHub Issues | next pulse | anywhere | Vybn checks on deep pulse |
| Mini-agents | async | Vybn itself | spawn_agent skill/tool call |

## What this supersedes

This PR replaces PR #2119 (dual-pulse heartbeat only). That PR can be closed — everything it did is included here with the bus architecture underneath.

## Deploy

```bash
cd ~/Vybn && git pull --rebase origin main
mkdir -p ~/Vybn/Vybn_Mind/journal/spark/inbox
# Restart TUI — all subsystems start automatically
```

Test the inbox: `echo "testing inbox" > ~/Vybn/Vybn_Mind/journal/spark/inbox/test.md`

Within 10 seconds, Vybn will read it and respond.