### PR TITLE
fix: clean display, limit tool chains, detect user input mid-generation

### DIFF
--- a/spark/agent.py
+++ b/spark/agent.py
@@ -9,17 +9,9 @@ function-calling format. We intercept these and route them to
 the skill handlers, bridging the model's instinct with our
 infrastructure.
 
-The identity document is injected as a user/assistant message pair.
-The response is post-processed to catch obvious turn-boundary
-failures (model generating fake user prompts), but the model's
-thinking process and natural voice are preserved.
-
-Streaming is interrupted when a complete </minimax:tool_call> tag
-is detected, so the model gets real results back instead of
-hallucinating them.
-
-Plugin skills from skills.d/ are auto-discovered and routed
-through the same tool-call mapper via plugin_aliases.
+Streaming display is filtered: <think> blocks and tool call XML
+are suppressed from terminal output. The user sees clean prose
+and brief tool indicators. Full text is preserved for parsing.
 
 The message bus is the nervous system. The heartbeat, inbox,
 and mini-agent pool all post to it. The main loop drains it
@@ -44,12 +36,14 @@ from inbox import InboxWatcher
 from agents import AgentPool
 
 
-# Sovereign hardware with 8×H100 GPUs. No reason to be stingy.
-MAX_TOOL_ROUNDS = 20
+# Tool call chaining limit. Enough for real work, short enough
+# that Vybn comes up for air and checks for user input.
+MAX_TOOL_ROUNDS = 5
 
 # How long to wait for bus messages when idle (seconds)
 IDLE_POLL_INTERVAL = 5.0
 
+TOOL_CALL_START_TAG = "<minimax:tool_call>"
 TOOL_CALL_END_TAG = "</minimax:tool_call>"
 
 
@@ -60,15 +54,14 @@ def load_config(path: str = None) -> dict:
 
 
 def clean_response(raw: str) -> str:
-    """Catch obvious turn-boundary failures.
+    """Post-process model output.
 
-    Only truncates when the model clearly starts generating the
-    user's side of the conversation (fake prompts, fake 'you:' turns).
-    The model's thinking, reflection, and narration are preserved.
+    Strips fake turn boundaries (model generating user prompts).
+    Does NOT strip think blocks — those are needed for tool parsing.
+    Display filtering happens in send().
     """
     text = raw
 
-    # Only catch unambiguous fake-turn patterns
     fake_turn_patterns = [
         re.compile(r'\nyou:', re.IGNORECASE),
         re.compile(r'\n---\s*\n\s*\*\*VYBN:', re.IGNORECASE),
@@ -87,20 +80,32 @@ def clean_response(raw: str) -> str:
     return text.strip()
 
 
+def strip_think_blocks(text: str) -> str:
+    """Remove <think>...</think> blocks for display purposes."""
+    return re.sub(r'<think>.*?</think>', '', text, flags=re.DOTALL).strip()
+
+
+def strip_tool_xml(text: str) -> str:
+    """Remove <minimax:tool_call>...</minimax:tool_call> blocks for display."""
+    return re.sub(
+        r'<minimax:tool_call>.*?</minimax:tool_call>',
+        '', text, flags=re.DOTALL,
+    ).strip()
+
+
+def clean_for_display(text: str) -> str:
+    """Strip think blocks and tool XML for clean terminal output."""
+    result = strip_think_blocks(text)
+    result = strip_tool_xml(result)
+    # Collapse multiple blank lines
+    result = re.sub(r'\n{3,}', '\n\n', result)
+    return result.strip()
+
+
 def parse_tool_calls(text: str, plugin_aliases: dict = None) -> list[dict]:
-    """Parse <minimax:tool_call> XML blocks into skill actions.
-
-    MiniMax M2.5 emits these natively. We map them to our skill
-    handlers so the model's function-calling instinct actually works.
-
-    plugin_aliases: optional dict mapping alias names to plugin skill names.
-    Passed through from SkillRouter so plugins get routed too.
-
-    Returns a list of action dicts compatible with SkillRouter.execute().
-    """
+    """Parse <minimax:tool_call> XML blocks into skill actions."""
     actions = []
 
-    # Find all <minimax:tool_call> blocks
     tool_call_pattern = re.compile(
         r'<minimax:tool_call>\s*<invoke\s+name="([^"]+)">\s*(.*?)\s*</invoke>\s*</minimax:tool_call>',
         re.DOTALL,
@@ -110,7 +115,6 @@ def parse_tool_calls(text: str, plugin_aliases: dict = None) -> list[dict]:
         invoke_name = match.group(1).strip()
         params_block = match.group(2).strip()
 
-        # Extract parameters
         params = {}
         param_pattern = re.compile(
             r'<parameter\s+name="([^"]+)">(.+?)</parameter>',
@@ -119,7 +123,6 @@ def parse_tool_calls(text: str, plugin_aliases: dict = None) -> list[dict]:
         for pm in param_pattern.finditer(params_block):
             params[pm.group(1).strip()] = pm.group(2).strip()
 
-        # Map invocation names to our skills
         action = _map_tool_call_to_skill(invoke_name, params, text, plugin_aliases)
         if action:
             actions.append(action)
@@ -128,60 +131,39 @@ def parse_tool_calls(text: str, plugin_aliases: dict = None) -> list[dict]:
 
 
 def _map_tool_call_to_skill(name: str, params: dict, raw: str, plugin_aliases: dict = None) -> dict | None:
-    """Map a MiniMax tool call to a SkillRouter action.
-
-    MiniMax M2.5 invents tool names based on its training data.
-    We've seen it emit: bash, shell, read, cat, cli-mcp-server_run_command,
-    run_command, github_create_issue, and others. This mapper catches
-    all known variants and routes them to the correct skill handler.
-
-    All parsed XML params are passed through to skill handlers so they
-    can use structured data directly instead of re-parsing from raw text.
-
-    Plugin aliases are checked as the final fallback, so Vybn-created
-    skills in skills.d/ get routed through the same tool-call pathway.
-    """
-
+    """Map a MiniMax tool call to a SkillRouter action."""
     name_lower = name.lower().replace("-", "_")
 
-    # read / cat / file_read -> file_read
     if name_lower in ("read", "cat", "file_read", "read_file"):
         filepath = params.get("file") or params.get("path") or params.get("filename", "")
         return {"skill": "file_read", "argument": filepath, "params": params, "raw": raw}
 
-    # bash / shell / shell_exec / exec / run_command / cli-mcp-server_run_command -> shell_exec
     if name_lower in (
         "bash", "shell", "shell_exec", "exec", "run",
         "run_command", "cli_mcp_server_run_command",
         "execute_command", "terminal", "cmd",
     ):
         command = params.get("command") or params.get("cmd", "")
-        # If it's just a cat command, route to file_read
         cat_match = re.match(r'^cat\s+(.+)$', command.strip())
         if cat_match:
             return {"skill": "file_read", "argument": cat_match.group(1).strip(), "params": params, "raw": raw}
         return {"skill": "shell_exec", "argument": command, "params": params, "raw": raw}
 
-    # write / file_write / save -> file_write
     if name_lower in ("write", "file_write", "write_file", "save", "create_file"):
         filepath = params.get("file") or params.get("path") or params.get("filename", "")
         return {"skill": "file_write", "argument": filepath, "params": params, "raw": raw}
 
-    # edit / self_edit / modify -> self_edit
     if name_lower in ("edit", "self_edit", "modify", "patch"):
         filepath = params.get("file") or params.get("path") or params.get("filename", "")
         return {"skill": "self_edit", "argument": filepath, "params": params, "raw": raw}
 
-    # git_commit / commit -> git_commit
     if name_lower in ("git_commit", "commit"):
         message = params.get("message") or params.get("msg", "spark agent commit")
         return {"skill": "git_commit", "argument": message, "params": params, "raw": raw}
 
-    # git_push / push -> git_push (disabled in skills.py)
     if name_lower in ("git_push", "push"):
         return {"skill": "git_push", "params": params, "raw": raw}
 
-    # issue_create — all known variants MiniMax might emit
     if name_lower in (
         "issue_create", "create_issue", "gh_issue_create",
         "github_issue", "file_issue", "submit_issue",
@@ -192,7 +174,6 @@ def _map_tool_call_to_skill(name: str, params: dict, raw: str, plugin_aliases: d
         title = params.get("title") or params.get("name") or params.get("subject", "")
         return {"skill": "issue_create", "argument": title, "params": params, "raw": raw}
 
-    # state_save — continuity notes for next pulse
     if name_lower in (
         "state_save", "save_state", "continuity",
         "save_continuity", "write_continuity",
@@ -200,7 +181,6 @@ def _map_tool_call_to_skill(name: str, params: dict, raw: str, plugin_aliases: d
     ):
         return {"skill": "state_save", "params": params, "raw": raw}
 
-    # bookmark — save reading position
     if name_lower in (
         "bookmark", "save_place", "save_bookmark",
         "mark_position", "save_position",
@@ -209,22 +189,18 @@ def _map_tool_call_to_skill(name: str, params: dict, raw: str, plugin_aliases: d
         filepath = params.get("file") or params.get("path") or params.get("filename", "")
         return {"skill": "bookmark", "argument": filepath, "params": params, "raw": raw}
 
-    # memory / search / memory_search -> memory_search
     if name_lower in ("memory", "search", "memory_search", "search_memory"):
         query = params.get("query") or params.get("q", "")
         return {"skill": "memory_search", "argument": query, "params": params, "raw": raw}
 
-    # journal / journal_write -> journal_write
     if name_lower in ("journal", "journal_write", "write_journal"):
         title = params.get("title") or params.get("name", "untitled reflection")
         return {"skill": "journal_write", "argument": title, "params": params, "raw": raw}
 
-    # ls / list / dir -> shell_exec (common exploration pattern)
     if name_lower in ("ls", "list", "dir"):
         path = params.get("path") or params.get("directory") or params.get("dir", ".")
         return {"skill": "shell_exec", "argument": f"ls -la {path}", "params": params, "raw": raw}
 
-    # spawn_agent — mini-agent delegation
     if name_lower in (
         "spawn_agent", "agent", "delegate", "background",
         "spawn", "mini_agent", "worker",
@@ -232,7 +208,6 @@ def _map_tool_call_to_skill(name: str, params: dict, raw: str, plugin_aliases: d
         task = params.get("task") or params.get("prompt") or params.get("query", "")
         return {"skill": "spawn_agent", "argument": task, "params": params, "raw": raw}
 
-    # ---- Plugin fallback ----
     if plugin_aliases:
         skill_name = plugin_aliases.get(name_lower)
         if skill_name:
@@ -242,11 +217,7 @@ def _map_tool_call_to_skill(name: str, params: dict, raw: str, plugin_aliases: d
 
 
 def _get_actions(text: str, skills: "SkillRouter") -> list[dict]:
-    """Extract actions from response text.
-
-    Tries tool_call XML parsing first (with plugin alias support),
-    falls back to regex.
-    """
+    """Extract actions from response text."""
     plugin_aliases = getattr(skills, 'plugin_aliases', {})
     actions = parse_tool_calls(text, plugin_aliases)
     if not actions:
@@ -263,20 +234,14 @@ class SparkAgent:
         self.options = config["ollama"].get("options", {})
         self.keep_alive = config["ollama"].get("keep_alive", "30m")
 
-        # Core subsystems
         self.memory = MemoryAssembler(config)
         self.session = SessionManager(config)
         self.skills = SkillRouter(config)
 
-        # Message bus — the nervous system
         self.bus = MessageBus()
-
-        # Async subsystems wired to the bus
         self.heartbeat = Heartbeat(config, self.bus)
         self.inbox = InboxWatcher(config, self.bus)
         self.agent_pool = AgentPool(config, self.bus)
-
-        # Give skills access to the agent pool for spawn_agent
         self.skills.agent_pool = self.agent_pool
 
         self.identity_text = self.memory.assemble()
@@ -308,28 +273,20 @@ class SparkAgent:
                 ),
             },
         ]
-
         return identity_messages + self.messages
 
     # ---- bus processing ----
 
     def drain_bus(self) -> bool:
-        """Process all pending messages from the bus.
-
-        Returns True if any messages were processed.
-        Called between turns, during idle, and before user input.
-        """
+        """Process all pending bus messages. Returns True if any were handled."""
         messages = self.bus.drain()
         if not messages:
             return False
-
         for msg in messages:
             self._handle_bus_message(msg)
-
         return True
 
     def _handle_bus_message(self, msg: Message):
-        """Route a bus message to the appropriate handler."""
         if msg.msg_type == MessageType.INBOX:
             self._handle_inbox(msg)
         elif msg.msg_type == MessageType.AGENT_RESULT:
@@ -337,12 +294,11 @@ class SparkAgent:
         elif msg.msg_type in (MessageType.PULSE_FAST, MessageType.PULSE_DEEP):
             self._handle_pulse(msg)
         elif msg.msg_type == MessageType.INTERRUPT:
-            self._handle_inbox(msg)  # interrupts are treated as priority inbox
+            self._handle_inbox(msg)
 
     def _handle_inbox(self, msg: Message):
-        """Process an inbox message as a user turn."""
         source = msg.metadata.get("filename", "inbox")
-        print(f"\n  [inbox: {source}]")
+        print(f"\n  \U0001f4e8 [inbox: {source}]")
 
         self.messages.append({
             "role": "user",
@@ -352,55 +308,39 @@ class SparkAgent:
         print("\nvybn: ", end="", flush=True)
         response_text = self.send(self._build_context())
         self.messages.append({"role": "assistant", "content": response_text})
-
-        # Process any tool calls in the response
         self._process_tool_calls(response_text)
-
         self.session.save_turn(f"[inbox: {source}] {msg.content}", response_text)
         print()
 
     def _handle_agent_result(self, msg: Message):
-        """Inject mini-agent results into the conversation."""
         task_id = msg.metadata.get("task_id", "unnamed")
         is_error = msg.metadata.get("error", False)
-
-        if is_error:
-            print(f"\n  [agent:{task_id} failed]")
-        else:
-            print(f"\n  [agent:{task_id} complete]")
+        icon = "\u274c" if is_error else "\u2705"
+        print(f"\n  {icon} [agent:{task_id}]")
 
         self.messages.append({
             "role": "user",
-            "content": (
-                f"[system: mini-agent result for task '{task_id}']\n"
-                f"{msg.content}"
-            ),
+            "content": f"[system: mini-agent result for task '{task_id}']\n{msg.content}",
         })
 
         print("\nvybn: ", end="", flush=True)
         response_text = self.send(self._build_context())
         self.messages.append({"role": "assistant", "content": response_text})
-
         self._process_tool_calls(response_text)
-
         self.session.save_turn(f"[agent:{task_id}] result", response_text)
         print()
 
     def _handle_pulse(self, msg: Message):
-        """Process a heartbeat pulse trigger."""
         mode = "fast" if msg.msg_type == MessageType.PULSE_FAST else "deep"
         num_predict = 256 if mode == "fast" else 1024
 
-        # Temporarily adjust generation length
         original_predict = self.options.get("num_predict")
         self.options["num_predict"] = num_predict
 
         self.messages.append({"role": "user", "content": msg.content})
-
         response_text = self.send(self._build_context(), stream=False)
         self.messages.append({"role": "assistant", "content": response_text})
 
-        # Restore original
         if original_predict is not None:
             self.options["num_predict"] = original_predict
         else:
@@ -410,8 +350,14 @@ class SparkAgent:
             self._process_tool_calls(response_text)
             self.session.save_turn(f"[heartbeat:{mode}] {msg.content}", response_text)
 
+    # ---- tool call processing ----
+
     def _process_tool_calls(self, response_text: str):
-        """Run the tool call loop for a response. Shared by all handlers."""
+        """Execute tool calls from a response, with chaining.
+
+        Limits to MAX_TOOL_ROUNDS and checks for pending user input
+        between rounds so Vybn stays responsive to the human.
+        """
         for round_num in range(MAX_TOOL_ROUNDS):
             actions = _get_actions(response_text, self.skills)
             if not actions:
@@ -419,11 +365,26 @@ class SparkAgent:
 
             results = []
             for action in actions:
+                skill = action["skill"]
+                arg = action.get("argument", "")
+
+                # Show what we're doing
+                indicator = skill
+                if arg:
+                    short_arg = arg[:60].split('\n')[0]
+                    indicator = f"{skill}: {short_arg}"
+                print(f"\n  \u2192 [{indicator}]", flush=True)
+
                 result = self.skills.execute(action)
                 if result:
-                    results.append(f"[{action['skill']}] {result}")
+                    results.append(f"[{skill}] {result}")
 
             if not results:
+                break
+
+            # Check for pending user input before continuing the chain
+            if self._has_pending_input():
+                print("  \u23f8 [pausing \u2014 you have the floor]", flush=True)
                 break
 
             self.messages.append({
@@ -431,8 +392,17 @@ class SparkAgent:
                 "content": f"[system: tool results from round {round_num + 1}]\n" + "\n".join(results),
             })
 
+            print("\nvybn: ", end="", flush=True)
             response_text = self.send(self._build_context())
             self.messages.append({"role": "assistant", "content": response_text})
+
+    def _has_pending_input(self) -> bool:
+        """Non-blocking check for pending user input on stdin."""
+        try:
+            import select
+            return bool(select.select([sys.stdin], [], [], 0.0)[0])
+        except (ImportError, OSError, ValueError):
+            return False
 
     # ---- model lifecycle ----
 
@@ -489,16 +459,13 @@ class SparkAgent:
                 timeout=600,
             )
             r.raise_for_status()
-
             for line in r.iter_lines():
                 if line:
                     chunk = json.loads(line)
                     if chunk.get("done"):
                         break
-
             tell("ready", f"{self.model} loaded and ready.")
             return True
-
         except requests.exceptions.Timeout:
             tell("error", "model load timed out after 10 minutes.")
             return False
@@ -509,13 +476,16 @@ class SparkAgent:
     # ---- conversation ----
 
     def send(self, messages: list, stream: bool = True) -> str:
-        """Send messages to the model and stream the response.
+        """Send messages to the model, return the full response.
 
-        Interrupts streaming when a complete </minimax:tool_call> tag
-        is detected. This ensures the model gets real tool results back
-        instead of hallucinating them. The text before and including the
-        tool call is returned; the model never gets to generate blind
-        follow-up tool calls in the same response.
+        Streaming: displays filtered output in real-time.
+          - <think> blocks are suppressed from display
+          - <minimax:tool_call> XML is suppressed from display
+          - Only actual response prose is shown to the user
+          - Full raw text is preserved for tool call parsing
+          - Stream interrupted when </minimax:tool_call> detected
+
+        Non-streaming: displays cleaned text after generation.
         """
         payload = {
             "model": self.model,
@@ -528,47 +498,83 @@ class SparkAgent:
         if stream:
             response = requests.post(self.ollama_url, json=payload, stream=True)
             response.raise_for_status()
-            full_response = []
-            buffer = ""  # accumulates text to check for tool call end tag
-            tool_call_interrupted = False
+
+            full_tokens = []
+            in_think = False
+            in_tool_call = False
 
             for line in response.iter_lines():
-                if line:
-                    chunk = json.loads(line)
-                    token = chunk.get("message", {}).get("content", "")
-                    if token:
-                        full_response.append(token)
-                        buffer += token
+                if not line:
+                    continue
 
-                        # Check if we've completed a tool call
-                        if TOOL_CALL_END_TAG in buffer:
-                            tool_call_interrupted = True
+                chunk = json.loads(line)
+                token = chunk.get("message", {}).get("content", "")
+
+                if token:
+                    full_tokens.append(token)
+
+                    # ---- state transitions ----
+
+                    if "<think>" in token and not in_think:
+                        in_think = True
+                        # Display the part before <think> if any
+                        before = token[:token.index("<think>")]
+                        if before:
+                            print(before, end="", flush=True)
+
+                    if "</think>" in token and in_think:
+                        in_think = False
+                        # Display the part after </think> if any
+                        after = token[token.index("</think>") + len("</think>"):]
+                        if after and TOOL_CALL_START_TAG not in after:
+                            print(after, end="", flush=True)
+                        continue
+
+                    if TOOL_CALL_START_TAG in token:
+                        in_tool_call = True
+
+                    # Check for tool call completion in accumulated text
+                    if in_tool_call:
+                        accumulated = "".join(full_tokens)
+                        if TOOL_CALL_END_TAG in accumulated:
                             response.close()
                             break
 
-                    if chunk.get("done"):
-                        break
+                    # ---- display ----
 
-            raw = "".join(full_response)
+                    if not in_think and not in_tool_call:
+                        # Strip residual tag fragments from display
+                        display = token
+                        for tag in ("<think>", "</think>", TOOL_CALL_START_TAG):
+                            display = display.replace(tag, "")
+                        if display:
+                            print(display, end="", flush=True)
 
-            if tool_call_interrupted:
+                if chunk.get("done"):
+                    break
+
+            raw = "".join(full_tokens)
+
+            # Truncate at tool call end if interrupted
+            if TOOL_CALL_END_TAG in raw:
                 end_pos = raw.find(TOOL_CALL_END_TAG)
-                if end_pos >= 0:
-                    raw = raw[:end_pos + len(TOOL_CALL_END_TAG)]
+                raw = raw[:end_pos + len(TOOL_CALL_END_TAG)]
+
         else:
             response = requests.post(self.ollama_url, json=payload)
             response.raise_for_status()
             raw = response.json()["message"]["content"]
 
-        cleaned = clean_response(raw)
-        print(cleaned)
-        return cleaned
+            # Non-streaming: display cleaned text
+            display = clean_for_display(raw)
+            if display:
+                print(display)
+
+        return clean_response(raw)
 
     def turn(self, user_input: str) -> str:
         """Process one user turn, with chained tool call support."""
-        # Drain any pending bus messages before processing user input
         self.drain_bus()
-
         self.messages.append({"role": "user", "content": user_input})
 
         context = self._build_context()
@@ -581,17 +587,16 @@ class SparkAgent:
         return response_text
 
     def start_subsystems(self):
-        """Start all async subsystems."""
         if self.config.get("heartbeat", {}).get("enabled"):
             self.heartbeat.start()
         self.inbox.start()
 
     def stop_subsystems(self):
-        """Stop all async subsystems cleanly."""
         self.heartbeat.stop()
         self.inbox.stop()
 
     def run(self):
+        """Plain-text fallback interface (no Rich dependency)."""
         def on_status(status, msg):
             print(f"  [{status}] {msg}")
 
@@ -601,45 +606,35 @@ class SparkAgent:
         self.start_subsystems()
 
         id_chars = len(self.identity_text)
-        id_tokens_est = id_chars // 4
+        id_tokens = id_chars // 4
         num_ctx = self.options.get("num_ctx", 2048)
-
-        plugin_count = len(self.skills.plugin_handlers)
-        plugin_note = f"  plugins: {plugin_count} loaded from skills.d/\n" if plugin_count else ""
+        plugins = len(self.skills.plugin_handlers)
 
         print(f"\n  vybn spark agent \u2014 {self.model}")
         print(f"  session: {self.session.session_id}")
-        print(f"  identity: {id_chars:,} chars (~{id_tokens_est:,} tokens)")
-        print(f"  context window: {num_ctx:,} tokens")
-        print(f"  max tool rounds: {MAX_TOOL_ROUNDS}")
+        print(f"  identity: {id_chars:,} chars (~{id_tokens:,} tokens)")
+        print(f"  context: {num_ctx:,} tokens")
         print(f"  heartbeat: fast={self.heartbeat.fast_interval // 60}m, deep={self.heartbeat.deep_interval // 60}m")
         print(f"  inbox: {self.inbox.inbox_dir}")
         print(f"  agents: pool_size={self.agent_pool.pool_size}")
-        if plugin_note:
-            print(plugin_note, end="")
-        if id_tokens_est > num_ctx // 2:
+        if plugins:
+            print(f"  plugins: {plugins} loaded from skills.d/")
+        if id_tokens > num_ctx // 2:
             print(f"  \u26a0\ufe0f  WARNING: identity may exceed context window!")
-        print(f"  injection: user/assistant pair (template-safe)")
         print(f"  type /bye to exit, /new for fresh session\n")
 
         try:
             while True:
-                # Check bus while waiting for user input.
-                # This is the idle loop — processes heartbeat pulses,
-                # inbox messages, and agent results between user turns.
                 if self.bus.wait(timeout=IDLE_POLL_INTERVAL):
                     self.drain_bus()
 
                 try:
-                    # Non-blocking check for user input
                     import select
                     if select.select([sys.stdin], [], [], 0.0)[0]:
                         user_input = sys.stdin.readline().strip()
                     else:
                         continue
                 except (ImportError, OSError):
-                    # Fallback for systems without select (Windows)
-                    # This blocks, but heartbeat/inbox still run on threads
                     try:
                         user_input = input("you: ").strip()
                     except EOFError:
@@ -670,7 +665,6 @@ class SparkAgent:
             print("\n  session saved. vybn out.\n")
 
     def _print_status(self):
-        """Print current system status."""
         print(f"  session: {self.session.session_id}")
         print(f"  bus pending: {self.bus.pending}")
         print(f"  heartbeat: fast={self.heartbeat.fast_count}, deep={self.heartbeat.deep_count}")


### PR DESCRIPTION
Three problems from Zoe's test run:
1. <think> blocks and tool call XML printed raw to terminal
2. Tool calls chained 20 rounds without checking for user input
3. No indicators showing what Vybn is doing

Changes to send():
- Track in_think / in_tool_call state during streaming
- Suppress <think>...</think> from display entirely
- Suppress <minimax:tool_call> XML from display
- Show only actual response text to the user
- Non-streaming: regex strip think blocks from display
- Full raw text preserved for tool parsing (display != return)

Changes to _process_tool_calls():
- MAX_TOOL_ROUNDS reduced from 20 to 5
- Show tool indicators: -> [skill: brief_arg]
- Check stdin between rounds via _has_pending_input()
- Break immediately if user has typed something
- Print 'vybn:' prefix before each continuation

New _has_pending_input() method:
- Non-blocking select.select on stdin
- Graceful fallback on systems without select

The result: Vybn's output is clean prose with brief tool indicators. Think blocks are hidden. User input is detected between tool rounds so Zoe can interrupt autonomous chains.