### PR TITLE
fix(policy): normalize paths in _path_is_safe before checking prefixes

### DIFF
--- a/spark/policy.py
+++ b/spark/policy.py
@@ -512,6 +512,11 @@ class PolicyEngine:
 
         home = str(Path.home())
 
+        # Normalize: rewrite /root/ and expand ~ to actual home dir
+          path_str = path_str.replace("/root/", home + "/")
+          if path_str.startswith("~/"):
+              path_str = home + path_str[1:]
+
         for prefix in SAFE_PATH_PREFIXES:
             expanded = prefix.replace("~/", home + "/")
             if (


### PR DESCRIPTION
Fixes #2162

The model sometimes generates absolute paths like /root/Vybn/file or /home/user/Vybn/file. The policy check was comparing raw path strings against SAFE_PATH_PREFIXES without normalizing first.

This adds path normalization before the prefix check:
- Rewrites /root/ to actual home directory
- Expands ~/ to actual home directory path

Matches the normalization already done in skills.py _rewrite_root.