### PR TITLE
Add Mid-2024 SRL AI program entry to timeline start, move Substack li…

### DIFF
--- a/Vybn_Mind/intelligence-sovereignty.html
+++ b/Vybn_Mind/intelligence-sovereignty.html
@@ -410,6 +410,10 @@
         <section class="endnote" id="endnote-timeline">
         <p class="note-label">Timeline of convergence:</p>
         <div class="timeline">
+                      <div class="moment">
+                <div class="date">Mid-2024</div>
+                <p>We launched an <a href="https://synapticjustice.substack.com/p/ai-program-for-self-represented-litigants">AI program for self-represented litigants</a> at Public Counsel's Appellate Clinic in Los Angeles &mdash; teaching people navigating the appeals process how to use AI tools safely and effectively for legal research and drafting.</p>
+            </div>
           <div class="moment">
             <div class="date">Mid-2025</div>
             <p>We shifted our clinical teaching from building specific AI tools to developing generalized AI capabilities in self-represented litigants and law students &mdash; the move from literacy to fluency.</p>
@@ -424,7 +428,7 @@
           </div>
                       <div class="moment">
                 <div class="date">October 2025</div>
-                <p><a href="https://www.nbcnews.com/tech/innovation/ai-chatgpt-court-law-legal-lawyer-self-represent-pro-se-attorney-rcna230401">NBC News featured</a> the first known AI-assisted appellate victory by a self-represented litigant from our clinic's <a href="https://synapticjustice.substack.com/p/ai-program-for-self-represented-litigants">AI program for self-represented litigants</a> &mdash; a woman in her 70s who overturned her eviction in the Appellate Division of the LA Superior Court, with the panel also reversing a ~$55,000 attorney fee award.</p>
+                <p><a href="https://www.nbcnews.com/tech/innovation/ai-chatgpt-court-law-legal-lawyer-self-represent-pro-se-attorney-rcna230401">NBC News featured</a> the first known AI-assisted appellate victory by a self-represented litigant from our clinic's AI program for self-represented litigants &mdash; a woman in her 70s who overturned her eviction in the Appellate Division of the LA Superior Court, with the panel also reversing a ~$55,000 attorney fee award.</p>
             </div>
           <div class="moment">
             <div class="date">November 2025</div>


### PR DESCRIPTION
Two changes to the endnote timeline in intelligence-sovereignty.html:

1. Added new **Mid-2024** entry at the very start of the timeline for the launch of the AI program for self-represented litigants at Public Counsel's Appellate Clinic, with link to the [Substack write-up](https://synapticjustice.substack.com/p/ai-program-for-self-represented-litigants)

2. Removed the Substack link from the October 2025 NBC News entry (since the Substack link now lives in its own chronologically correct Mid-2024 entry)