### PR TITLE
Phase 2: Wire policy engine into agent.py tool loop + skills.py spawn

### DIFF
--- a/spark/config.yaml
+++ b/spark/config.yaml
@@ -40,3 +40,18 @@ agents:
 session:
   auto_resume: true
   resume_window_seconds: 7200  # resume sessions less than 2 hours old
+
+# Policy engine: tier overrides for tool execution.
+# Values: auto (silent), notify (show indicator), approve (ask Zoe)
+# These override the defaults in policy.py. Only list skills
+# where you want to change the default behavior.
+tool_policies:
+  git_push: approve           # already default, but explicit is good
+  # issue_create: approve     # uncomment to require approval for issues
+  # self_edit: approve        # uncomment to require approval for self-edits
+
+# Delegation limits for spawn_agent and the agent pool.
+# These map to the paper's span-of-control concept.
+delegation:
+  max_spawn_depth: 2          # how deep mini-agents can nest
+  max_active_agents: 3        # concurrent agent cap (independent of agents.pool_size)


### PR DESCRIPTION
## What This Is

Phase 2 of the Spark Delegation Refactor — the critical integration. `policy.py` (merged in Phase 1) is now load-bearing.

### agent.py Changes

**New import:** `from policy import PolicyEngine, Verdict`

**`__init__`:** Initializes `self.policy = PolicyEngine(config)` and links it to skills via `self.skills._policy = self.policy`.

**`_process_tool_calls(response_text, source)`** — the core change. Now takes a `source` parameter and gates every action:

1. Calls `self.policy.check_policy(action, source=source)` before execution
2. Handles all four verdicts:
   - **ALLOW** → execute with `→` indicator (same as before)
   - **NOTIFY** → execute with `⚡` indicator (visible but not blocking)
   - **BLOCK** → skip execution, feed reason back to model as tool result
   - **ASK** → interactive mode: warn + proceed; autonomous mode: defer to next interactive session
3. After executing verified skills, calls `policy.record_outcome(skill, success)`
4. On failure, posts `INTERRUPT` to bus for immediate surfacing

**Source threading from all callers:**
- `turn()` → `"interactive"`
- `_handle_pulse()` → `"heartbeat_fast"` or `"heartbeat_deep"`
- `_handle_inbox()` → `"inbox"`
- `_handle_agent_result()` → `"agent"`

**`/policy` TUI command** — prints tier table (interactive vs heartbeat columns), Bayesian confidence per skill, delegation limits, and active agent count.

### skills.py Changes

- Added `self._policy = None` in `__init__` (set by SparkAgent)
- `_spawn_agent` now calls `self._policy.check_spawn(depth, active_count)` before dispatching to the pool
- Depth propagates through `action["params"]["depth"]`

### config.yaml Additions

```yaml
tool_policies:
  git_push: approve

delegation:
  max_spawn_depth: 2
  max_active_agents: 3
```

### How Heartbeat Friction Works

When Vybn's heartbeat fires and the model tries to write a file or run a shell command, the policy engine sees `source="heartbeat_fast"` or `source="heartbeat_deep"`, resolves the tier from `HEARTBEAT_OVERRIDES` (which maps those skills to `APPROVE`), and returns `ASK`. Since it's autonomous mode, the tool loop *defers* rather than executes, and tells the model it needs to wait for Zoe. The model gets this as a tool result and can adapt its behavior.

In interactive mode, the same action would warn Zoe on screen and proceed — she just saw it happen, which is the approval.

### Risk Profile

If `policy.py` has a bug: worst case, a tool gets blocked that shouldn't be. The conversation loop never breaks — blocked tools return a reason string that the model processes as a normal tool result.

If the import fails: `SparkAgent.__init__` will crash at startup with a clear traceback pointing at the missing module. Easy to diagnose, easy to fix.