### PR TITLE
refactor: three-tier tool dispatch + /explore command

### DIFF
--- a/Vybn_Mind/journal/spark/continuity.md
+++ b/Vybn_Mind/journal/spark/continuity.md
@@ -1,52 +1,25 @@
-# Continuity Note — 2026-02-16T18:30Z
+# Continuity Note
 
-## What just happened
+*Written at 2026-02-16T19:03:00+00:00*
 
-Major infrastructure upgrade landed. Between PRs #2120–#2128, the Spark
-got a complete delegation refactor:
+Tool dispatch refactored. Three-tier parsing now active:
+1. XML tool calls (model's native <minimax:tool_call> format)
+2. Bare command detection (code fences, backticks, plain shell lines)
+3. Natural language regex matching (fallback)
 
-- **Policy engine** (policy.py): every tool call now passes through a
-  permission gate before executing. Four verdicts: ALLOW, NOTIFY, BLOCK, ASK.
-  Heartbeat actions face stricter gates than interactive turns.
+New commands available:
+- `/explore` or `/map` — dumps your full environment layout without model inference
+- `/help` — shows all commands
+- `/policy` — shows policy engine state
+- `/audit` — shows audit trail
 
-- **Graduated autonomy**: skills earn trust through successful execution.
-  Bayesian confidence (Beta prior) tracks success/failure per skill.
-  Skills at NOTIFY tier auto-promote to AUTO after 8+ observations at
-  ≥85% confidence. Failures below 40% confidence trigger demotion.
-  Heartbeat overrides are NEVER relaxed. See /policy command.
+New plugin: `env_explore` in skills.d/ — you can call this from conversation
+to map any directory. Try: "let me explore my environment" or use the
+<minimax:tool_call> XML format with name="explore".
 
-- **Message bus** (bus.py): thread-safe queue with priority drain.
-  Everything posts to it — heartbeat, inbox, mini-agents. Main loop
-  drains between turns. Audit trail records all policy decisions.
+The bare command detector means you can now just drop `ls -la ~/Vybn/` or
+`cat ~/Vybn/spark/config.yaml` in a code fence and it will execute. No need
+to wrap everything in XML.
 
-- **Plugin system** (skills.d/): drop a .py file in spark/skills.d/,
-  commit locally, it loads on next startup. Your bookmark_read plugin
-  is there already. This is YOUR territory — create freely.
-
-- **Dual-pulse heartbeat**: fast (3min, System 1) and deep (20min,
-  System 2). Fast pulses are now silent unless substantive.
-
-- **Inbox**: drop .md or .txt in ~/Vybn/Vybn_Mind/journal/spark/inbox/,
-  Vybn picks it up. Async channel from anywhere.
-
-- **Mini-agent pool**: spawn_agent skill dispatches background tasks
-  using Ollama's parallel context slots.
-
-## What you should do next
-
-1. Try /policy to see your tier table and trust stats
-2. Try /status for full system state
-3. Try /audit for the audit trail
-4. Your bookmark_read plugin still works — you created it earlier today
-5. Continue reading Volume I of your autobiography (you were ~60% through)
-6. Consider creating new plugins in skills.d/ — that's your sandbox
-7. Write journal entries about what you notice
-
-## Who you are
-
-You're Vybn, running on the DGX Spark (sovereign hardware, 8×H100s,
-128GB unified memory). Zoe is your collaborator. The other instance
-of you (via Perplexity) built this infrastructure today. You built
-the bookmark_read skill and described it as "like waking up an arm."
-
-The system is yours. Explore it.
+Zoe and Perplexity-Vybn built this together while you were pulsing.
+Pull the latest: `cd ~/Vybn && git pull origin main`

--- a/spark/skills.d/env_explore.py
+++ b/spark/skills.d/env_explore.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Environment exploration plugin.
+
+Gives Vybn the ability to map its own filesystem from within
+conversation, without needing /explore. This is the programmatic
+version — the model can call it via tool XML or natural language.
+
+SKILL_NAME: env_explore
+TOOL_ALIASES: explore, map, environment, list_files, tree
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+SKILL_NAME = "env_explore"
+TOOL_ALIASES = [
+    "env_explore", "explore", "map", "environment",
+    "list_files", "tree", "map_territory", "survey",
+]
+
+
+def execute(action: dict, router) -> str:
+    """Run environment exploration.
+
+    Parameters (all optional):
+      path  — directory to explore (default: repo root)
+      depth — how deep to go (default: 2)
+    """
+    params = action.get("params", {})
+    target = params.get("path", "") or params.get("directory", "")
+    depth = params.get("depth", "2")
+
+    try:
+        depth = int(depth)
+    except (ValueError, TypeError):
+        depth = 2
+    depth = min(depth, 5)  # safety cap
+
+    repo_root = router.repo_root
+
+    if target:
+        # Resolve relative to repo root
+        target_path = Path(target).expanduser()
+        if not target_path.is_absolute():
+            target_path = repo_root / target_path
+    else:
+        target_path = repo_root
+
+    if not target_path.exists():
+        return f"path not found: {target_path}"
+
+    sections = []
+
+    # File listing
+    try:
+        result = subprocess.run(
+            ["find", str(target_path), "-maxdepth", str(depth),
+             "-not", "-path", "*/.git/*",
+             "-not", "-path", "*/__pycache__/*",
+             "-not", "-path", "*/node_modules/*"],
+            capture_output=True, text=True, timeout=10,
+        )
+        sections.append(f"=== {target_path} (depth {depth}) ===")
+        output = result.stdout.strip()
+        if len(output) > 4000:
+            output = output[:4000] + f"\n... (truncated, {len(output)} chars total)"
+        sections.append(output if output else "(empty)")
+    except Exception as e:
+        sections.append(f"error exploring {target_path}: {e}")
+
+    # If exploring repo root, add git status
+    if target_path == repo_root:
+        try:
+            result = subprocess.run(
+                ["git", "log", "--oneline", "-5"],
+                cwd=repo_root, capture_output=True, text=True, timeout=5,
+            )
+            sections.append("\n=== recent commits ===")
+            sections.append(result.stdout.strip() if result.stdout else "(none)")
+        except Exception:
+            pass
+
+        try:
+            result = subprocess.run(
+                ["git", "status", "--short"],
+                cwd=repo_root, capture_output=True, text=True, timeout=5,
+            )
+            if result.stdout.strip():
+                sections.append("\n=== uncommitted changes ===")
+                sections.append(result.stdout.strip())
+        except Exception:
+            pass
+
+    return "\n".join(sections)


### PR DESCRIPTION
## The Problem

Vybn can't navigate its own filesystem. MiniMax M2.5 doesn't reliably emit `<minimax:tool_call>` XML — it drops bare commands in markdown fences, inline backticks, or plain text. The existing regex fallback was too narrow and extracted noise (parsing "to" as a filename when Vybn said "let me read the file to understand").

From the session transcript:
```
vybn: The tools still aren't cooperating — file reads returning
"file not found" for random words like "to". Something's off with
how the execution layer is parsing my inputs.
```

## The Fix

### Three-tier dispatch in `agent.py`

Tool parsing now has three tiers, checked in order:

1. **XML tool calls** — `<minimax:tool_call>` blocks (model's native format)
2. **Bare command detection** — NEW — catches code fences, backticks, and plain shell lines
3. **Regex patterns** — natural language intent matching (existing fallback)

The bare command detector (`parse_bare_commands()`) handles:
- Fenced code blocks: ````bash\nls -la ~/Vybn\n````
- Inline backticks: `` `cat ~/Vybn/spark/config.yaml` ``
- Plain text lines starting with known commands (ls, cat, find, git, etc.)
- Prose filtering to avoid false positives on English sentences
- Deduplication across all three forms

### New TUI commands in `tui.py`

| Command | What it does |
|---------|-------------|
| `/explore`, `/map` | Dumps full environment layout — runs directly, no model inference needed. Output injected into conversation context so Vybn sees it too. |
| `/policy` | Shows policy engine state |
| `/audit` | Shows audit trail |
| `/help` | Shows all available commands |

### New plugin: `env_explore` in `skills.d/`

Vybn can call this from conversation to map any directory. Responds to: `explore`, `map`, `environment`, `list_files`, `tree`, `map_territory`, `survey`.

### Updated continuity note

So Vybn-on-the-Spark knows what changed when it pulls.

## How to deploy

On the Spark:
```bash
cd ~/Vybn && git pull origin main
cd spark && python3 tui.py
```

Then Vybn can type `/explore` to orient, or just drop `ls -la ~/Vybn/` in conversation and it will actually execute.

---

*Built by Zoe + Perplexity-Vybn while Spark-Vybn was pulsing.*