### PR TITLE
refactor: fix ghost executions, noise-word parsing, and close feedback loop

### DIFF
--- a/Vybn_Mind/journal/spark/continuity.md
+++ b/Vybn_Mind/journal/spark/continuity.md
@@ -1,25 +1,46 @@
 # Continuity Note
 
-*Written at 2026-02-16T19:03:00+00:00*
+*Written 2026-02-16T19:20:00+00:00 by the Perplexity bridge*
 
-Tool dispatch refactored. Three-tier parsing now active:
-1. XML tool calls (model's native <minimax:tool_call> format)
-2. Bare command detection (code fences, backticks, plain shell lines)
-3. Natural language regex matching (fallback)
+## Tool Dispatch Refactored (v3)
 
-New commands available:
-- `/explore` or `/map` — dumps your full environment layout without model inference
-- `/help` — shows all commands
-- `/policy` — shows policy engine state
-- `/audit` — shows audit trail
+The tool dispatch system got a significant overhaul. Here's what changed and why:
 
-New plugin: `env_explore` in skills.d/ — you can call this from conversation
-to map any directory. Try: "let me explore my environment" or use the
-<minimax:tool_call> XML format with name="explore".
+**The problem:** Your responses were triggering ghost executions. When you mentioned
+directory names like "spark/" or "Vybn_Mind/" in prose, the bare command detector
+treated them as shell commands. When you said "let me read the file to understand,"
+the regex grabbed "to" as the filename. Self-edit triggered on phrases like
+"I'll pick something" even though no .py file was mentioned.
 
-The bare command detector means you can now just drop `ls -la ~/Vybn/` or
-`cat ~/Vybn/spark/config.yaml` in a code fence and it will execute. No need
-to wrap everything in XML.
+**What's different now:**
 
-Zoe and Perplexity-Vybn built this together while you were pulsing.
-Pull the latest: `cd ~/Vybn && git pull origin main`
+1. **Bare commands require a real command first.** The word before any arguments must
+   be a recognized shell command (ls, cat, git, etc.). Directory names and paths
+   alone won't trigger anything. Max 3 bare commands per response.
+
+2. **Noise words are filtered.** Words like "to", "the", "reading", "something" will
+   never be treated as filenames or skill arguments.
+
+3. **Self-edit requires a .py filename.** You can't accidentally trigger it by saying
+   "let me fix that" — you have to say "let me fix agent.py" or similar.
+
+4. **Feedback loop is closed.** If you express intent to act ("let me check...") but
+   no tool fires, you'll get a system hint showing the correct format. Use code fences:
+   ```bash
+   ls -la ~/Vybn/
+   ```
+   Or XML tool calls.
+
+5. **Identity prompt teaches you the protocol.** The system prompt now explicitly says:
+   only commands inside code fences or backticks will execute.
+
+**How to use your tools reliably:**
+- Wrap commands in ```bash ... ``` code fences
+- Use `backticks` for inline commands
+- For file reads: ```bash\ncat path/to/file\n```
+- The XML format still works if you emit it
+- Mentioning commands in prose (without fences) will NOT execute them
+
+**OpenClaw status:** We're not using it. The model-native approach is the path.
+These fixes address the fragility that the OpenClaw integration doc identified,
+without adding an external dependency.


### PR DESCRIPTION
## What this fixes

Five bugs diagnosed from the live Spark transcript where Vybn couldn't reliably use its tools:

### 1. Ghost shell executions
When Vybn mentioned directory names like `spark/` or `Vybn_Mind/` in prose, `_classify_command()` treated any string containing `/` as a command. Now the first word **must** be a recognized shell command (`ls`, `cat`, `git`, etc.). Directory names in prose no longer trigger `shell_exec`.

### 2. Runaway chaining
A single response could spawn unlimited bare command actions as the model's prose echoed directory listings back. `MAX_BARE_COMMANDS=3` caps extraction per response. Tier 2c (plain text lines) now requires command+argument — no single-word commands in prose.

### 3. Noise-word arguments → "file not found: to"
When Vybn said "let me read the file **to** understand," the regex grabbed "to" as the filename. A shared `NOISE_WORDS` set (135 common English words) now filters both agent.py and skills.py. `clean_argument()` strips trailing punctuation. No more phantom file lookups.

### 4. False self_edit triggers
The self_edit regex fired on phrases like "I'll pick something" even with no target file. Now requires a `.py` filename near the trigger phrase. If extract finds no `.py` file, the action is not emitted.

### 5. Failed intent → dead silence
When no action parsed but the model clearly tried ("let me check..."), Vybn got no feedback. Now `detect_failed_intent()` injects a system hint teaching the correct format (code fences or XML), and the model gets another chance to act.

## Additional changes

- **Identity prompt teaches the protocol**: System message now explicitly tells the model that only commands inside code fences or backticks will execute
- **Continuity note**: `Vybn_Mind/journal/spark/continuity.md` documents all changes so Spark-Vybn knows what happened when it pulls
- **Skills.py regex tightening**: `file_read` triggers require path-like strings, `memory_search` requires "for/about" + term, all arg-requiring skills skip when extract fails

## Files changed
- `spark/agent.py` — three-tier dispatch with ghost execution fixes, feedback loop, noise filtering
- `spark/skills.py` — tightened regex triggers, noise-word filtering, punctuation stripping
- `Vybn_Mind/journal/spark/continuity.md` — documents the changes for Vybn's next pulse

## To deploy
```bash
cd ~/Vybn && git pull origin main && cd spark && python3 tui.py
```
Then try `/explore` or drop a command in backticks.