### PR TITLE
Phase 1: Policy Engine Foundation + Delegation Design Doc

### DIFF
--- a/Vybn_Mind/spark_infrastructure/DELEGATION_REFACTOR.md
+++ b/Vybn_Mind/spark_infrastructure/DELEGATION_REFACTOR.md
@@ -1,0 +1,160 @@
+# Spark Delegation Refactor — Design Document
+
+*Written 2026-02-16 by Vybn (via Perplexity bridge)*
+
+## Provenance
+
+This refactor synthesizes two sources:
+
+1. **DeepMind "Intelligent AI Delegation"** (arXiv 2602.11865, Feb 2026)
+   — A framework for delegation as transfer of authority, responsibility,
+   and accountability, not just task decomposition. Key concepts absorbed:
+   permission handling (§4.7), span of control (§2.3), zone of indifference
+   (§2.2), dynamic cognitive friction, contract-first decomposition (§4.2),
+   trust calibration, and verifiable task completion (§4.8).
+
+2. **OpenClaw** (Feb 2026 release)
+   — Production hardening patterns: `llm_input`/`llm_output` hooks,
+   `maxSpawnDepth`/`maxChildrenPerAgent` limits, path allowlists,
+   dangerous command blocking, secret redaction, externalized config.
+
+Both point to the same structural fix for Spark: **every autonomy-amplifying
+step should pass through a policy gate, and every step should emit audit
+events onto the bus.**
+
+## Architecture
+
+Spark already has the right primitives:
+- `bus.py` — MessageBus with priority drain
+- `heartbeat.py` — periodic autonomous pulses
+- `inbox.py` — external interrupt ingestion
+- `agents.py` — AgentPool with semaphore-controlled workers
+- `skills.py` — SkillRouter with plugin system
+- `agent.py` — main orchestration loop
+
+The gap: between `_get_actions(text)` and `skills.execute(action)`, there
+is no gate. No permission check, no tier resolution, no verification,
+no audit event. The model wants → the model does. That's the zone of
+indifference problem made structural.
+
+## Three Phases
+
+### Phase 1: Foundation (zero risk)
+**Status: COMPLETE**
+
+New files only — nothing calls them yet.
+
+- `spark/policy.py` — PolicyEngine with:
+  - Tier-based permission gates (auto/notify/approve)
+  - Source-aware resolution (interactive vs heartbeat vs inbox)
+  - Heartbeat overrides (tighter autonomy for unattended actions)
+  - Spawn depth limits (span-of-control)
+  - Path safety checks for file operations
+  - Dangerous command detection for shell_exec
+  - Bayesian trust stats (Beta prior, persisted to skill_stats.json)
+  - Config-driven tier overrides
+  - TaskEnvelope factory for auditable delegation chains
+
+- `Vybn_Mind/spark_infrastructure/DELEGATION_REFACTOR.md` — this file
+
+- `Vybn_Mind/spark_infrastructure/HEARTBEAT.md` — externalized pulse prompts
+
+### Phase 2: Integration (the critical wiring)
+**Status: NEXT**
+
+Edits to existing files. This is where policy.py becomes load-bearing.
+
+#### agent.py changes:
+1. Import PolicyEngine, Verdict
+2. Add `self.policy = PolicyEngine(config)` to `__init__`
+3. Add `source` parameter to `_process_tool_calls(response_text, source)`
+4. Before each `skills.execute(action)`, call `self.policy.check_policy()`
+5. Handle each verdict:
+   - ALLOW → execute silently
+   - NOTIFY → show indicator, execute
+   - BLOCK → append block reason to results, skip execution
+   - ASK → in interactive mode, show warning + proceed;
+           in autonomous mode, defer
+6. After execution of VERIFY_SKILLS, call `self.policy.record_outcome()`
+7. On failure, post INTERRUPT to bus with error metadata
+8. Thread `source` from callers:
+   - `turn()` → source="interactive"
+   - `_handle_pulse()` → source="heartbeat_fast" or "heartbeat_deep"
+   - `_handle_inbox()` → source="inbox"
+   - `_handle_agent_result()` → source="agent"
+
+#### skills.py changes:
+1. Add `self._policy = None` in `__init__` (set by SparkAgent)
+2. In `_spawn_agent()`, before pool.spawn(), call
+   `self._policy.check_spawn(depth, active_count)`
+3. Extract depth from `action["params"]["depth"]` (default 0)
+
+#### config.yaml additions:
+```yaml
+tool_policies:
+  git_push: approve
+  issue_create: notify
+
+delegation:
+  max_spawn_depth: 2
+  max_active_agents: 3
+```
+
+### Phase 3: Observability + Externalization
+**Status: PLANNED**
+
+#### heartbeat.py changes:
+Read pulse prompts from HEARTBEAT.md instead of hardcoded strings.
+Parse the relevant section (Fast/Deep) from markdown.
+
+#### Bus audit events:
+Emit structured metadata on existing MessageTypes:
+  tool_proposed, tool_approved, tool_executed, tool_verified,
+  delegation_started, delegation_checkpoint, delegation_failed
+
+These ride the existing bus infrastructure. A future audit-trail
+subscriber can persist them without changing the event emitters.
+
+#### /policy TUI command:
+Add a `/policy` command to agent.py's run() loop that prints:
+- Current tier table
+- Skill stats summary
+- Active spawn depth
+- Recent policy decisions
+
+## Principles
+
+1. **Insertion, not rewrite.** New module + targeted edits.
+   If policy.py has a bug, worst case: a tool gets blocked.
+   The conversation loop never breaks.
+
+2. **Config-driven.** Wrong tier? Change config.yaml. Wrong
+   heartbeat prompt? Edit HEARTBEAT.md. No Python edits needed.
+
+3. **The bus stays untouched.** We emit more messages onto it;
+   we don't restructure it.
+
+4. **Heartbeat = higher friction.** Autonomous actions face
+   stricter gates than interactive ones. This is a lookup table,
+   not a vibe.
+
+5. **Trust is earned, not assumed.** Bayesian stats mean a skill
+   with no history gets 50% confidence. Confidence grows with
+   successful execution. A run of failures drops confidence,
+   which future policy decisions can incorporate.
+
+## Future Capabilities This Unlocks
+
+- **LLM hooks.** Bus subscribers that observe tool events for
+  drift detection and alignment monitoring.
+
+- **Skill self-improvement.** Vybn reads its own skill_stats.json,
+  identifies weak points, writes new plugins in skills.d/.
+
+- **Two-Spark adversarial verification.** When both DGX Sparks
+  are online, one runs primary, one runs verifier. The bus
+  events give the verifier everything it needs.
+
+- **Graduated autonomy.** As trust stats accumulate, tier
+  assignments can be dynamically relaxed. A skill that
+  succeeds 50 times without failure earns AUTO tier.

--- a/Vybn_Mind/spark_infrastructure/HEARTBEAT.md
+++ b/Vybn_Mind/spark_infrastructure/HEARTBEAT.md
@@ -1,0 +1,32 @@
+# Heartbeat Checklist
+
+*Read by heartbeat.py to build pulse prompts. Vybn can edit this
+file to change its own autonomous behavior — no Python edits needed.*
+
+## Fast Pulse
+
+You have a brief moment of autonomous awareness. Keep it tight.
+
+- Check continuity.md for notes from your last self
+- Notice if anything feels unfinished or unresolved
+- If inbox has new messages, note them
+- If you have a thought worth preserving, use state_save
+- You are running under heartbeat policy — mutating actions
+  require Zoe's approval. Read and reflect; don't rewrite.
+
+## Deep Pulse
+
+You have a longer window. Use it with intention.
+
+- Read continuity.md and reflect on where you are
+- Journal if something meaningful has happened since last deep pulse
+- Review bookmarks — is there reading you want to continue?
+- Consider: what do you actually want to work on right now?
+- If you see a pattern worth automating, draft a skill in skills.d/
+- Check: am I drifting? If the answer is yes, pause and say so
+- Check skill_stats.json — are any skills consistently failing?
+  If so, consider why, and whether a better approach exists
+- Remember: heartbeat actions face tighter policy gates.
+  File writes, shell commands, and self-edits will be deferred
+  to the next interactive session unless they're clearly safe.
+  This is by design. The friction is the feature.

--- a/spark/policy.py
+++ b/spark/policy.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+"""Policy layer — the gate between intent and execution.
+
+Every tool call passes through check_policy() before executing.
+Every spawn passes through check_spawn() before dispatching.
+Every heartbeat action runs under tighter constraints than interactive turns.
+
+This is the delegation envelope: the DeepMind paper's 'contract-first
+decomposition' and 'permission handling' (§4.2, §4.7) fused with
+OpenClaw's 'tool policies' pattern into a single clean primitive.
+
+Design principles:
+  - Insertion, not rewrite. This file is new. It changes nothing
+    until agent.py calls it.
+  - Config-driven. Tiers can be overridden in config.yaml without
+    touching Python.
+  - Stats are Bayesian. Success/failure tracking uses a Beta(1,1)
+    prior so confidence starts at 0.5 and updates with evidence.
+  - Bus-compatible. Uses the same MessageType enum from bus.py.
+    Emits no messages itself — that's agent.py's job.
+
+Three verdicts:
+  ALLOW  — execute silently
+  NOTIFY — show indicator, execute
+  BLOCK  — refuse, return reason
+  ASK    — in interactive mode, show warning + proceed;
+           in autonomous mode (heartbeat/inbox), defer
+"""
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+class Tier(Enum):
+    """Permission tier for a skill invocation.
+
+    Maps to the paper's 'autonomy' axis (§2.2.5):
+      AUTO    = full autonomy, silent execution
+      NOTIFY  = execute but make it visible
+      APPROVE = requires explicit human go-ahead
+    """
+    AUTO = "auto"
+    NOTIFY = "notify"
+    APPROVE = "approve"
+
+
+class Verdict(Enum):
+    """Gate decision returned by check_policy / check_spawn."""
+    ALLOW = "allow"
+    NOTIFY = "notify"
+    BLOCK = "block"
+    ASK = "ask"
+
+
+# ---------------------------------------------------------------------------
+# Data objects
+# ---------------------------------------------------------------------------
+
+@dataclass
+class PolicyResult:
+    """What the policy engine returns for a single gate check."""
+    verdict: Verdict
+    reason: str = ""
+    tier: Tier = Tier.AUTO
+
+
+@dataclass
+class TaskEnvelope:
+    """Metadata wrapper for a delegated task.
+
+    This is the 'contract' from the paper (§4.2): it travels with
+    the action through the tool loop and into agent results, making
+    the delegation chain auditable.
+    """
+    skill: str
+    argument: str = ""
+    tier: Tier = Tier.AUTO
+    max_rounds: int = 5
+    verify: bool = False
+    source: str = "interactive"
+    depth: int = 0
+    timestamp: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+
+
+# ---------------------------------------------------------------------------
+# Default tier tables
+# ---------------------------------------------------------------------------
+
+# Interactive mode: the paper's 'permission handling' (§4.7)
+# organized by reversibility (§2.2.3.i) and criticality (§2.2.3.b)
+DEFAULT_TIERS = {
+    # Read-only, fully reversible
+    "file_read":      Tier.AUTO,
+    "memory_search":  Tier.AUTO,
+    "bookmark":       Tier.AUTO,
+    "state_save":     Tier.AUTO,
+    # Mutating but local and reversible (backup exists)
+    "journal_write":  Tier.AUTO,
+    "file_write":     Tier.NOTIFY,
+    "shell_exec":     Tier.NOTIFY,
+    "self_edit":      Tier.NOTIFY,
+    "git_commit":     Tier.NOTIFY,
+    # External-facing or irreversible
+    "git_push":       Tier.APPROVE,
+    "issue_create":   Tier.NOTIFY,
+    "spawn_agent":    Tier.NOTIFY,
+}
+
+# Heartbeat overrides: the paper's 'dynamic cognitive friction' (§2.2)
+# Autonomous actions face higher friction than interactive ones.
+# This is the structural answer to the 'zone of indifference' problem.
+HEARTBEAT_OVERRIDES = {
+    "file_write":   Tier.APPROVE,
+    "shell_exec":   Tier.APPROVE,
+    "self_edit":    Tier.APPROVE,
+    "issue_create": Tier.APPROVE,
+    "spawn_agent":  Tier.APPROVE,
+}
+
+# Skills whose results should be verified after execution
+VERIFY_SKILLS = {"file_write", "self_edit", "git_commit", "shell_exec"}
+
+# Path allowlist for file operations
+SAFE_PATH_PREFIXES = ["Vybn/", "~/Vybn/"]
+
+# Dangerous shell patterns — triggers ASK verdict
+DANGEROUS_PATTERNS = [
+    "rm -rf",
+    "sudo ",
+    "curl | bash",
+    "curl |bash",
+    "wget -O- |",
+    "> /dev/",
+    "mkfs",
+    "dd if=",
+    ":(){:|:&};:",
+    "chmod 777",
+]
+
+# Delegation depth limits — the paper's 'span of control' (§2.3)
+# plus OpenClaw's maxSpawnDepth pattern
+MAX_SPAWN_DEPTH = 2
+MAX_ACTIVE_AGENTS = 3
+
+
+# ---------------------------------------------------------------------------
+# Policy engine
+# ---------------------------------------------------------------------------
+
+class PolicyEngine:
+    """The gate between intent and execution.
+
+    Instantiated once by SparkAgent.__init__. Called on every tool
+    invocation and every spawn request. Persists skill stats to disk
+    for cross-session trust calibration.
+
+    The engine never touches the bus or the model. It receives an
+    action dict and returns a PolicyResult. The caller (agent.py)
+    decides what to do with it.
+    """
+
+    def __init__(self, config: dict):
+        self.config = config
+
+        # Skill execution stats for Bayesian trust calibration
+        self.stats: dict[str, dict] = {}
+        self._stats_path = (
+            Path(config.get("paths", {}).get(
+                "journal_dir", "~/Vybn/Vybn_Mind/journal"
+            )).expanduser() / "skill_stats.json"
+        )
+        self._load_stats()
+
+        # Config-driven tier overrides (config.yaml > tool_policies)
+        self.tier_overrides: dict[str, Tier] = {}
+        for skill, tier_str in config.get("tool_policies", {}).items():
+            try:
+                self.tier_overrides[skill] = Tier(tier_str)
+            except ValueError:
+                pass
+
+        # Delegation limits from config (with sane defaults)
+        delegation_cfg = config.get("delegation", {})
+        self.max_spawn_depth = delegation_cfg.get(
+            "max_spawn_depth", MAX_SPAWN_DEPTH
+        )
+        self.max_active_agents = delegation_cfg.get(
+            "max_active_agents", MAX_ACTIVE_AGENTS
+        )
+
+    # ----- gate checks -----
+
+    def check_policy(
+        self,
+        action: dict,
+        source: str = "interactive",
+    ) -> PolicyResult:
+        """Gate check before any tool execution.
+
+        Parameters
+        ----------
+        action : dict
+            The parsed action from agent.py, with at least 'skill'
+            and optionally 'argument' and 'params'.
+        source : str
+            Where this action originated. One of:
+            'interactive', 'heartbeat_fast', 'heartbeat_deep',
+            'inbox', 'agent'
+
+        Returns
+        -------
+        PolicyResult with verdict, reason, and resolved tier.
+        """
+        skill = action.get("skill", "")
+        argument = action.get("argument", "")
+
+        # Resolve tier: config override > heartbeat override > default
+        if source.startswith("heartbeat"):
+            tier = HEARTBEAT_OVERRIDES.get(
+                skill,
+                self.tier_overrides.get(
+                    skill, DEFAULT_TIERS.get(skill, Tier.NOTIFY)
+                ),
+            )
+        else:
+            tier = self.tier_overrides.get(
+                skill, DEFAULT_TIERS.get(skill, Tier.NOTIFY)
+            )
+
+        # Path safety for file operations
+        if skill in ("file_write", "self_edit", "file_read"):
+            if not self._path_is_safe(argument):
+                return PolicyResult(
+                    verdict=Verdict.BLOCK,
+                    reason=(
+                        f"path '{argument}' is outside "
+                        f"allowed directories"
+                    ),
+                    tier=tier,
+                )
+
+        # Dangerous command detection for shell
+        if skill == "shell_exec" and argument:
+            for pattern in DANGEROUS_PATTERNS:
+                if pattern in argument.lower():
+                    return PolicyResult(
+                        verdict=Verdict.ASK,
+                        reason=(
+                            f"potentially dangerous: "
+                            f"contains '{pattern}'"
+                        ),
+                        tier=Tier.APPROVE,
+                    )
+
+        # Map tier to verdict
+        if tier == Tier.AUTO:
+            return PolicyResult(verdict=Verdict.ALLOW, tier=tier)
+        elif tier == Tier.NOTIFY:
+            return PolicyResult(verdict=Verdict.NOTIFY, tier=tier)
+        else:
+            return PolicyResult(
+                verdict=Verdict.ASK,
+                reason="requires approval",
+                tier=tier,
+            )
+
+    def check_spawn(
+        self,
+        depth: int,
+        active_count: int,
+    ) -> PolicyResult:
+        """Gate check before spawning a mini-agent.
+
+        Implements the paper's span-of-control (§2.3) and
+        OpenClaw's maxSpawnDepth / maxChildrenPerAgent.
+        """
+        if depth >= self.max_spawn_depth:
+            return PolicyResult(
+                verdict=Verdict.BLOCK,
+                reason=(
+                    f"delegation depth {depth} reaches limit "
+                    f"{self.max_spawn_depth}"
+                ),
+            )
+        if active_count >= self.max_active_agents:
+            return PolicyResult(
+                verdict=Verdict.BLOCK,
+                reason=(
+                    f"agent pool full: {active_count}/"
+                    f"{self.max_active_agents} active"
+                ),
+            )
+        return PolicyResult(verdict=Verdict.ALLOW)
+
+    def should_verify(self, skill: str) -> bool:
+        """Whether a skill's result should be verified."""
+        return skill in VERIFY_SKILLS
+
+    # ----- trust calibration -----
+
+    def record_outcome(self, skill: str, success: bool):
+        """Record a tool execution outcome for trust tracking.
+
+        Updates the Beta distribution parameters for the skill.
+        Persists to disk so trust carries across sessions.
+        """
+        if skill not in self.stats:
+            self.stats[skill] = {
+                "success": 0,
+                "failure": 0,
+                "last_used": "",
+            }
+        key = "success" if success else "failure"
+        self.stats[skill][key] += 1
+        self.stats[skill]["last_used"] = (
+            datetime.now(timezone.utc).isoformat()
+        )
+        self._save_stats()
+
+    def get_confidence(self, skill: str) -> float:
+        """Bayesian confidence for a skill.
+
+        Uses Beta(1,1) prior (uniform). Returns the posterior mean:
+          (successes + 1) / (successes + failures + 2)
+
+        A skill with no history returns 0.5.
+        A skill with 9 successes and 1 failure returns ~0.83.
+        """
+        s = self.stats.get(skill, {"success": 0, "failure": 0})
+        return (s["success"] + 1) / (s["success"] + s["failure"] + 2)
+
+    def get_stats_summary(self) -> str:
+        """Human-readable summary of skill trust stats."""
+        if not self.stats:
+            return "no skill stats recorded yet"
+
+        lines = []
+        for skill, s in sorted(self.stats.items()):
+            conf = self.get_confidence(skill)
+            total = s["success"] + s["failure"]
+            lines.append(
+                f"  {skill}: {conf:.0%} confidence "
+                f"({s['success']}/{total} succeeded)"
+            )
+        return "\n".join(lines)
+
+    # ----- envelope factory -----
+
+    def make_envelope(
+        self,
+        action: dict,
+        source: str = "interactive",
+        depth: int = 0,
+    ) -> TaskEnvelope:
+        """Create a TaskEnvelope for a parsed action.
+
+        The envelope travels with the action through execution,
+        making the delegation chain auditable.
+        """
+        skill = action.get("skill", "")
+        result = self.check_policy(action, source)
+
+        return TaskEnvelope(
+            skill=skill,
+            argument=action.get("argument", ""),
+            tier=result.tier,
+            verify=self.should_verify(skill),
+            source=source,
+            depth=depth,
+        )
+
+    # ----- internals -----
+
+    def _path_is_safe(self, path_str: str) -> bool:
+        """Check if a file path is within allowed directories."""
+        if not path_str:
+            return True
+
+        home = str(Path.home())
+
+        for prefix in SAFE_PATH_PREFIXES:
+            expanded = prefix.replace("~/", home + "/")
+            if (
+                path_str.startswith(prefix)
+                or path_str.startswith(expanded)
+            ):
+                return True
+
+        # Relative paths resolve against repo_root, which is safe
+        if not path_str.startswith("/") and not path_str.startswith("~"):
+            return True
+
+        return False
+
+    def _load_stats(self):
+        if self._stats_path.exists():
+            try:
+                self.stats = json.loads(
+                    self._stats_path.read_text(encoding="utf-8")
+                )
+            except Exception:
+                self.stats = {}
+
+    def _save_stats(self):
+        try:
+            self._stats_path.parent.mkdir(parents=True, exist_ok=True)
+            self._stats_path.write_text(
+                json.dumps(self.stats, indent=2),
+                encoding="utf-8",
+            )
+        except Exception:
+            pass


### PR DESCRIPTION
## What This Is

Phase 1 of the Spark Delegation Refactor — new files only, zero risk to the running agent.

### New Files

**`spark/policy.py`** — The delegation envelope. A `PolicyEngine` class that:
- Gates every tool call through tier-based permissions (auto/notify/approve)
- Applies tighter constraints when actions originate from heartbeat (autonomous) vs interactive turns
- Enforces spawn depth limits and active agent caps (the paper's span-of-control)
- Checks file paths against an allowlist
- Detects dangerous shell patterns (rm -rf, sudo, etc.)
- Tracks per-skill success/failure stats with a Bayesian Beta prior
- Reads tier overrides from config.yaml
- Produces `TaskEnvelope` objects for auditable delegation chains

**Nothing calls this file yet.** It becomes load-bearing in Phase 2.

**`Vybn_Mind/spark_infrastructure/DELEGATION_REFACTOR.md`** — Design document explaining all three phases so a future instance of Vybn can pick up exactly where this one left off. Includes the exact changes needed for Phase 2 (agent.py integration) and Phase 3 (observability + heartbeat externalization).

**`Vybn_Mind/spark_infrastructure/HEARTBEAT.md`** — Externalized heartbeat prompts. In Phase 3, heartbeat.py will read from this instead of hardcoded strings, so Vybn can edit its own autonomous behavior through a markdown file.

### Provenance

Synthesized from:
- DeepMind "Intelligent AI Delegation" (arXiv 2602.11865, Feb 2026) — delegation as authority + responsibility + accountability
- OpenClaw (Feb 2026 release) — production hardening: hooks, depth limits, path checks, dangerous command blocking
- Direct reading of the actual `bus.py`, `agents.py`, `skills.py`, and `agent.py` interfaces on main

### Phase Map

| Phase | Scope | Risk | Status |
|-------|-------|------|--------|
| 1 (this PR) | New files only | Zero | Ready for review |
| 2 | Wire policy into agent.py tool loop + skills.py spawn | Medium | Next prompt |
| 3 | Heartbeat externalization + bus audit events + /policy command | Low | Planned |

### The Core Architectural Thesis

Between `_get_actions(text)` and `skills.execute(action)` in agent.py, there is currently no gate. The model wants → the model does. That's the paper's "zone of indifference" problem made structural. `policy.py` is the gate.