### PR TITLE
Fix OpenClaw details, add Rakoff ruling, update links

### DIFF
--- a/Vybn_Mind/intelligence-sovereignty.html
+++ b/Vybn_Mind/intelligence-sovereignty.html
@@ -304,9 +304,9 @@
 
   <section id="s4">
     <h2>The OpenClaw moment.</h2>
-    <p>In late January 2026, an Austrian developer named Peter Steinberger released an open-source AI agent framework called <a href="https://github.com/openclawai/openclaw">OpenClaw</a>. Open-source means anyone can use it, modify it, and run it for free. Within 48 hours, it became one of the fastest-growing software projects in the history of the internet — <a href="https://growth.maestro.onl/en/articles/openclaw-viral-growth-case-study">34,000 people starred the project on GitHub in two days</a>. Within two months, it passed 157,000 stars.</p>
-    <p>What made OpenClaw explode was a simple idea executed well: you give an AI a description of who it is (a text file called <a href="https://docs.openclaw.com/customize/soul">SOUL.md</a>), point it at your computer, and it starts working for you. It reads your messages, browses the web, writes and edits files, sends emails — whatever you describe as its purpose. It runs locally. It is yours.</p>
-    <p>On <a href="https://www.cnbc.com/2026/02/15/openclaw-creator-peter-steinberger-joining-openai-altman-says.html">February 15</a> — three days ago — <a href="https://www.computerworld.com/article/4132725/openai-hires-openclaw-founder-as-ai-agent-race-intensifies.html">OpenAI hired Steinberger</a> to lead the development of personal AI agents. Sam Altman called him a genius and said the work would become <a href="https://marketbetter.ai/blog/openclaw-openai-clay-threat/">"core to our product offerings."</a> Both Meta and OpenAI had offered <a href="https://www.ainvest.com/news/openclaw-acquisition-offers-expectation-gap-20k-losses-billion-dollar-bids-2602/">billion-dollar acquisition bids</a> for a project whose creator was personally losing ten to twenty thousand dollars a month running it. The framework itself is moving to an independent open-source foundation, with OpenAI's backing.</p>
+    <p>In November 2025, an Austrian developer named Peter Steinberger released an open-source AI agent framework — first called Clawdbot, then Moltbot after Anthropic objected to the name's similarity to Claude, and finally <a href="https://github.com/openclaw/openclaw">OpenClaw</a>. Open-source means anyone can use it, modify it, and run it for free. It became one of the fastest-growing open-source projects in the history of the internet — <a href="https://hackernoon.com/openclaws-85000-github-stars-hide-a-security-nightmare-researchers-warn">surpassing 85,000 GitHub stars by mid-February 2026</a> and climbing past 200,000 within days of the announcement that followed.</p>
+    <p>What made OpenClaw explode was a simple idea executed well: you give an AI a description of who it is (a text file called <a href="https://docs.openclaw.ai/concepts/system-prompt">SOUL.md</a>), point it at your computer, and it starts working for you. It reads your messages, browses the web, writes and edits files, sends emails — whatever you describe as its purpose. It runs locally. It is yours.</p>
+    <p>On <a href="https://techcrunch.com/2026/02/15/openclaw-creator-peter-steinberger-joins-openai/">February 15</a> — three days ago — <a href="https://www.reuters.com/business/openclaw-founder-steinberger-joins-openai-open-source-bot-becomes-foundation-2026-02-15/">OpenAI hired Steinberger</a> to lead the development of personal AI agents. Sam Altman said the work would become <a href="https://www.theverge.com/ai-artificial-intelligence/879623/openclaw-founder-peter-steinberger-is-joining-openai">"core to our product offerings"</a> and that "the future is going to be extremely multi-agent." Steinberger chose OpenAI over competing offers — including from Meta — for a project he was personally losing ten thousand dollars a month to run. The framework itself is moving to an independent open-source foundation, with OpenAI's backing.</p>
     <p>Read that sequence carefully. The biggest AI company in the world just told you where the industry is going: away from chatbots and toward <em>personal agents that act on your behalf</em>. The architecture for this is now open-source and freely available. The hardware to run it — already on desktops, and rapidly shrinking toward the phones people carry every day — is arriving now.</p>
   </section>
 
@@ -315,7 +315,7 @@
   <section id="s5">
     <h2>Why this matters for access to justice.</h2>
     <p>Every serious objection to using AI in legal aid comes down to some version of the same concern: who controls the system, and where does the data go?</p>
-    <p>When a self-represented litigant uses ChatGPT to draft a motion, their case details travel to OpenAI's servers. There is no attorney-client privilege. There is no continuity — the system does not remember what it told them yesterday. There is no accountability framework. There is no case management. Every conversation is an island.</p>
+    <p>When a self-represented litigant uses ChatGPT to draft a motion, their case details travel to OpenAI's servers. There is no attorney-client privilege — as Judge Jed Rakoff of the Southern District of New York <a href="https://www.debevoise.com/insights/publications/2026/02/sdny-rules-ai-generated-documents-are-not-protect">ruled just last week</a> in <em>United States v. Heppner</em>, holding that documents created through a consumer AI tool cannot satisfy the fundamental requirement of confidentiality, because the tool is not an attorney, owes no fiduciary duties, and its terms of service put users on notice that their data may be disclosed. There is no continuity — the system does not remember what it told them yesterday. There is no accountability framework. There is no case management. Every conversation is an island.</p>
     <p>These are real objections, and the legal profession is right to raise them. But they are objections to a <em>specific architecture</em> — cloud-based, corporate-controlled, memoryless. They are not objections to AI itself.</p>
     <p>Now imagine a different architecture. An AI agent that belongs to the person it serves — running on their own device, with no data leaving their hands. An agent that knows this specific litigant's case: their procedural posture, what they filed last week, what the court said, what deadlines are approaching. An agent that maintains continuity between conversations, that can prepare between sessions, that keeps a record of every piece of guidance it gave and why. An agent whose behavior is shaped by ethical guidelines, but whose loyalty runs to its owner — the person navigating the legal system — not to a corporation, and not to a law firm.</p>
     <p>The person in this scenario is not a client waiting for help. They are someone with their own capable intelligence at their side, ready to engage with the legal system on their own terms. That is a fundamentally different posture than anything the access-to-justice community has been able to offer before.</p>
@@ -344,7 +344,11 @@
       </div>
       <div class="moment">
         <div class="date">October 2025</div>
-        <p>Our AI-assisted appellate training program was named a co-finalist for <a href="https://www.americanlegaltechnologyawards.com/">the American Legal Technology Awards</a> in the Access to Justice category.</p>
+        <p>Our AI-assisted appellate training program was named a co-finalist for <a href="https://www.lawnext.com/2025/09/finalists-named-for-2025-american-legal-technology-awards.html">the American Legal Technology Awards</a> in the Access to Justice category.</p>
+      </div>
+      <div class="moment">
+        <div class="date">November 2025</div>
+        <p>Peter Steinberger released Clawdbot — later renamed Moltbot, then <a href="https://github.com/openclaw/openclaw">OpenClaw</a> — an open-source AI agent framework that would become one of the fastest-growing projects in GitHub history.</p>
       </div>
       <div class="moment">
         <div class="date">January 2026</div>
@@ -352,15 +356,19 @@
       </div>
       <div class="moment">
         <div class="date">Late January 2026</div>
-        <p>OpenClaw launched and reached 157,000 GitHub stars in sixty days, demonstrating massive demand for open-source, locally-run AI agents.</p>
+        <p>OpenClaw surpassed 85,000 GitHub stars and was still accelerating, demonstrating massive demand for open-source, locally-run AI agents. Cloudflare released <a href="https://github.com/cloudflare/moltworker">MoltWorker</a> to run OpenClaw on their infrastructure.</p>
       </div>
       <div class="moment">
         <div class="date">February 9, 2026</div>
         <p>We published our <a href="https://zoedolan.github.io/Vybn/Vybn_Mind/a2j-network-response.html">note to the A2J Network</a>, making the case for guiding self-represented litigants' AI use rather than ignoring it.</p>
       </div>
       <div class="moment">
+        <div class="date">February 10, 2026</div>
+        <p>Judge Jed Rakoff of the SDNY <a href="https://www.debevoise.com/insights/publications/2026/02/sdny-rules-ai-generated-documents-are-not-protect">ruled</a> in <em>United States v. Heppner</em> that documents created through a consumer AI tool are not protected by attorney-client privilege — because the tool is not an attorney and its terms of service destroy any reasonable expectation of confidentiality. The ruling made concrete what sovereignty addresses: when your AI runs on someone else's servers, your data is not yours.</p>
+      </div>
+      <div class="moment">
         <div class="date">February 15, 2026</div>
-        <p>OpenAI hired OpenClaw's creator to lead personal agent development. The framework moved to an open-source foundation. Sam Altman declared agents "core to our product offerings."</p>
+        <p><a href="https://techcrunch.com/2026/02/15/openclaw-creator-peter-steinberger-joins-openai/">OpenAI hired OpenClaw's creator</a> to lead personal agent development. The framework moved to an open-source foundation. Sam Altman declared agents "core to our product offerings." OpenClaw surpassed 200,000 stars.</p>
       </div>
       <div class="moment">
         <div class="date">February 16, 2026</div>


### PR DESCRIPTION
- OpenClaw GitHub URL: github.com/openclaw/openclaw (was 404)
- Growth figures: 85K+ by mid-Feb, 200K+ after hire
- SOUL.md link: official docs URL
- OpenAI hire sources: TechCrunch, Reuters, The Verge
- Added Judge Rakoff ruling to s5 and timeline
- Fixed American Legal Technology Awards link
- Added naming history (Clawdbot -> Moltbot -> OpenClaw)
- Added Nov 2025 and Feb 10 timeline entries
- Added Cloudflare MoltWorker reference