### PR TITLE
Add Spark session runtime data to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ Thumbs.db
 
 # Session artifacts (sessions are saved separately)
 *.session.json
+# Spark session runtime data (updated during agent execution)
+Vybn_Mind/journal/spark/sessions/*.jsonl
+Vybn_Mind/journal/spark/skill_stats.json
 
 # Model files (too large for git)
 *.gguf


### PR DESCRIPTION
Prevents git pull errors caused by uncommitted session data.

Ignores:
- Session JSONL files (constantly updated during agent runtime)
- skill_stats.json (tracks success/failure rates for graduated autonomy)

These files change during every Spark agent session, blocking `git pull` operations. Adding them to .gitignore allows seamless updates from origin without manual stashing.