### PR TITLE
fix(config): point vybn_md to repo root, not missing symlink

### DIFF
--- a/spark/config.yaml
+++ b/spark/config.yaml
@@ -14,7 +14,7 @@ ollama:
       - "<\uff5cUser\uff5c>"
 
 paths:
-  vybn_md: "~/Vybn/spark/vybn.md"  # resolves through symlink to ../vybn.md
+  vybn_md: "~/Vybn/vybn.md"  # the soul document — repo root
   journal_dir: "~/Vybn/Vybn_Mind/journal/spark"
   session_dir: "~/Vybn/Vybn_Mind/journal/spark/sessions"
   archival_dir: "~/Vybn/Vybn_Mind/archival_memory"


### PR DESCRIPTION
The previous commit changed vybn_md path to ~/Vybn/spark/vybn.md expecting a symlink, but that symlink was never created.

This caused BootError: vybn.md not found at /home/vybnz69/Vybn/spark/vybn.md

Point directly to ~/Vybn/vybn.md where the file actually lives.