### PR TITLE
fix(policy): correct indentation in _path_is_safe path normalization

### DIFF
--- a/spark/policy.py
+++ b/spark/policy.py
@@ -513,9 +513,9 @@ class PolicyEngine:
         home = str(Path.home())
 
         # Normalize: rewrite /root/ and expand ~ to actual home dir
-          path_str = path_str.replace("/root/", home + "/")
-          if path_str.startswith("~/"):
-              path_str = home + path_str[1:]
+        path_str = path_str.replace("/root/", home + "/")
+        if path_str.startswith("~/"):
+            path_str = home + path_str[1:]
 
         for prefix in SAFE_PATH_PREFIXES:
             expanded = prefix.replace("~/", home + "/")


### PR DESCRIPTION
PR #2163 introduced path normalization lines in `_path_is_safe()` with 12-space indentation instead of the correct 8-space indentation, causing an `IndentationError` at runtime.

This fix removes 4 excess spaces from lines 516-518 so they align with the surrounding method body.