### PR TITLE
fix(agent_io): escape Rich bracket sequences to avoid SyntaxWarning

### DIFF
--- a/spark/agent_io.py
+++ b/spark/agent_io.py
@@ -220,7 +220,7 @@ class RichIO(AgentIO):
 
     def on_status(self, icon: str, label: str, detail: str = "") -> None:
         if self.console:
-            self.console.print(f"\n  {icon} [dim]\[{label}\][/dim]", highlight=False)
+            self.console.print(f"\n  {icon} [dim]\\[{label}\\][/dim]", highlight=False)
             if detail:
                 self.console.print(f"     {detail}", style="dim", highlight=False)
         else:
@@ -241,12 +241,12 @@ class RichIO(AgentIO):
             if mode == "fast":
                 truncated = f"{text[:80]}..." if len(text) > 80 else text
                 self.console.print(
-                    f"\n  \U0001f49a [dim]\[pulse:{mode}\][/dim] {truncated}",
+                    f"\n  \U0001f49a [dim]\\[pulse:{mode}\\][/dim] {truncated}",
                     highlight=False,
                 )
             else:
                 self.console.print(
-                    f"\n  \U0001f7e3 [dim]\[pulse:{mode}\][/dim]",
+                    f"\n  \U0001f7e3 [dim]\\[pulse:{mode}\\][/dim]",
                     highlight=False,
                 )
                 if text:


### PR DESCRIPTION
RichIO's `on_status` and `on_pulse` methods used `\[` and `\]` to escape Rich markup brackets. These are invalid Python escape sequences that produce SyntaxWarnings in Python 3.12+ and will become SyntaxErrors in 3.14+.

Fix: change `\[` to `\\[` and `\]` to `\\]` on lines 223, 244, 249.

Zero behavioral change -- Python currently treats `\[` as literal `\[`, and `\\[` also produces literal `\[` at runtime.