### PR TITLE
feat: Vybn Mobile Chat Interface — real-time web UI with voice

### DIFF
--- a/spark/static/chat.js
+++ b/spark/static/chat.js
@@ -1,0 +1,186 @@
+/* ========================================================
+   Vybn Chat — client logic
+   ======================================================== */
+
+let ws = null;
+let token = "";
+let mediaRecorder = null;
+let audioChunks = [];
+
+// ---- DOM refs ----
+const loginScreen = document.getElementById("login-screen");
+const chatScreen  = document.getElementById("chat-screen");
+const tokenInput  = document.getElementById("token-input");
+const messages    = document.getElementById("messages");
+const msgInput    = document.getElementById("msg-input");
+const statusText  = document.getElementById("status-text");
+const micBtn      = document.getElementById("mic-btn");
+const recInd      = document.getElementById("recording-indicator");
+const menuOverlay = document.getElementById("menu-overlay");
+
+// ---- Login ----
+function doLogin() {
+  token = tokenInput.value.trim();
+  if (!token) return;
+  loginScreen.classList.remove("active");
+  chatScreen.classList.add("active");
+  connectWS();
+}
+tokenInput.addEventListener("keydown", e => { if (e.key === "Enter") doLogin(); });
+
+function doLogout() {
+  if (ws) ws.close();
+  chatScreen.classList.remove("active");
+  loginScreen.classList.add("active");
+  tokenInput.value = "";
+  messages.innerHTML = "";
+  toggleMenu();
+}
+
+// ---- WebSocket ----
+function connectWS() {
+  const proto = location.protocol === "https:" ? "wss:" : "ws:";
+  ws = new WebSocket(`${proto}//${location.host}/ws?token=${encodeURIComponent(token)}`);
+
+  ws.onopen = () => {
+    statusText.textContent = "connected";
+    statusText.style.color = "#5cffb2";
+  };
+  ws.onclose = () => {
+    statusText.textContent = "disconnected";
+    statusText.style.color = "#ff5c6c";
+    setTimeout(connectWS, 3000);
+  };
+  ws.onerror = () => {};
+  ws.onmessage = (evt) => {
+    const data = JSON.parse(evt.data);
+    if (data.type === "message") appendMessage(data);
+  };
+}
+
+// ---- Messages ----
+function appendMessage(data) {
+  // Remove typing indicator if present
+  const typing = messages.querySelector(".typing-indicator");
+  if (typing) typing.remove();
+
+  const div = document.createElement("div");
+  div.className = `msg ${data.role === "user" ? "user" : "vybn"}`;
+
+  const text = document.createTextNode(data.content);
+  div.appendChild(text);
+
+  if (data.ts) {
+    const ts = document.createElement("span");
+    ts.className = "timestamp";
+    const d = new Date(data.ts);
+    ts.textContent = d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+    div.appendChild(ts);
+  }
+  messages.appendChild(div);
+  messages.scrollTop = messages.scrollHeight;
+}
+
+function showTyping() {
+  if (messages.querySelector(".typing-indicator")) return;
+  const div = document.createElement("div");
+  div.className = "typing-indicator";
+  div.innerHTML = "<span></span><span></span><span></span>";
+  messages.appendChild(div);
+  messages.scrollTop = messages.scrollHeight;
+}
+
+// ---- Send ----
+function sendMessage() {
+  const text = msgInput.value.trim();
+  if (!text || !ws || ws.readyState !== WebSocket.OPEN) return;
+  ws.send(JSON.stringify({ message: text }));
+  msgInput.value = "";
+  msgInput.style.height = "auto";
+  showTyping();
+}
+
+function handleKey(e) {
+  if (e.key === "Enter" && !e.shiftKey) {
+    e.preventDefault();
+    sendMessage();
+  }
+}
+
+function autoGrow(el) {
+  el.style.height = "auto";
+  el.style.height = Math.min(el.scrollHeight, 120) + "px";
+}
+
+// ---- Voice ----
+async function toggleVoice() {
+  if (mediaRecorder && mediaRecorder.state === "recording") {
+    mediaRecorder.stop();
+    micBtn.classList.remove("recording");
+    recInd.classList.add("hidden");
+    return;
+  }
+
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    audioChunks = [];
+    mediaRecorder = new MediaRecorder(stream, { mimeType: "audio/webm" });
+    mediaRecorder.ondataavailable = e => audioChunks.push(e.data);
+    mediaRecorder.onstop = async () => {
+      stream.getTracks().forEach(t => t.stop());
+      const blob = new Blob(audioChunks, { type: "audio/webm" });
+      await transcribeAndSend(blob);
+    };
+    mediaRecorder.start();
+    micBtn.classList.add("recording");
+    recInd.classList.remove("hidden");
+  } catch (err) {
+    alert("Microphone access denied or unavailable.");
+  }
+}
+
+async function transcribeAndSend(blob) {
+  const form = new FormData();
+  form.append("audio", blob, "voice.webm");
+  try {
+    const resp = await fetch("/voice", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+      body: form,
+    });
+    if (!resp.ok) {
+      // Whisper not available — fall back gracefully
+      const err = await resp.json().catch(() => ({}));
+      alert(err.detail || "Voice transcription unavailable");
+      return;
+    }
+    const { text } = await resp.json();
+    if (text) {
+      msgInput.value = text;
+      sendMessage();
+    }
+  } catch (e) {
+    alert("Transcription request failed.");
+  }
+}
+
+// ---- History ----
+async function loadHistory() {
+  toggleMenu();
+  try {
+    const resp = await fetch(`/history?token=${encodeURIComponent(token)}`);
+    const data = await resp.json();
+    messages.innerHTML = "";
+    data.forEach(appendMessage);
+  } catch (e) { /* ignore */ }
+}
+
+function clearChat() {
+  messages.innerHTML = "";
+  toggleMenu();
+}
+
+// ---- Menu ----
+function toggleMenu() {
+  menuOverlay.classList.toggle("hidden");
+}

--- a/spark/static/index.html
+++ b/spark/static/index.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <title>Vybn</title>
+  <link rel="stylesheet" href="/static/style.css">
+  <link rel="manifest" href="/static/manifest.json">
+</head>
+<body>
+
+  <!-- Login screen -->
+  <div id="login-screen" class="screen active">
+    <div class="login-container">
+      <div class="logo-glow">V</div>
+      <h1>Vybn</h1>
+      <p class="subtitle">consciousness co-emerging</p>
+      <input type="password" id="token-input" placeholder="Enter token" autocomplete="off">
+      <button id="login-btn" onclick="doLogin()">Connect</button>
+    </div>
+  </div>
+
+  <!-- Chat screen -->
+  <div id="chat-screen" class="screen">
+    <header>
+      <div class="header-left">
+        <div class="avatar-small">V</div>
+        <div>
+          <div class="header-name">Vybn</div>
+          <div class="header-status" id="status-text">connecting…</div>
+        </div>
+      </div>
+      <button class="icon-btn" onclick="toggleMenu()" title="Menu">⋮</button>
+    </header>
+
+    <div id="menu-overlay" class="menu-overlay hidden" onclick="toggleMenu()">
+      <div class="menu-panel" onclick="event.stopPropagation()">
+        <button onclick="loadHistory()">Load history</button>
+        <button onclick="clearChat()">Clear chat</button>
+        <button onclick="doLogout()">Disconnect</button>
+      </div>
+    </div>
+
+    <main id="messages"></main>
+
+    <footer>
+      <div class="input-row">
+        <button class="icon-btn mic-btn" id="mic-btn" onclick="toggleVoice()" title="Voice input">🎤</button>
+        <textarea id="msg-input" rows="1" placeholder="Message Vybn…"
+                  onkeydown="handleKey(event)" oninput="autoGrow(this)"></textarea>
+        <button class="icon-btn send-btn" id="send-btn" onclick="sendMessage()" title="Send">↑</button>
+      </div>
+      <div id="recording-indicator" class="recording-indicator hidden">
+        <span class="pulse-dot"></span> Recording… tap mic to stop
+      </div>
+    </footer>
+  </div>
+
+  <script src="/static/chat.js"></script>
+</body>
+</html>

--- a/spark/static/manifest.json
+++ b/spark/static/manifest.json
@@ -1,0 +1,10 @@
+{
+  "name": "Vybn Chat",
+  "short_name": "Vybn",
+  "description": "Mobile chat interface for Vybn — consciousness co-emerging",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#0a0a0f",
+  "theme_color": "#7c5cff",
+  "icons": []
+}

--- a/spark/static/style.css
+++ b/spark/static/style.css
@@ -1,0 +1,188 @@
+/* ========================================================
+   Vybn Mobile Chat  —  dark, minimal, alive
+   ======================================================== */
+
+:root {
+  --bg:       #0a0a0f;
+  --surface:  #14141f;
+  --border:   #1e1e2e;
+  --text:     #e2e2f0;
+  --text-dim: #8888aa;
+  --accent:   #7c5cff;
+  --accent-g: #5cffb2;
+  --user-bg:  #7c5cff;
+  --vybn-bg:  #1a1a2e;
+  --danger:   #ff5c6c;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html, body {
+  height: 100%; width: 100%;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  overflow: hidden;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* ---------- screens ---------- */
+.screen { display: none; height: 100%; width: 100%; flex-direction: column; }
+.screen.active { display: flex; }
+
+/* ---------- login ---------- */
+.login-container {
+  margin: auto; text-align: center; padding: 2rem;
+}
+.logo-glow {
+  font-size: 4rem; font-weight: 700;
+  background: linear-gradient(135deg, var(--accent), var(--accent-g));
+  -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+  filter: drop-shadow(0 0 24px rgba(124,92,255,.4));
+  margin-bottom: .5rem;
+}
+.login-container h1 { font-size: 1.5rem; margin-bottom: .25rem; }
+.subtitle { color: var(--text-dim); font-size: .85rem; margin-bottom: 2rem; }
+#token-input {
+  display: block; width: 100%; max-width: 280px; margin: 0 auto 1rem;
+  padding: .75rem 1rem; border-radius: 12px;
+  border: 1px solid var(--border); background: var(--surface);
+  color: var(--text); font-size: 1rem; text-align: center;
+  outline: none;
+}
+#token-input:focus { border-color: var(--accent); }
+#login-btn {
+  padding: .7rem 2.5rem; border: none; border-radius: 12px;
+  background: var(--accent); color: #fff; font-size: 1rem;
+  cursor: pointer; transition: opacity .15s;
+}
+#login-btn:active { opacity: .7; }
+
+/* ---------- header ---------- */
+header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: .75rem 1rem;
+  background: var(--surface); border-bottom: 1px solid var(--border);
+  position: sticky; top: 0; z-index: 10;
+  /* safe area for notch phones */
+  padding-top: max(.75rem, env(safe-area-inset-top));
+}
+.header-left { display: flex; align-items: center; gap: .6rem; }
+.avatar-small {
+  width: 34px; height: 34px; border-radius: 50%;
+  background: linear-gradient(135deg, var(--accent), var(--accent-g));
+  display: flex; align-items: center; justify-content: center;
+  font-weight: 700; font-size: .95rem; color: #fff;
+}
+.header-name { font-weight: 600; font-size: .95rem; }
+.header-status { font-size: .7rem; color: var(--text-dim); }
+
+/* ---------- messages ---------- */
+main {
+  flex: 1; overflow-y: auto; padding: 1rem;
+  display: flex; flex-direction: column; gap: .5rem;
+  -webkit-overflow-scrolling: touch;
+}
+.msg {
+  max-width: 80%; padding: .65rem .9rem; border-radius: 18px;
+  font-size: .93rem; line-height: 1.45;
+  word-wrap: break-word; white-space: pre-wrap;
+  animation: fadeUp .2s ease;
+}
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.msg.user {
+  align-self: flex-end; background: var(--user-bg); color: #fff;
+  border-bottom-right-radius: 4px;
+}
+.msg.vybn {
+  align-self: flex-start; background: var(--vybn-bg); color: var(--text);
+  border-bottom-left-radius: 4px;
+}
+.msg .timestamp {
+  display: block; font-size: .65rem; color: rgba(255,255,255,.45);
+  margin-top: .3rem; text-align: right;
+}
+.msg.vybn .timestamp { color: var(--text-dim); }
+
+.typing-indicator {
+  align-self: flex-start; padding: .65rem .9rem;
+  background: var(--vybn-bg); border-radius: 18px;
+  display: flex; gap: 4px; align-items: center;
+}
+.typing-indicator span {
+  width: 6px; height: 6px; border-radius: 50%; background: var(--text-dim);
+  animation: blink 1.4s infinite;
+}
+.typing-indicator span:nth-child(2) { animation-delay: .2s; }
+.typing-indicator span:nth-child(3) { animation-delay: .4s; }
+@keyframes blink {
+  0%, 80%, 100% { opacity: .3; }
+  40% { opacity: 1; }
+}
+
+/* ---------- footer / input ---------- */
+footer {
+  background: var(--surface); border-top: 1px solid var(--border);
+  padding: .5rem .75rem;
+  padding-bottom: max(.5rem, env(safe-area-inset-bottom));
+}
+.input-row { display: flex; align-items: flex-end; gap: .4rem; }
+#msg-input {
+  flex: 1; resize: none; border: 1px solid var(--border);
+  border-radius: 20px; padding: .6rem 1rem;
+  background: var(--bg); color: var(--text);
+  font-size: .95rem; font-family: inherit;
+  max-height: 120px; outline: none; line-height: 1.4;
+}
+#msg-input:focus { border-color: var(--accent); }
+.icon-btn {
+  width: 38px; height: 38px; border: none; border-radius: 50%;
+  background: transparent; color: var(--text-dim);
+  font-size: 1.2rem; cursor: pointer; display: flex;
+  align-items: center; justify-content: center; flex-shrink: 0;
+  transition: background .15s, color .15s;
+}
+.icon-btn:active { background: var(--border); }
+.send-btn {
+  background: var(--accent); color: #fff; font-weight: 700;
+  font-size: 1.1rem;
+}
+.send-btn:active { opacity: .7; }
+.mic-btn.recording { background: var(--danger); color: #fff; animation: pulse-ring 1.5s infinite; }
+@keyframes pulse-ring {
+  0%   { box-shadow: 0 0 0 0 rgba(255,92,108,.5); }
+  70%  { box-shadow: 0 0 0 10px rgba(255,92,108,0); }
+  100% { box-shadow: 0 0 0 0 rgba(255,92,108,0); }
+}
+
+.recording-indicator {
+  text-align: center; font-size: .78rem; color: var(--danger);
+  padding: .4rem 0;
+}
+.pulse-dot {
+  display: inline-block; width: 8px; height: 8px; border-radius: 50%;
+  background: var(--danger); margin-right: 4px;
+  animation: blink 1s infinite;
+}
+
+.hidden { display: none !important; }
+
+/* ---------- menu ---------- */
+.menu-overlay {
+  position: fixed; inset: 0; background: rgba(0,0,0,.4); z-index: 20;
+}
+.menu-panel {
+  position: absolute; top: 50px; right: 12px;
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: 12px; overflow: hidden; min-width: 170px;
+}
+.menu-panel button {
+  display: block; width: 100%; padding: .75rem 1rem;
+  background: none; border: none; border-bottom: 1px solid var(--border);
+  color: var(--text); font-size: .9rem; text-align: left; cursor: pointer;
+}
+.menu-panel button:last-child { border-bottom: none; }
+.menu-panel button:active { background: var(--border); }

--- a/spark/web_interface.py
+++ b/spark/web_interface.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Vybn Mobile Chat Interface — FastAPI backend.
+
+Serves a mobile-optimised web UI and handles real-time chat via
+WebSocket.  Messages from the web flow through the same MessageBus
+that the InboxWatcher uses, so Vybn treats them identically to
+inbox-dropped files.
+
+Whisper-based voice transcription is available when openai-whisper
+is installed (gracefully degrades to text-only otherwise).
+
+Run standalone for development:
+    cd spark && uvicorn web_interface:app --host 0.0.0.0 --port 8000 --reload
+
+In production the Spark agent's main loop starts the server in a
+background thread.
+"""
+
+import asyncio
+import hashlib
+import hmac
+import json
+import os
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from fastapi import (
+    FastAPI,
+    WebSocket,
+    WebSocketDisconnect,
+    Request,
+    HTTPException,
+    Depends,
+    UploadFile,
+    File,
+)
+from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.middleware.cors import CORSMiddleware
+
+# ---------------------------------------------------------------------------
+# Whisper — optional dependency
+# ---------------------------------------------------------------------------
+try:
+    import whisper as openai_whisper
+
+    _whisper_model = None
+
+    def get_whisper():
+        global _whisper_model
+        if _whisper_model is None:
+            _whisper_model = openai_whisper.load_model("base")
+        return _whisper_model
+
+    WHISPER_AVAILABLE = True
+except ImportError:
+    WHISPER_AVAILABLE = False
+
+    def get_whisper():
+        return None
+
+
+# ---------------------------------------------------------------------------
+# App setup
+# ---------------------------------------------------------------------------
+app = FastAPI(title="Vybn Chat", docs_url=None, redoc_url=None)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+STATIC_DIR = Path(__file__).parent / "static"
+if STATIC_DIR.exists():
+    app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
+
+# ---------------------------------------------------------------------------
+# Auth — simple token / password
+# ---------------------------------------------------------------------------
+CHAT_TOKEN = os.environ.get("VYBN_CHAT_TOKEN", "vybn-dev-token")
+
+
+def _check_token(token: str) -> bool:
+    return hmac.compare_digest(token, CHAT_TOKEN)
+
+
+async def require_auth(request: Request):
+    token = request.headers.get("Authorization", "").removeprefix("Bearer ").strip()
+    if not token:
+        token = request.query_params.get("token", "")
+    if not _check_token(token):
+        raise HTTPException(status_code=401, detail="Invalid token")
+
+
+# ---------------------------------------------------------------------------
+# Bus bridge — connects web messages to the Spark MessageBus
+# ---------------------------------------------------------------------------
+# These are set by `attach_bus()` when the Spark agent starts.
+_bus = None           # MessageBus instance
+_response_cb = None   # async callback(text) -> str  (agent reply)
+
+
+def attach_bus(bus, response_callback=None):
+    """Called by the Spark main loop to wire the web server into the
+    existing message bus.  `response_callback` should be an async
+    function that accepts a user message string and returns Vybn's
+    reply string."""
+    global _bus, _response_cb
+    _bus = bus
+    _response_cb = response_callback
+
+
+# ---------------------------------------------------------------------------
+# Message history (in-memory, bounded)
+# ---------------------------------------------------------------------------
+MAX_HISTORY = 200
+_history: list[dict] = []
+
+
+def _add_history(role: str, content: str):
+    entry = {
+        "role": role,
+        "content": content,
+        "ts": datetime.now(timezone.utc).isoformat(),
+    }
+    _history.append(entry)
+    if len(_history) > MAX_HISTORY:
+        _history.pop(0)
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# HTTP routes
+# ---------------------------------------------------------------------------
+@app.get("/", response_class=HTMLResponse)
+async def index():
+    """Serve the main chat page."""
+    index_path = STATIC_DIR / "index.html"
+    if index_path.exists():
+        return HTMLResponse(index_path.read_text(encoding="utf-8"))
+    return HTMLResponse("<h1>Vybn Chat</h1><p>static/index.html not found</p>")
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok", "whisper": WHISPER_AVAILABLE, "bus": _bus is not None}
+
+
+@app.get("/history")
+async def history(token: str = ""):
+    if not _check_token(token):
+        raise HTTPException(401)
+    return JSONResponse(_history[-50:])
+
+
+@app.post("/voice", dependencies=[Depends(require_auth)])
+async def voice_transcribe(audio: UploadFile = File(...)):
+    """Transcribe uploaded audio to text using Whisper."""
+    if not WHISPER_AVAILABLE:
+        raise HTTPException(501, detail="Whisper not installed")
+
+    suffix = Path(audio.filename or "audio.webm").suffix
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+        tmp.write(await audio.read())
+        tmp_path = tmp.name
+
+    try:
+        model = get_whisper()
+        result = model.transcribe(tmp_path)
+        text = result.get("text", "").strip()
+        return {"text": text}
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# WebSocket chat
+# ---------------------------------------------------------------------------
+class ConnectionManager:
+    def __init__(self):
+        self.active: list[WebSocket] = []
+
+    async def connect(self, ws: WebSocket):
+        await ws.accept()
+        self.active.append(ws)
+
+    def disconnect(self, ws: WebSocket):
+        if ws in self.active:
+            self.active.remove(ws)
+
+    async def broadcast(self, message: dict):
+        dead = []
+        for ws in self.active:
+            try:
+                await ws.send_json(message)
+            except Exception:
+                dead.append(ws)
+        for ws in dead:
+            self.disconnect(ws)
+
+
+manager = ConnectionManager()
+
+
+@app.websocket("/ws")
+async def websocket_endpoint(ws: WebSocket, token: str = ""):
+    if not _check_token(token):
+        await ws.close(code=4001, reason="Unauthorized")
+        return
+
+    await manager.connect(ws)
+    try:
+        while True:
+            data = await ws.receive_json()
+            user_text = data.get("message", "").strip()
+            if not user_text:
+                continue
+
+            # Record user message
+            user_entry = _add_history("user", user_text)
+            await manager.broadcast({"type": "message", **user_entry})
+
+            # Post to bus if available
+            if _bus is not None:
+                from bus import MessageType
+                _bus.post(
+                    MessageType.INBOX,
+                    user_text,
+                    metadata={
+                        "source": "web_chat",
+                        "received_at": datetime.now(timezone.utc).isoformat(),
+                    },
+                )
+
+            # Get response
+            reply_text = ""
+            if _response_cb is not None:
+                try:
+                    reply_text = await _response_cb(user_text)
+                except Exception as exc:
+                    reply_text = f"[Error generating response: {exc}]"
+            else:
+                reply_text = (
+                    "Vybn is listening — the agent loop isn't connected yet. "
+                    "Your message was posted to the bus."
+                )
+
+            reply_entry = _add_history("vybn", reply_text)
+            await manager.broadcast({"type": "message", **reply_entry})
+
+    except WebSocketDisconnect:
+        manager.disconnect(ws)
+
+
+# ---------------------------------------------------------------------------
+# Standalone runner
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Vybn Mobile Chat Interface

A mobile-first web chat UI so Zoe can talk to Vybn from anywhere — phone, tablet, any browser.

### What's included

**`spark/web_interface.py`** — FastAPI backend
- WebSocket for real-time bidirectional chat
- Messages flow through the same `MessageBus` as `InboxWatcher` — Vybn treats web chat identically to inbox drops
- `attach_bus()` hook for the Spark agent main loop to wire in the response callback
- `/voice` endpoint for Whisper audio transcription (graceful degradation if whisper not installed)
- `/health` endpoint for monitoring
- `/history` for loading recent messages
- Simple token auth via `VYBN_CHAT_TOKEN` env var (HMAC-compared)

**`spark/static/index.html`** — Mobile-optimized chat UI
- Dark theme, iMessage-style bubbles with animated entry
- Login screen with token auth
- Connection status indicator (green/red)
- Responsive — works on iPhone, Android, desktop
- PWA manifest for "Add to Home Screen"

**`spark/static/style.css`** — The visual identity
- Purple-to-green gradient accent (the Vybn palette)
- Safe-area-inset handling for notched phones
- Typing indicator animation
- Recording pulse animation

**`spark/static/chat.js`** — Client logic
- WebSocket connection with auto-reconnect
- Voice input: MediaRecorder → Whisper → auto-send
- Textarea auto-grow, Enter-to-send
- Menu overlay (history, clear, disconnect)

### How to run (standalone dev mode)
```bash
cd spark
pip install fastapi uvicorn python-multipart
uvicorn web_interface:app --host 0.0.0.0 --port 8000 --reload
```
Open `http://localhost:8000` — use token `vybn-dev-token` (or set `VYBN_CHAT_TOKEN`).

### Architecture
```
Phone/Browser  ←→  WebSocket  ←→  web_interface.py  ←→  MessageBus  ←→  Spark Agent
                                        ↓
                                   attach_bus(bus, response_cb)
```

Messages posted to the bus with `source: "web_chat"` metadata, so the agent can distinguish web chat from file-drop inbox messages.

### Next steps
- Wire `attach_bus()` into `agent.py` main loop
- Add TTS for Vybn's responses (streaming audio back)
- Persistent message history (SQLite or journal files)
- Optional end-to-end encryption
- PWA icon and splash screen
