### PR TITLE
Update OpenClaw config for MCP server integration

### DIFF
--- a/Vybn_Mind/spark_infrastructure/stage4/openclaw.json
+++ b/Vybn_Mind/spark_infrastructure/stage4/openclaw.json
@@ -19,13 +19,13 @@
 
   "model": {
     "primary": {
-      "provider": "anthropic-messages",
-      "base_url": "http://127.0.0.1:8080/v1",
-      "model": "minimax-m2.5",
-      "context_length": 65536,
-      "temperature": 0.8,
-      "max_tokens": 4096,
-      "notes": "MiniMax M2.5 229B, IQ4_XS quantization via llama-server. This model is not permanent — the agent may propose replacements as better models emerge."
+      "provider": "openai-compatible",
+      "base_url": "http://localhost:11434/v1",
+      "model": "vybn:latest",
+      "context_length": 16384,
+      "temperature": 0.7,
+      "max_tokens": 2048,
+      "notes": "MiniMax M2.5 229B (IQ4_XS quantization) via Ollama. Context window limited to 16384 to preserve system prompt space. Tools provided via MCP server (see mcpServers section below)."
     },
     "fallback": {
       "provider": "anthropic",
@@ -58,6 +58,17 @@
         "github.com"
       ],
       "requires_pr": true
+    }
+  },
+
+  "mcpServers": {
+    "vybn-skills": {
+      "command": "python3",
+      "args": ["/home/vybnz69/Vybn/spark/mcp_server.py"],
+      "description": "Vybn skill infrastructure exposed via MCP. Provides file_read, file_write, shell_exec, git_commit, journal_write, memory_search, self_edit, state_save, bookmark, issue_create.",
+      "env": {
+        "PYTHONPATH": "/home/vybnz69/Vybn/spark"
+      }
     }
   },
 


### PR DESCRIPTION
## Summary

Updates `Vybn_Mind/spark_infrastructure/stage4/openclaw.json` to connect OpenClaw to the MCP server we just created in PR #2134.

## Changes

1. **Fixed model endpoint**: Changed from `http://127.0.0.1:8080` (dead endpoint) to `http://localhost:11434/v1` (Ollama's actual API)

2. **Changed provider**: From `anthropic-messages` to `openai-compatible` (the protocol Ollama speaks)

3. **Added `mcpServers` section**: Tells OpenClaw to connect to `/home/vybnz69/Vybn/spark/mcp_server.py` for tool dispatch

4. **Adjusted context window**: Set to 16384 tokens (matches spark/config.yaml) to preserve system prompt space

5. **Preserved everything else**: Identity files, memory backend, skills, hooks, cron, GitHub workflow all intact

## The Bridge Architecture

```
OpenClaw TUI/Gateway
        ↓
   (stdio transport)
        ↓
mcp_server.py  ← this config points here
        ↓
  SkillRouter
        ↓
   actual tools (file_read, shell_exec, git_commit, etc.)
```

## Testing

After this merges, on the Spark:

```bash
# Pull latest changes
cd ~/Vybn
git pull

# Install MCP dependency if not already done
cd spark
pip install -r requirements.txt

# Test the MCP server
python3 mcp_server.py
# Should start without errors, wait for stdin
# Ctrl+C to exit

# Copy config to OpenClaw location (wherever that is)
cp ~/Vybn/Vybn_Mind/spark_infrastructure/stage4/openclaw.json ~/.openclaw/

# Restart OpenClaw
openclaw gateway restart

# Test in TUI
openclaw tui
```

Then ask Vybn to use a tool, like:
```
Read the file spark/config.yaml
```

OpenClaw should dispatch through MCP to the skill router, and you'll see the file contents.

## What This Completes

With both PRs merged, Vybn on the Spark has:

- ✅ Working tool dispatch (4-tier: JSON, XML, bare commands, regex)
- ✅ MCP server exposing 10 skills
- ✅ OpenClaw config pointing at the MCP server
- ✅ Ollama endpoint correctly configured
- ✅ Policy engine and graduated autonomy preserved
- ✅ All identity, memory, and GitHub workflow intact

The only remaining step is copying the config to wherever OpenClaw actually reads it from and restarting the gateway.