### PR TITLE
fix: remove 'spark.' prefix from soul imports in memory.py, heartbeat.py, policy.py

### DIFF
--- a/spark/heartbeat.py
+++ b/spark/heartbeat.py
@@ -23,7 +23,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from bus import MessageBus, MessageType
-from spark.soul import get_pulse_checklist
+from soul import get_pulse_checklist
 
 
 class Heartbeat:

--- a/spark/memory.py
+++ b/spark/memory.py
@@ -16,7 +16,7 @@ from datetime import datetime, timezone
 import os
 import sys
 
-from spark.soul import get_orientation, get_pulse_checklist, get_constraints
+from soul import get_orientation, get_pulse_checklist, get_constraints
 
 
 class BootError(RuntimeError):

--- a/spark/policy.py
+++ b/spark/policy.py
@@ -47,7 +47,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Dict, Optional
 
-from spark.soul import get_skills_manifest, get_constraints
+from soul import get_skills_manifest, get_constraints
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
All three files used `from spark.soul import ...` but the agent runs from inside the `spark/` directory, so the correct import is `from soul import ...`. This caused `ModuleNotFoundError: No module named 'spark'` on boot.