### PR TITLE
fix(tui): correct indentation on RichIO init line

### DIFF
--- a/spark/tui.py
+++ b/spark/tui.py
@@ -42,7 +42,7 @@ from commands import explore, format_policy, format_audit
 class SparkTUI:
     def __init__(self, config: dict):
         self.console = Console() if HAS_RICH else None
-            io = RichIO(self.console) if HAS_RICH else None
+        io = RichIO(self.console) if HAS_RICH else None
         self.agent = SparkAgent(config, io=io)
         self._drain_lock = threading.Lock()
         self._stop_drain = threading.Event()


### PR DESCRIPTION
Phase 5 PR #2174 introduced `io = RichIO(self.console)` with 12-space indentation (3 levels) instead of 8 spaces (2 levels), causing `IndentationError` at runtime. Removes the 4 excess spaces.