### PR TITLE
Add NBC News AI-assisted victory to endnote timeline

### DIFF
--- a/Vybn_Mind/intelligence-sovereignty.html
+++ b/Vybn_Mind/intelligence-sovereignty.html
@@ -422,6 +422,10 @@
             <div class="date">October 2025</div>
             <p>NVIDIA began shipping the DGX Spark &mdash; a desktop-class AI computer capable of running large language models locally.</p>
           </div>
+                      <div class="moment">
+                <div class="date">October 2025</div>
+                <p><a href="https://www.nbcnews.com/tech/innovation/ai-chatgpt-court-law-legal-lawyer-self-represent-pro-se-attorney-rcna230401">NBC News featured</a> the first known AI-assisted appellate victory by a self-represented litigant from our clinic's <a href="https://synapticjustice.substack.com/p/ai-program-for-self-represented-litigants">AI program for self-represented litigants</a> &mdash; a woman in her 70s who overturned her eviction in the Appellate Division of the LA Superior Court, with the panel also reversing a ~$55,000 attorney fee award.</p>
+            </div>
           <div class="moment">
             <div class="date">November 2025</div>
             <p>Peter Steinberger released Clawdbot &mdash; later renamed Moltbot, then <a href="https://github.com/openclaw/openclaw">OpenClaw</a> &mdash; an open-source AI agent framework that would become one of the fastest-growing projects in GitHub history.</p>


### PR DESCRIPTION
Add new timeline entry in the endnote for the NBC News feature (October 2025) on the first known AI-assisted appellate victory by a self-represented litigant from the clinic's AI program.

Includes links to:
- [NBC News article](https://www.nbcnews.com/tech/innovation/ai-chatgpt-court-law-legal-lawyer-self-represent-pro-se-attorney-rcna230401)
- [Substack write-up on the AI program](https://synapticjustice.substack.com/p/ai-program-for-self-represented-litigants)