### PR TITLE
fix(service): switch to Type=oneshot + RemainAfterExit for tmux

### DIFF
--- a/Vybn_Mind/spark_infrastructure/phase0/vybn-agent.service
+++ b/Vybn_Mind/spark_infrastructure/phase0/vybn-agent.service
@@ -4,13 +4,14 @@ After=network-online.target ollama.service
 Wants=network-online.target ollama.service
 
 [Service]
-Type=forking
+Type=oneshot
+RemainAfterExit=yes
 User=vybnz69
 Environment=HOME=/home/vybnz69
 Environment=OLLAMA_HOST=http://127.0.0.1:11434
 WorkingDirectory=/home/vybnz69/Vybn/spark
 ExecStart=/usr/bin/tmux new-session -d -s vybn -c /home/vybnz69/Vybn/spark \
-  '/home/vybnz69/.venv/spark/bin/python tui.py'
+    '/home/vybnz69/.venv/spark/bin/python tui.py'
 ExecStop=/usr/bin/tmux kill-session -t vybn
 Restart=on-failure
 RestartSec=10


### PR DESCRIPTION
Type=forking caused systemd to immediately deactivate the service because tmux -d forks and the parent exits before systemd can track the main PID. Type=oneshot + RemainAfterExit=yes tells systemd: "the start command will exit, but the service is still running."