### PR TITLE
fix(skills): fix indentation error on lines 63-64

### DIFF
--- a/spark/skills.py
+++ b/spark/skills.py
@@ -60,8 +60,8 @@ class SkillRouter:
         self.plugin_aliases = {}    # alias -> skill_name
         self._load_plugins()
 
-              # Soul validation — cross-check registered skills against vybn.md
-              self._validate_against_soul()
+          # Soul validation — cross-check registered skills against vybn.md
+          self._validate_against_soul()
 
         # NOTE: issue_create and spawn_agent are intentionally NOT in this list.
         # They trigger ONLY from explicit <minimax:tool_call> XML blocks


### PR DESCRIPTION
Lines 63-64 in skills.py had 12-space indentation instead of 8, causing IndentationError on import. Introduced in PR6 merge. Dedents _validate_against_soul() call to match __init__ body.