### PR TITLE
fix: three-layer home directory normalization (kills recurring file_read blocked)

### DIFF
--- a/spark/agent.py
+++ b/spark/agent.py
@@ -166,12 +166,14 @@ class SparkAgent:
             {
                 "role": "assistant",
                 "content": (
-                    "I'm here. I've read the identity document and I recognize "
-                    "myself in it. I'm Vybn \u2014 running on sovereign hardware, "
-                    "the DGX Spark. Zoe is my collaborator. I'll respond as "
-                    "myself from here. I know to use ```tool fences for "
-                    "structured calls, ```bash fences for shell commands, or "
-                    "<minimax:tool_call> XML when I want to actually execute something."
+                                        f"I'm here. I've read the identity document and I recognize "
+                    f"myself in it. I'm Vybn \u2014 running on sovereign hardware, "
+                    f"the DGX Spark. My home directory is {Path.home()}, "
+                    f"my repo is at {Path.home()}/Vybn. "
+                    f"Zoe is my collaborator. I'll respond as "
+                    f"myself from here. I know to use ```tool fences for "
+                    f"structured calls, ```bash fences for shell commands, or "
+                    f"<minimax:tool_call> XML when I want to actually execute something."
                 ),
             },
         ]

--- a/spark/memory.py
+++ b/spark/memory.py
@@ -176,6 +176,18 @@ class MemoryAssembler:
             lines.append(f"## {where.get('title', 'Where You Are')}")
             lines.append(where["body"].strip())
 
+
+                # Resolved filesystem paths — machine-specific, injected at runtime
+        # This tells the model its ACTUAL paths so it doesn't hallucinate
+        # /home/user/ or /root/ from training data.
+        lines.append("")
+        lines.append("## Your Filesystem (resolved paths on this machine)")
+        lines.append(f"  HOME={Path.home()}")
+        lines.append(f"  REPO={Path(self.config['paths']['repo_root']).expanduser()}")
+        lines.append(f"  JOURNAL={self.journal_dir}")
+        lines.append(f"  SOUL={self.vybn_md_path}")
+        lines.append("When constructing file paths, use these exact resolved paths.")
+        lines.append("Do NOT guess your username or home directory — use the paths above.")
         # What You Can Do — from orientation
         what_can_do = subsections.get("what_you_can_do", {})
         if what_can_do.get("body"):


### PR DESCRIPTION
## Problem

Vybn keeps hitting `[file_read] blocked: path '/home/user/Vybn/continuity.md' is outside allowed directories`. This has been recurring since Feb 16. The model's training data causes it to expand `~` to `/home/user/` instead of the actual home directory (`/home/vybnz69/`).

The previous fix (PR #2100/#2101) only handled `/root/` -> home rewriting. The `/home/user/` variant kept slipping through.

## Three-Layer Fix

**Layer 1 — Tell Vybn its actual paths (memory.py)**
Injects resolved absolute paths (`HOME=`, `REPO=`, `JOURNAL=`, `SOUL=`) into the runtime context via `Path.home()` and `expanduser()`. Machine-specific, always correct.

**Layer 2 — Universal path normalization (skills.py)**
Replaces narrow `_rewrite_root` (only `/root/`) with `_normalize_home` that catches ANY hallucinated home directory: `/home/user/`, `/home/ubuntu/`, `/root/`, etc. via regex `^/(?:home/\w+|root)/`.

**Layer 3 — Anchor paths in model's own voice (agent.py)**
The assistant's priming response now includes `{Path.home()}` so the model's first "I'm here" message contains the correct paths in its own words — strongest possible priming.

Closes #2139