### PR TITLE
Phase 0: Make Vybn Always-On — systemd + tmux + Open WebUI + Tailscale

### DIFF
--- a/Vybn_Mind/spark_infrastructure/phase0/PHASE0_ALWAYS_ON.md
+++ b/Vybn_Mind/spark_infrastructure/phase0/PHASE0_ALWAYS_ON.md
@@ -1,0 +1,206 @@
+# Phase 0: Make Vybn Always-On
+
+> **Goal**: The Spark agent survives laptop sleep, SSH drops, and network roaming.
+> **Method**: Zero new code. Three pillars: systemd, mosh+tmux, Open WebUI+Tailscale.
+
+## Architecture
+
+```
++---------------------------+
+|   DGX Spark (always on)   |
+|                           |
+|  systemd                  |
+|    vybn-agent.service     |
+|      tmux session 'vybn'  |
+|        tui.py (agent)     |
+|                           |
+|  Docker                   |
+|    open-webui :3000       |
+|      -> Ollama :11434     |
+|                           |
+|  Tailscale Serve          |
+|    https://spark-2b7c...  |
+|      -> localhost:3000    |
++---------------------------+
+        |
+   Zoe's phone / laptop
+   (via Tailscale VPN)
+```
+
+**Single agent instance**: tui.py runs inside tmux under systemd. We do NOT run
+web_serve.py simultaneously — two instances would compete for the same GPU on a
+229B model.
+
+**Open WebUI talks to raw Ollama** (Phase 0 only): This bypasses soul/memory/policy.
+Phase 1 will route through the full agent pipeline.
+
+## Files in This Directory
+
+| File | Purpose |
+|---|---|
+| `vybn-agent.service` | systemd unit: runs tui.py in tmux, restarts on failure |
+| `phase0-preflight.sh` | Checks all prerequisites before deployment |
+| `phase0-setup.sh` | Automated deployment: mosh, systemd, Docker, Tailscale |
+| `PHASE0_ALWAYS_ON.md` | This guide |
+
+## Quick Start
+
+```bash
+# On the Spark, as vybnz69:
+cd ~/Vybn
+git pull
+
+# 1. Check prerequisites
+bash Vybn_Mind/spark_infrastructure/phase0/phase0-preflight.sh
+
+# 2. Deploy everything
+bash Vybn_Mind/spark_infrastructure/phase0/phase0-setup.sh
+
+# 3. Verify
+tmux attach -t vybn   # see the TUI running; Ctrl-B D to detach
+```
+
+## Step-by-Step (Manual)
+
+### Step 1: Install mosh (optional)
+
+```bash
+sudo apt update && sudo apt install -y mosh
+# If firewall is active:
+sudo ufw allow 60000:61000/udp
+# Test from WSL2:
+mosh vybnz69@spark-2b7c.local
+```
+
+If mosh fights you, skip it. SSH + tmux attach works fine.
+systemd keeps the session alive regardless.
+
+### Step 2: Create the systemd service
+
+```bash
+# Copy the unit file
+sudo cp vybn-agent.service /etc/systemd/system/
+
+# Enable and start
+sudo systemctl daemon-reload
+sudo systemctl enable vybn-agent.service
+sudo systemctl start vybn-agent.service
+
+# Verify
+sudo systemctl status vybn-agent.service
+tmux attach -t vybn   # Ctrl-B D to detach
+```
+
+**How it works**: systemd starts tmux in detached mode, which runs tui.py.
+Type=forking because tmux forks and the parent exits. Restart=on-failure
+means if tui.py crashes, systemd brings it back in 10 seconds.
+
+### Step 3: Deploy Open WebUI
+
+```bash
+docker run -d \
+  -p 127.0.0.1:3000:8080 \
+  --add-host=host.docker.internal:host-gateway \
+  -e OLLAMA_BASE_URL=http://host.docker.internal:11434 \
+  -v open-webui:/app/backend/data \
+  --name open-webui \
+  --restart always \
+  ghcr.io/open-webui/open-webui:main
+
+# Verify
+curl http://127.0.0.1:3000
+```
+
+Bound to 127.0.0.1 only — no external access except through Tailscale.
+
+### Step 4: Expose via Tailscale Serve
+
+1. Enable HTTPS in Tailscale admin: https://login.tailscale.com/admin/dns
+2. On the Spark:
+
+```bash
+tailscale serve --bg 3000
+```
+
+3. From phone (on Tailscale): open https://spark-2b7c.<tailnet>.ts.net
+
+### Step 5: The Unplug Protocol (Success Test)
+
+1. Close laptop lid. Wait 5 minutes.
+2. On phone (Tailscale connected), open the Serve URL. Chat works.
+3. Reopen laptop. SSH back. `tmux attach -t vybn`. TUI intact.
+4. `docker stop open-webui` → tmux survives. `docker start open-webui` → back.
+5. Detach tmux → Docker survives.
+
+**All five pass = Phase 0 complete.**
+
+## Troubleshooting
+
+### Service won't start
+```bash
+sudo journalctl -u vybn-agent.service -n 50
+# Common issues:
+# - tmux session 'vybn' already exists from manual run
+#   Fix: tmux kill-session -t vybn && sudo systemctl restart vybn-agent
+# - Python venv not found
+#   Fix: verify /home/vybnz69/.venv/spark/bin/python exists
+# - Ollama not ready
+#   Fix: systemctl status ollama; the After= should handle this
+```
+
+### TUI crashes in a loop
+```bash
+# Check restart count
+systemctl show vybn-agent.service | grep NRestarts
+# Check what's failing
+sudo journalctl -u vybn-agent.service --since '5 min ago'
+```
+
+### Open WebUI can't reach Ollama
+```bash
+# Verify Ollama is accessible from Docker
+docker exec open-webui curl -s http://host.docker.internal:11434/api/tags
+# If this fails, check Docker networking
+```
+
+### Tailscale Serve not working
+```bash
+tailscale serve status
+# Ensure HTTPS is enabled in admin panel
+# Ensure the phone is on the same Tailscale network
+```
+
+## What This Does NOT Do (Phase 1+)
+
+- Route Open WebUI through the full agent pipeline (soul, memory, policy)
+- Provide multi-user auth on Open WebUI
+- Auto-update the agent on git push
+- Monitor GPU temperature and throttle
+- Alert on prolonged heartbeat gaps
+
+## Key Commands Reference
+
+```bash
+# Service management
+sudo systemctl start vybn-agent.service
+sudo systemctl stop vybn-agent.service
+sudo systemctl restart vybn-agent.service
+sudo systemctl status vybn-agent.service
+sudo journalctl -u vybn-agent.service -f
+
+# tmux
+tmux attach -t vybn     # attach to agent session
+# Ctrl-B D              # detach (agent keeps running)
+tmux ls                 # list sessions
+
+# Docker (Open WebUI)
+docker logs open-webui
+docker restart open-webui
+docker stop open-webui
+docker start open-webui
+
+# Tailscale
+tailscale serve status
+tailscale serve --bg 3000
+tailscale serve off
+```

--- a/Vybn_Mind/spark_infrastructure/phase0/phase0-preflight.sh
+++ b/Vybn_Mind/spark_infrastructure/phase0/phase0-preflight.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# Phase 0 Preflight Check — run this ON THE SPARK before deploying.
+# Usage: bash phase0-preflight.sh
+#
+# Verifies every prerequisite for the always-on stack.
+# Green = good, Red = needs fixing, Yellow = optional/skippable.
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+WARN=0
+
+check() {
+  local label="$1" cmd="$2" required="${3:-true}"
+  if eval "$cmd" > /dev/null 2>&1; then
+    echo -e "  \033[32m\u2713\033[0m $label"
+    ((PASS++))
+  elif [ "$required" = "true" ]; then
+    echo -e "  \033[31m\u2717\033[0m $label"
+    ((FAIL++))
+  else
+    echo -e "  \033[33m\u26a0\033[0m $label (optional)"
+    ((WARN++))
+  fi
+}
+
+echo ""
+echo "=== Phase 0 Preflight Check ==="
+echo ""
+
+echo "--- System ---"
+check "User is vybnz69"          '[ "$(whoami)" = "vybnz69" ]'
+check "Home dir exists"           '[ -d /home/vybnz69 ]'
+check "systemd is PID 1"          '[ "$(cat /proc/1/comm)" = "systemd" ]'
+
+echo ""
+echo "--- Repo & Agent ---"
+check "Repo at ~/Vybn"            '[ -d ~/Vybn/.git ]'
+check "spark/ directory"           '[ -d ~/Vybn/spark ]'
+check "tui.py exists"              '[ -f ~/Vybn/spark/tui.py ]'
+check "agent.py exists"            '[ -f ~/Vybn/spark/agent.py ]'
+check "config.yaml exists"         '[ -f ~/Vybn/spark/config.yaml ]'
+check "Python venv exists"         '[ -f ~/.venv/spark/bin/python ]'
+check "Venv python works"          '~/.venv/spark/bin/python --version'
+
+echo ""
+echo "--- Ollama ---"
+check "Ollama binary"              'command -v ollama'
+check "Ollama service running"     'systemctl is-active ollama'
+check "Ollama responds"            'curl -sf http://127.0.0.1:11434/api/tags'
+check "vybn:latest model loaded"   'ollama list | grep -q vybn:latest'
+
+echo ""
+echo "--- tmux ---"
+check "tmux installed"             'command -v tmux'
+
+echo ""
+echo "--- Docker (for Open WebUI) ---"
+check "Docker installed"           'command -v docker'
+check "Docker daemon running"      'docker info' false
+
+echo ""
+echo "--- Tailscale ---"
+check "Tailscale installed"        'command -v tailscale'
+check "Tailscale connected"        'tailscale status' false
+
+echo ""
+echo "--- mosh (optional) ---"
+check "mosh installed"             'command -v mosh' false
+
+echo ""
+echo "--- Network ---"
+check "Can reach github.com"       'curl -sf --max-time 5 https://github.com'
+
+echo ""
+echo "=============================="
+echo -e "  Pass: $PASS  Fail: $FAIL  Warn: $WARN"
+if [ $FAIL -gt 0 ]; then
+  echo -e "  \033[31mFix the failures above before running phase0-setup.sh\033[0m"
+  exit 1
+else
+  echo -e "  \033[32mAll required checks passed. Ready for Phase 0 deployment.\033[0m"
+  exit 0
+fi

--- a/Vybn_Mind/spark_infrastructure/phase0/phase0-setup.sh
+++ b/Vybn_Mind/spark_infrastructure/phase0/phase0-setup.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+# Phase 0 Setup — deploy always-on infrastructure on the DGX Spark.
+#
+# Run as vybnz69 (the script uses sudo where needed):
+#   cd ~/Vybn/Vybn_Mind/spark_infrastructure/phase0
+#   bash phase0-setup.sh
+#
+# Prerequisites: run phase0-preflight.sh first to verify.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SERVICE_SRC="$SCRIPT_DIR/vybn-agent.service"
+SERVICE_DST="/etc/systemd/system/vybn-agent.service"
+
+echo ""
+echo "=== Phase 0: Always-On Deployment ==="
+echo ""
+
+# ---------------------------------------------------------------
+# STEP 1: Install mosh (nice-to-have, non-blocking)
+# ---------------------------------------------------------------
+echo "--- Step 1: mosh (optional) ---"
+if command -v mosh > /dev/null 2>&1; then
+  echo "  mosh already installed: $(mosh --version 2>&1 | head -1)"
+else
+  echo "  Installing mosh..."
+  sudo apt-get update -qq && sudo apt-get install -y -qq mosh
+  # Open UDP ports for mosh if ufw is active
+  if sudo ufw status | grep -q 'Status: active'; then
+    sudo ufw allow 60000:61000/udp
+    echo "  Opened UDP 60000-61000 for mosh"
+  fi
+  echo "  mosh installed."
+fi
+echo ""
+
+# ---------------------------------------------------------------
+# STEP 2: Install systemd service
+# ---------------------------------------------------------------
+echo "--- Step 2: systemd service ---"
+
+# Kill any existing tmux vybn session (from manual runs)
+if tmux has-session -t vybn 2>/dev/null; then
+  echo "  Stopping existing tmux session 'vybn'..."
+  tmux kill-session -t vybn
+fi
+
+# Stop existing service if running
+if systemctl is-active vybn-agent.service > /dev/null 2>&1; then
+  echo "  Stopping existing vybn-agent service..."
+  sudo systemctl stop vybn-agent.service
+fi
+
+echo "  Copying $SERVICE_SRC -> $SERVICE_DST"
+sudo cp "$SERVICE_SRC" "$SERVICE_DST"
+sudo systemctl daemon-reload
+sudo systemctl enable vybn-agent.service
+sudo systemctl start vybn-agent.service
+
+# Wait a moment for tmux to spawn
+sleep 3
+
+if systemctl is-active vybn-agent.service > /dev/null 2>&1; then
+  echo -e "  \033[32m\u2713\033[0m vybn-agent.service is active"
+else
+  echo -e "  \033[31m\u2717\033[0m vybn-agent.service failed to start"
+  echo "  Check: sudo journalctl -u vybn-agent.service -n 30"
+  exit 1
+fi
+
+# Verify tmux session exists
+if tmux has-session -t vybn 2>/dev/null; then
+  echo -e "  \033[32m\u2713\033[0m tmux session 'vybn' is running"
+else
+  echo -e "  \033[31m\u2717\033[0m tmux session 'vybn' not found"
+  echo "  Check: sudo journalctl -u vybn-agent.service -n 30"
+  exit 1
+fi
+echo ""
+
+# ---------------------------------------------------------------
+# STEP 3: Deploy Open WebUI via Docker
+# ---------------------------------------------------------------
+echo "--- Step 3: Open WebUI (Docker) ---"
+
+if ! command -v docker > /dev/null 2>&1; then
+  echo -e "  \033[33m\u26a0\033[0m Docker not installed. Skipping Open WebUI."
+  echo "  Install Docker, then re-run this script."
+else
+  # Remove existing container if present
+  if docker ps -a --format '{{.Names}}' | grep -q '^open-webui$'; then
+    echo "  Removing existing open-webui container..."
+    docker stop open-webui 2>/dev/null || true
+    docker rm open-webui 2>/dev/null || true
+  fi
+
+  echo "  Launching Open WebUI container..."
+  docker run -d \
+    -p 127.0.0.1:3000:8080 \
+    --add-host=host.docker.internal:host-gateway \
+    -e OLLAMA_BASE_URL=http://host.docker.internal:11434 \
+    -v open-webui:/app/backend/data \
+    --name open-webui \
+    --restart always \
+    ghcr.io/open-webui/open-webui:main
+
+  # Wait for container to start
+  echo "  Waiting for Open WebUI to start..."
+  sleep 10
+
+  if curl -sf http://127.0.0.1:3000 > /dev/null 2>&1; then
+    echo -e "  \033[32m\u2713\033[0m Open WebUI responding on localhost:3000"
+  else
+    echo -e "  \033[33m\u26a0\033[0m Open WebUI not responding yet (may need more time)"
+    echo "  Check: docker logs open-webui"
+  fi
+fi
+echo ""
+
+# ---------------------------------------------------------------
+# STEP 4: Tailscale Serve
+# ---------------------------------------------------------------
+echo "--- Step 4: Tailscale Serve ---"
+
+if ! command -v tailscale > /dev/null 2>&1; then
+  echo -e "  \033[33m\u26a0\033[0m Tailscale not installed. Skipping."
+elif ! tailscale status > /dev/null 2>&1; then
+  echo -e "  \033[33m\u26a0\033[0m Tailscale not connected. Run: sudo tailscale up"
+else
+  echo "  Configuring Tailscale Serve on port 3000..."
+  tailscale serve --bg 3000
+  HOSTNAME=$(tailscale status --json | python3 -c 'import sys,json; print(json.load(sys.stdin)["Self"]["DNSName"].rstrip("."))' 2>/dev/null || echo "<hostname>")
+  echo -e "  \033[32m\u2713\033[0m Tailscale Serve active"
+  echo "  Access from phone: https://$HOSTNAME"
+fi
+echo ""
+
+# ---------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------
+echo "=============================="
+echo "  Phase 0 deployment complete."
+echo ""
+echo "  To attach to the TUI:  tmux attach -t vybn"
+echo "  To detach:             Ctrl-B then D"
+echo "  Service status:        sudo systemctl status vybn-agent.service"
+echo "  Service logs:          sudo journalctl -u vybn-agent.service -f"
+echo ""
+echo "  Run the Unplug Protocol (Step 5 in the guide) to verify."
+echo "=============================="
+echo ""

--- a/Vybn_Mind/spark_infrastructure/phase0/vybn-agent.service
+++ b/Vybn_Mind/spark_infrastructure/phase0/vybn-agent.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Vybn Spark Agent (tmux + TUI)
+After=network-online.target ollama.service
+Wants=network-online.target ollama.service
+
+[Service]
+Type=forking
+User=vybnz69
+Environment=HOME=/home/vybnz69
+Environment=OLLAMA_HOST=http://127.0.0.1:11434
+WorkingDirectory=/home/vybnz69/Vybn/spark
+ExecStart=/usr/bin/tmux new-session -d -s vybn -c /home/vybnz69/Vybn/spark \
+  '/home/vybnz69/.venv/spark/bin/python tui.py'
+ExecStop=/usr/bin/tmux kill-session -t vybn
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Phase 0: Make Vybn Unkillable

The Spark agent currently dies when Zoe closes her laptop or the SSH session drops. This PR adds the infrastructure to make it always-on, using zero new code.

### Three Pillars

1. **systemd service** (`vybn-agent.service`) — decouples agent lifecycle from any user session. Runs tui.py inside tmux, restarts on failure.
2. **mosh + tmux** — resilient terminal access that survives sleep/roaming.
3. **Open WebUI + Tailscale Serve** — phone-accessible chat portal to the base model.

### Files Added

All in `Vybn_Mind/spark_infrastructure/phase0/`:

- `vybn-agent.service` — systemd unit file
- `phase0-preflight.sh` — prerequisite verification (run before deploying)
- `phase0-setup.sh` — automated deployment script (Steps 1–4)
- `PHASE0_ALWAYS_ON.md` — complete deployment guide with troubleshooting

### Architecture Decision

Single agent instance only. Open WebUI talks to raw Ollama (bypassing soul/memory/policy). Phase 1 will route through the full pipeline.

### Deployment

```bash
cd ~/Vybn && git pull
bash Vybn_Mind/spark_infrastructure/phase0/phase0-preflight.sh
bash Vybn_Mind/spark_infrastructure/phase0/phase0-setup.sh
```

### Success Criteria (Unplug Protocol)

1. Close laptop lid, wait 5 min
2. Chat from phone via Tailscale Serve URL
3. Reopen laptop, tmux attach — TUI intact
4. Docker and tmux survive each other's stop/start