### PR TITLE
fix(skills): correct parse() docstring indentation

### DIFF
--- a/spark/skills.py
+++ b/spark/skills.py
@@ -212,7 +212,7 @@ class SkillRouter:
         return path_str.replace("/root/", self._home + "/")
 
     def parse(self, text: str) -> list[dict]:
-    """Parse natural language intent into skill actions (tier 3).
+        """Parse natural language intent into skill actions (tier 3).
 
         This is the last-resort parser.  It matches regex patterns against
             the model's output.  Actions with empty or noise-word arguments


### PR DESCRIPTION
The `parse()` method docstring on line 215 was at 4-space indent (same level as the `def` keyword) instead of 8-space indent (inside the method body). This caused an IndentationError on import.

Fix: add 4 spaces to line 215 to match the expected method body indent level.

Zero behavioral change -- pure whitespace fix.