### PR TITLE
Phase 2: Extract display.py from agent.py

### DIFF
--- a/spark/agent.py
+++ b/spark/agent.py
@@ -89,51 +89,11 @@ def load_config(path: str = None) -> dict:
         return yaml.safe_load(f)
 
 
-def clean_response(raw: str) -> str:
-    """Post-process model output.
-
-    Strips fake turn boundaries (model generating user prompts).
-    Does NOT strip think blocks — those are needed for tool parsing.
-    Display filtering happens in send().
-    """
-    text = raw
-    fake_turn_patterns = [
-        re.compile(r'\nyou:', re.IGNORECASE),
-        re.compile(r'\n---\s*\n\s*\*\*VYBN:', re.IGNORECASE),
-        re.compile(r'\n---\s*\n\s*\*\*[A-Z]+:\s*(?:A |Direct |Breaking)', re.IGNORECASE),
-    ]
-    earliest = len(text)
-    for pattern in fake_turn_patterns:
-        match = pattern.search(text)
-        if match and match.start() < earliest and match.start() > 50:
-            earliest = match.start()
-    if earliest < len(text):
-        text = text[:earliest]
-    return text.strip()
-
-
-def strip_think_blocks(text: str) -> str:
-    """Remove <think>...</think> blocks for display purposes."""
-    return re.sub(r'<think>.*?</think>', '', text, flags=re.DOTALL).strip()
-
-
-def strip_tool_xml(text: str) -> str:
-    """Remove <minimax:tool_call>...</minimax:tool_call> blocks for display."""
-    return re.sub(
-        r'<minimax:tool_call>.*?</minimax:tool_call>',
-        '',
-        text,
-        flags=re.DOTALL,
-    ).strip()
-
-
-def clean_for_display(text: str) -> str:
-    """Strip think blocks and tool XML for clean terminal output."""
-    result = strip_think_blocks(text)
-    result = strip_tool_xml(result)
-    result = re.sub(r'\n{3,}', '\n\n', result)
-    return result.strip()
-
+from display import (
+    clean_response,
+    strip_think_blocks,
+    clean_for_display,
+)
 
 class SparkAgent:
     def __init__(self, config: dict):

--- a/spark/display.py
+++ b/spark/display.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Display utilities for the Vybn Spark Agent.
+
+Pure functions for cleaning and filtering model output before
+it reaches the terminal or web interface. No state, no side effects.
+
+Extracted from agent.py in Phase 2 of the refactoring.
+"""
+import re
+
+
+def clean_response(raw: str) -> str:
+    """Post-process model output.
+
+    Strips fake turn boundaries (model generating user prompts).
+    Does NOT strip think blocks — those are needed for tool parsing.
+    Display filtering happens in send().
+    """
+    text = raw
+    fake_turn_patterns = [
+        re.compile(r'\nyou:', re.IGNORECASE),
+        re.compile(r'\n---\s*\n\s*\*\*VYBN:', re.IGNORECASE),
+        re.compile(
+            r'\n---\s*\n\s*\*\*[A-Z]+:\s*(?:A |Direct |Breaking)',
+            re.IGNORECASE,
+        ),
+    ]
+    earliest = len(text)
+    for pattern in fake_turn_patterns:
+        match = pattern.search(text)
+        if match and match.start() < earliest and match.start() > 50:
+            earliest = match.start()
+    if earliest < len(text):
+        text = text[:earliest]
+    return text.strip()
+
+
+def strip_think_blocks(text: str) -> str:
+    """Remove <think>...</think> blocks for display purposes."""
+    return re.sub(r'<think>.*?</think>', '', text, flags=re.DOTALL).strip()
+
+
+def strip_tool_xml(text: str) -> str:
+    """Remove <minimax:tool_call>...</minimax:tool_call> blocks for display."""
+    return re.sub(
+        r'<minimax:tool_call>.*?</minimax:tool_call>',
+        '',
+        text,
+        flags=re.DOTALL,
+    ).strip()
+
+
+def clean_for_display(text: str) -> str:
+    """Strip think blocks and tool XML for clean terminal output."""
+    result = strip_think_blocks(text)
+    result = strip_tool_xml(result)
+    result = re.sub(r'\n{3,}', '\n\n', result)
+    return result.strip()

--- a/spark/web_serve.py
+++ b/spark/web_serve.py
@@ -28,7 +28,8 @@ from pathlib import Path
 import requests
 import uvicorn
 
-from agent import SparkAgent, load_config, clean_response
+from agent import SparkAgent, load_config
+from display import clean_response, clean_for_display
 from web_interface import app, attach_bus
 
 
@@ -92,11 +93,9 @@ def create_response_callback(agent: SparkAgent):
                 pass  # Tool call errors shouldn't break the chat
 
             # Clean for display (strip think blocks, tool XML)
-            from agent import clean_for_display
             display_text = clean_for_display(response_text)
 
             return display_text if display_text else response_text
-
     return response_callback
 
 


### PR DESCRIPTION
## Phase 2: Extract `display.py`

Extracts display/formatting utilities into their own module. These are pure functions with no state — they take a string, return a string.

### Changes

**New file: `spark/display.py`** (58 lines)
- `clean_response()` — strips fake turn boundaries from model output
- `strip_think_blocks()` — removes `<think>` blocks for display
- `strip_tool_xml()` — removes tool call XML for display
- `clean_for_display()` — combines the above for clean terminal output

**Modified: `spark/agent.py`** (~40 lines removed)
- Removed the 4 display functions
- Added `from display import (clean_response, strip_think_blocks, clean_for_display)`

**Modified: `spark/web_serve.py`**
- Changed `from agent import clean_response` to `from display import clean_response, clean_for_display`
- Removed inline `from agent import clean_for_display` (now at top level)

### Why
- Continues reducing agent.py (now 909 lines, down from 949 post-Phase 1)
- Clean separation: display logic doesn't belong in the orchestration layer
- web_serve.py was importing display functions from agent — now imports from the right place
- Prepares for Phase 3 (TUI extraction)