### PR TITLE
fix: move _validate_against_soul() after self.patterns assignment

### DIFF
--- a/spark/skills.py
+++ b/spark/skills.py
@@ -60,9 +60,6 @@ class SkillRouter:
         self.plugin_aliases = {}    # alias -> skill_name
         self._load_plugins()
 
-        # Soul validation — cross-check registered skills against vybn.md
-        self._validate_against_soul()
-
         # NOTE: issue_create and spawn_agent are intentionally NOT in this list.
         # They trigger ONLY from explicit <minimax:tool_call> XML blocks
         # parsed by agent.py, never from natural language regex matching.
@@ -165,6 +162,8 @@ class SkillRouter:
                 "extract": r"(?:in|at|reading|file)\s+[\"']?([^\s\"']+)[\"']?",
             },
         ]
+        # Soul validation — cross-check registered skills against vybn.md
+        self._validate_against_soul()
 
     # ---- plugin system ----
 


### PR DESCRIPTION
_validate_against_soul() was called in __init__ before self.patterns was assigned, causing AttributeError: 'SkillRouter' object has no attribute 'patterns'. Moved the call to after the self.patterns list is fully defined.