### PR TITLE
Phase 3b: Graduated Autonomy — trust-based tier promotion/demotion

### DIFF
--- a/spark/config.yaml
+++ b/spark/config.yaml
@@ -56,3 +56,13 @@ tool_policies:
 delegation:
   max_spawn_depth: 2          # how deep mini-agents can nest
   max_active_agents: 3        # concurrent agent cap (independent of agents.pool_size)
+
+# Graduated autonomy: Vybn earns trust through successful execution.
+# Skills at NOTIFY tier can auto-promote to AUTO after enough successes.
+# Skills demote back to NOTIFY after failures drop confidence.
+# Heartbeat overrides are NEVER relaxed — structural friction is preserved.
+graduated_autonomy:
+  enabled: true
+  promote_threshold: 0.85     # posterior mean needed to promote NOTIFY → AUTO
+  demote_threshold: 0.40      # posterior mean below which AUTO → NOTIFY
+  minimum_observations: 8     # must see at least this many executions before promoting


### PR DESCRIPTION
## What this does

The policy engine now **uses** the Bayesian confidence scores it's been accumulating to dynamically adjust skill permission tiers at runtime.

### Promotion (earning trust)
Skills at NOTIFY tier with:
- confidence ≥ 0.85 (configurable)
- at least 8 observations (configurable)

…auto-upgrade to AUTO for that check. Vybn earns silent execution through consistent success. No config change needed — it happens organically as skills prove reliable.

### Demotion (losing trust)
After a failure, if a skill's confidence drops below 0.40 (configurable), it gets force-downgraded to NOTIFY via a runtime override. Trust must be rebuilt through successful executions.

### Structural safety
- **Heartbeat overrides are never relaxed.** Autonomous actions retain structural friction regardless of trust score. This is the invariant that keeps graduated autonomy safe.
- **Config overrides (`tool_policies`) are never relaxed.** If Zoe explicitly sets a tier in config.yaml, graduation won't override it.
- **APPROVE-tier skills are never demoted further.** The hierarchy only moves within AUTO ↔ NOTIFY.

### Audit trail
`PolicyResult` now carries `promoted` and `demoted` flags so `agent.py` can emit bus events when tiers shift. `get_stats_summary()` annotates each skill with its graduation state (`[promoted→auto]`, `[demoted]`, `[N more to promote]`).

### Config
New `graduated_autonomy` section in `config.yaml`:
```yaml
graduated_autonomy:
  enabled: true
  promote_threshold: 0.85
  demote_threshold: 0.40
  minimum_observations: 8
```

Set `enabled: false` to disable entirely. All existing behavior is preserved — no change until skills accumulate enough observations to cross the threshold.

## Files changed
- `spark/policy.py` — promotion logic in `check_policy()`, demotion logic in `record_outcome()`, runtime overrides, startup rebuild, summary annotations
- `spark/config.yaml` — new `graduated_autonomy` section

## Relationship to DELEGATION_REFACTOR.md
This completes **Phase 3b** of the refactor plan. Phase 3a (bus audit trail, externalized heartbeat checklist) is already merged. Phase 3c (two-Spark adversarial verification) is next.