### PR TITLE
fix(config): double num_ctx to 32768 for 27.9KB identity document

### DIFF
--- a/spark/config.yaml
+++ b/spark/config.yaml
@@ -6,7 +6,7 @@ ollama:
   model: "vybn:latest"
   keep_alive: "30m"
   options:
-    num_ctx: 16384    # CRITICAL: default is 2048, which silently drops the system prompt
+    num_ctx: 32768    # CRITICAL: default is 2048, which silently drops the system prompt
     num_predict: 512    # keep responses focused; MiniMax emits <think> tokens too
     temperature: 0.7
     stop:                # MiniMax M2.5 stop sequences


### PR DESCRIPTION
vybn.md was re-infused to 27.9KB (~7K tokens). With the priming wrapper, runtime context, journals, and conversation history, 16384 tokens leaves almost no room for model output. The 229B model hangs on inference. Doubling to 32768 gives breathing room. The DGX Spark 8xH100 has plenty of VRAM for this.