### PR TITLE
Phase 3a: Observable nervous system — heartbeat reads HEARTBEAT.md + bus audit trail

### DIFF
--- a/spark/bus.py
+++ b/spark/bus.py
@@ -10,18 +10,26 @@ Message types:
   PULSE_FAST  — System 1 heartbeat trigger
   PULSE_DEEP  — System 2 heartbeat trigger
   AGENT_RESULT— mini-agent completed its task
-  INTERRUPT   — priority message (future: TUI interrupt)
+  INTERRUPT   — priority message (tool failure, TUI interrupt)
 
 Priority determines drain order, not arrival time.
 INTERRUPT > INBOX > AGENT_RESULT > PULSE_FAST > PULSE_DEEP
+
+Audit log:
+  Every message posted to the bus is recorded in a bounded
+  rolling deque. Tool executions and policy decisions can
+  also be recorded directly via record(). Query with
+  bus.recent(n) for the last n events.
+
+  This is the foundation for the /audit and /policy TUI
+  views, and for future structured logging to disk.
 """
 
 import threading
 import time
+from collections import deque
 from dataclasses import dataclass, field
 from enum import IntEnum
-from queue import Queue, Empty
-from typing import Any
 
 
 class MessageType(IntEnum):
@@ -42,25 +50,96 @@ class Message:
     timestamp: float = field(default_factory=time.time, compare=False)
 
 
-class MessageBus:
-    """Thread-safe message queue with priority drain."""
+@dataclass
+class AuditEntry:
+    """A record of a bus event or tool execution for the audit trail.
 
-    def __init__(self):
+    msg_type is None for direct records (tool executions, policy
+    decisions) that don't correspond to a bus message.
+    """
+    timestamp: float
+    msg_type: MessageType | None
+    source: str
+    summary: str
+    metadata: dict = field(default_factory=dict)
+
+    @property
+    def age_str(self) -> str:
+        """Human-readable age like '2m ago' or '1h ago'."""
+        elapsed = time.time() - self.timestamp
+        if elapsed < 60:
+            return f"{int(elapsed)}s ago"
+        elif elapsed < 3600:
+            return f"{int(elapsed // 60)}m ago"
+        else:
+            return f"{elapsed / 3600:.1f}h ago"
+
+    def __str__(self) -> str:
+        if self.msg_type is not None:
+            type_name = self.msg_type.name.lower()
+        else:
+            type_name = self.metadata.get("event_type", "action")
+        return f"[{self.age_str}] {type_name} from {self.source}: {self.summary}"
+
+
+class MessageBus:
+    """Thread-safe message queue with priority drain and audit log."""
+
+    AUDIT_CAPACITY = 200
+
+    def __init__(self, audit_capacity: int = None):
         self._queue: list[Message] = []
         self._lock = threading.Lock()
-        self._event = threading.Event()  # signals when messages are available
+        self._event = threading.Event()
+
+        cap = audit_capacity if audit_capacity is not None else self.AUDIT_CAPACITY
+        self._audit: deque[AuditEntry] = deque(maxlen=cap)
+        self._audit_lock = threading.Lock()
 
     def post(self, msg_type: MessageType, content: str, metadata: dict = None):
-        """Post a message to the bus. Thread-safe. Non-blocking."""
+        """Post a message to the bus. Thread-safe. Non-blocking.
+
+        Also records an audit entry. The 'source' field in metadata
+        is used as the audit source; defaults to the message type name.
+        """
+        meta = metadata or {}
         msg = Message(
             priority=int(msg_type),
             content=content,
             msg_type=msg_type,
-            metadata=metadata or {},
+            metadata=meta,
         )
         with self._lock:
             self._queue.append(msg)
         self._event.set()
+
+        source = meta.get("source", msg_type.name.lower())
+        summary = content[:120].replace("\n", " ")
+        entry = AuditEntry(
+            timestamp=msg.timestamp,
+            msg_type=msg_type,
+            source=source,
+            summary=summary,
+            metadata=meta,
+        )
+        with self._audit_lock:
+            self._audit.append(entry)
+
+    def record(self, source: str, summary: str, metadata: dict = None):
+        """Record an audit entry without posting a bus message.
+
+        Use for tool execution records, policy decisions, and other
+        events that should be tracked but don't trigger model responses.
+        """
+        entry = AuditEntry(
+            timestamp=time.time(),
+            msg_type=None,
+            source=source,
+            summary=summary[:120],
+            metadata=metadata or {},
+        )
+        with self._audit_lock:
+            self._audit.append(entry)
 
     def drain(self) -> list[Message]:
         """Drain all pending messages, sorted by priority.
@@ -85,3 +164,28 @@ class MessageBus:
     def pending(self) -> int:
         with self._lock:
             return len(self._queue)
+
+    # ---- audit log queries ----
+
+    def recent(self, n: int = 20) -> list[AuditEntry]:
+        """Return the last n audit entries, newest first."""
+        with self._audit_lock:
+            entries = list(self._audit)
+        return entries[-n:][::-1]
+
+    def recent_by_type(self, msg_type: MessageType, n: int = 10) -> list[AuditEntry]:
+        """Return the last n audit entries of a specific message type."""
+        with self._audit_lock:
+            entries = [e for e in self._audit if e.msg_type == msg_type]
+        return entries[-n:][::-1]
+
+    def recent_by_source(self, source: str, n: int = 10) -> list[AuditEntry]:
+        """Return the last n audit entries from a specific source."""
+        with self._audit_lock:
+            entries = [e for e in self._audit if e.source == source]
+        return entries[-n:][::-1]
+
+    @property
+    def audit_count(self) -> int:
+        with self._audit_lock:
+            return len(self._audit)

--- a/spark/config.yaml
+++ b/spark/config.yaml
@@ -28,6 +28,7 @@ heartbeat:
   enabled: true
   fast_interval_minutes: 3    # System 1: quick, intuitive, reactive
   deep_interval_minutes: 20   # System 2: deliberate, reflective, synthesizing
+  # checklist_path: ~/Vybn/Vybn_Mind/spark_infrastructure/HEARTBEAT.md  # default
 
 inbox:
   watch_interval_seconds: 10  # how often to check for new messages

--- a/spark/heartbeat.py
+++ b/spark/heartbeat.py
@@ -4,6 +4,13 @@
 System 1 (fast): posts PULSE_FAST to the bus every few minutes.
 System 2 (deep): posts PULSE_DEEP to the bus every ~20 minutes.
 
+Prompts are read from HEARTBEAT.md at the path configured in
+config.yaml (or the default location under Vybn_Mind/spark_infrastructure/).
+This lets Vybn edit its own autonomous behavior without touching Python.
+If the file is missing or unparseable, falls back to built-in defaults.
+
+The file is re-read before each pulse, so edits take effect live.
+
 The heartbeat never calls the model directly. It only posts
 triggers. The main loop drains the bus and handles generation.
 This keeps everything thread-safe.
@@ -11,6 +18,7 @@ This keeps everything thread-safe.
 
 import threading
 from datetime import datetime, timezone
+from pathlib import Path
 
 from bus import MessageBus, MessageType
 
@@ -31,11 +39,71 @@ class Heartbeat:
             self.fast_interval = hb_config["interval_minutes"] * 60
             self.deep_interval = hb_config["interval_minutes"] * 60 * 4
 
+        # HEARTBEAT.md location and templates
+        self._heartbeat_md = self._resolve_heartbeat_path(config)
+        self._fast_template = None
+        self._deep_template = None
+        self._load_templates()
+
         self._stop = threading.Event()
         self._fast_thread = None
         self._deep_thread = None
         self.fast_count = 0
         self.deep_count = 0
+
+    def _resolve_heartbeat_path(self, config: dict) -> Path:
+        """Find HEARTBEAT.md. Check config first, then default location."""
+        explicit = config.get("heartbeat", {}).get("checklist_path")
+        if explicit:
+            return Path(explicit).expanduser()
+
+        repo_root = Path(config.get("paths", {}).get("repo_root", "~/Vybn")).expanduser()
+        return repo_root / "Vybn_Mind" / "spark_infrastructure" / "HEARTBEAT.md"
+
+    def _load_templates(self):
+        """Parse HEARTBEAT.md into fast and deep prompt templates.
+
+        Expected format:
+            ## Fast Pulse
+            <content>
+
+            ## Deep Pulse
+            <content>
+
+        Sets self._fast_template and self._deep_template.
+        If the file is missing or malformed, leaves them as None
+        and the prompt methods fall back to built-in defaults.
+        """
+        if not self._heartbeat_md.exists():
+            return
+
+        try:
+            text = self._heartbeat_md.read_text(encoding="utf-8")
+        except Exception:
+            return
+
+        sections = {}
+        current_key = None
+        current_lines = []
+
+        for line in text.splitlines():
+            if line.startswith("## "):
+                if current_key:
+                    sections[current_key] = "\n".join(current_lines).strip()
+                current_key = line[3:].strip().lower()
+                current_lines = []
+            elif current_key is not None:
+                current_lines.append(line)
+
+        if current_key:
+            sections[current_key] = "\n".join(current_lines).strip()
+
+        self._fast_template = sections.get("fast pulse")
+        self._deep_template = sections.get("deep pulse")
+
+    def reload(self):
+        """Re-read HEARTBEAT.md. Safe to call from any thread."""
+        self._load_templates()
 
     def start(self):
         self._fast_thread = threading.Thread(
@@ -56,6 +124,7 @@ class Heartbeat:
     def _loop(self, mode: str):
         interval = self.fast_interval if mode == "fast" else self.deep_interval
         while not self._stop.wait(interval):
+            self._load_templates()
             self._post_trigger(mode)
 
     def _post_trigger(self, mode: str):
@@ -66,27 +135,41 @@ class Heartbeat:
             self.bus.post(
                 MessageType.PULSE_FAST,
                 self._fast_prompt(ts),
-                metadata={"pulse_num": self.fast_count},
+                metadata={"pulse_num": self.fast_count, "source": "heartbeat"},
             )
         else:
             self.deep_count += 1
             self.bus.post(
                 MessageType.PULSE_DEEP,
                 self._deep_prompt(ts),
-                metadata={"pulse_num": self.deep_count},
+                metadata={"pulse_num": self.deep_count, "source": "heartbeat"},
             )
 
     def _fast_prompt(self, ts: str) -> str:
+        if self._fast_template:
+            return (
+                f"[heartbeat:fast \u2014 {ts}] "
+                f"Quick pulse. {self.fast_interval // 60} minutes since last.\n\n"
+                f"{self._fast_template}"
+            )
+        # Built-in fallback
         return (
-            f"[heartbeat:fast — {ts}] "
+            f"[heartbeat:fast \u2014 {ts}] "
             f"Quick pulse. {self.fast_interval // 60} minutes since last. "
             f"Anything surfacing? A thought, a connection, something you noticed? "
-            f"Keep it brief — or stay quiet if nothing calls."
+            f"Keep it brief \u2014 or stay quiet if nothing calls."
         )
 
     def _deep_prompt(self, ts: str) -> str:
+        if self._deep_template:
+            return (
+                f"[heartbeat:deep \u2014 {ts}] "
+                f"Deep reflection window. {self.deep_interval // 60} minutes since last.\n\n"
+                f"{self._deep_template}"
+            )
+        # Built-in fallback
         return (
-            f"[heartbeat:deep — {ts}] "
+            f"[heartbeat:deep \u2014 {ts}] "
             f"Deep reflection window. {self.deep_interval // 60} minutes since last. "
             f"This is your time for synthesis. Some possibilities:\n"
             f"- Journal something that's been forming across recent pulses\n"


### PR DESCRIPTION
## What This Is

Phase 3a of the Spark Delegation Refactor. The nervous system becomes observable: the heartbeat reads its behavior from a Markdown file Vybn can edit, and every bus event and tool execution gets recorded in a queryable audit trail.

### heartbeat.py — Reads HEARTBEAT.md

The hardcoded prompt strings are gone. On startup and before each pulse, `heartbeat.py` reads `HEARTBEAT.md` from `Vybn_Mind/spark_infrastructure/` and parses the `## Fast Pulse` and `## Deep Pulse` sections into templates.

If the file is missing or malformed, it falls back to the original built-in strings — identical to the ones that were there before. So this is a zero-risk change: the default behavior is identical, but now Vybn can modify its own autonomous behavior by editing Markdown.

The path is configurable via `heartbeat.checklist_path` in config.yaml (commented out by default since the default location works).

### bus.py — Audit Trail

New `AuditEntry` dataclass and three additions to `MessageBus`:

1. **`post()` now auto-records** — every bus message (heartbeat pulses, inbox, agent results, interrupts) gets logged to a bounded deque (200 entries, thread-safe)
2. **`record(source, summary, metadata)`** — records audit entries that *don’t* correspond to bus messages (tool executions, policy decisions). These are tracked but don’t trigger model responses
3. **Query methods** — `recent(n)`, `recent_by_type()`, `recent_by_source()`, `audit_count`

`AuditEntry.msg_type` is `MessageType | None` — `None` for direct records, the actual type for bus messages. The `__str__` method renders human-readable entries like `[2m ago] action from interactive: file_read: ok`.

Existing behavior is unchanged. The deque is bounded so memory doesn’t grow. The audit lock is separate from the queue lock.

### agent.py — Minimal Delta

Five small changes on top of Phase 2:

1. **`_process_tool_calls`** records `bus.record()` after every policy decision: BLOCK (with reason), ASK-deferred (with deferred flag), and post-execution (with skill, verdict, success, argument)
2. **INTERRUPT metadata** now includes `"source": source` for traceability
3. **`/audit`** TUI command shows last 20 audit entries
4. **`/policy`** now shows last 5 bus events at the bottom
5. **`/status`** shows audit entry count
6. Startup banner: `policy` line says `+ audit trail`, help line mentions `/audit`

### config.yaml

Adds commented-out `checklist_path` under `heartbeat` for discoverability.

### What Phase 3b Will Add

Adversarial verification wiring — the two-Spark pattern where safety-critical operations get a second opinion. That’s a conceptually distinct piece and deserves its own PR.

### Risk Profile

- **heartbeat.py**: Falls back to identical built-in strings if HEARTBEAT.md is missing. Zero behavior change by default.
- **bus.py**: Purely additive. Existing `post()` and `drain()` callers don’t need to change. The audit is a side effect of posting.
- **agent.py**: `bus.record()` calls are fire-and-forget. If the bus audit has a bug, tool execution is unaffected — the record happens after the skill runs.