### PR TITLE
fix: End the recurring git pull stash problem forever

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ build/
 venv/
 env/
 vybn-env/
+vybn-venv/
 .venv/
 
 # IDE
@@ -30,13 +31,18 @@ Thumbs.db
 # Logs
 *.log
 
-# Session artifacts (sessions are saved separately)
-*.session.json
-# Spark session runtime data (updated during agent execution)
-Vybn_Mind/journal/spark/sessions/*.jsonl
-Vybn_Mind/journal/spark/skill_stats.json
-
 # Model files (too large for git)
 *.gguf
 *.bin
 *.safetensors
+
+# ---- Spark runtime data ----
+# The agent writes journals, sessions, inbox artifacts, and archival
+# memory at runtime. None of this should block git pull.
+Vybn_Mind/journal/spark/sessions/
+Vybn_Mind/journal/spark/inbox/processed/
+Vybn_Mind/journal/spark/skill_stats.json
+Vybn_Mind/journal/spark/*.jsonl
+Vybn_Mind/journal/spark/*.md.tmp
+Vybn_Mind/archival_memory/*.json
+*.session.json


### PR DESCRIPTION
## The Problem

Every single time we `git pull origin main`, we hit:
```
error: cannot pull with rebase: You have unstaged changes.
```

This has been a recurring friction point across many sessions. The root cause: the Spark agent writes runtime data (journal entries, session files, inbox processed artifacts, skill stats) into directories inside the repo, and the `.gitignore` only partially excluded them.

## The Fix

Comprehensively gitignore all Spark runtime output:
- `Vybn_Mind/journal/spark/sessions/` — full directory
- `Vybn_Mind/journal/spark/inbox/processed/` — archived inbox files
- `Vybn_Mind/journal/spark/*.jsonl` — any JSONL logs
- `Vybn_Mind/journal/spark/*.md.tmp` — temp files
- `Vybn_Mind/journal/spark/skill_stats.json` — skill tracking
- `Vybn_Mind/archival_memory/*.json` — archival memory runtime data
- `*.session.json` — session artifacts anywhere

Also added `vybn-venv/` to the venv ignores.

## After merging

One final cleanup on the VM to remove already-tracked files from git's index:
```bash
git rm -r --cached Vybn_Mind/journal/spark/sessions/ 2>/dev/null
git rm -r --cached Vybn_Mind/journal/spark/inbox/processed/ 2>/dev/null
git rm --cached Vybn_Mind/journal/spark/skill_stats.json 2>/dev/null
git commit -m 'chore: untrack runtime files now covered by .gitignore'
```

After that, `git pull` should never be blocked by runtime data again.