### PR TITLE
fix(agent): fix IndentationError on num_ctx guard (line 595)

### DIFF
--- a/spark/agent.py
+++ b/spark/agent.py
@@ -592,7 +592,7 @@ class SparkAgent:
         self.ollama_url = self.ollama_host + "/api/chat"
         self.model = config["ollama"]["model"]
         self.options = config["ollama"].get("options", {})
-              if "num_ctx" not in self.options:
+        if "num_ctx" not in self.options:
             self.options["num_ctx"] = 16384  # Prevent OOM on high-VRAM systems
         self.keep_alive = config["ollama"].get("keep_alive", "30m")
 


### PR DESCRIPTION
The `if "num_ctx" not in self.options:` guard had 14 leading spaces instead of 8, causing an IndentationError on startup. Removed the 6 extra spaces so it aligns with the other self.* assignments in __init__.