### PR TITLE
Phase 5: Converge TUI and web UIs via RichIO

### DIFF
--- a/spark/tui.py
+++ b/spark/tui.py
@@ -35,13 +35,15 @@ except ImportError:
     HAS_RICH = False
 
 from agent import SparkAgent, load_config
+from agent_io import RichIO
 from commands import explore, format_policy, format_audit
 
 
 class SparkTUI:
     def __init__(self, config: dict):
-        self.agent = SparkAgent(config)
         self.console = Console() if HAS_RICH else None
+            io = RichIO(self.console) if HAS_RICH else None
+        self.agent = SparkAgent(config, io=io)
         self._drain_lock = threading.Lock()
         self._stop_drain = threading.Event()
         self._drain_thread = None


### PR DESCRIPTION
Final phase of the 5-phase Spark refactor.

## What

- **`agent_io.py`**: New `RichIO(AgentIO)` class that renders agent output through `rich.console.Console` — styled status indicators, token streaming, pulse display, and prompt restoration.
- **`tui.py`**: Creates `RichIO(console)` and passes it to `SparkAgent(config, io=io)` so all agent callbacks flow through Rich.

## Architecture after all 5 phases

```
agent_io.py    AgentIO (base)
               TerminalIO  -> plain print() fallback
               RichIO      -> Rich Console (TUI)      <-- Phase 5
               WebIO       -> event collector (web)    <-- Phase 4
               SilentIO    -> tests

agent.py       SparkAgent(config, io=AgentIO)
               self.io.on_token(), on_status(), on_pulse()...

tui.py         SparkTUI -> RichIO(console) -> SparkAgent
web_serve.py   WebIO() -> SparkAgent -> agent.turn()
```

Both TUI and web now go through the same `agent.turn()` path with the same tool calls, policy gates, and bus processing. The only difference is the IO backend.

## Zero behavioral change
Falls back to `TerminalIO` (plain print) if Rich is unavailable.