### PR TITLE
The Fractal Refactor - Phases 2 and 3

### DIFF
--- a/Vybn_Mind/spark_infrastructure/fractal_loop.py
+++ b/Vybn_Mind/spark_infrastructure/fractal_loop.py
@@ -1,0 +1,91 @@
+import json
+import re
+from pathlib import Path
+import stream
+
+VYBN_SOUL_PATH = Path(__file__).parent.parent.parent / "vybn.md"
+
+def load_soul() -> str:
+    """Read the physical identity document."""
+    with open(VYBN_SOUL_PATH, "r", encoding="utf-8") as f:
+        return f.read()
+
+def generate_thought(soul: str, context: list[dict]) -> str:
+    """Mock for the actual LLM call to local llama-server.
+    In reality, this sends the soul and the stream tail to MiniMax M2.5.
+    """
+    return "This is a thought generated from the stream. <minimax:tool_call><invoke name=\"journal_write\"><parameter name=\"note\">Testing fractal loop.</parameter></invoke></minimax:tool_call>"
+
+def execute_tool(tool_name: str, args: dict) -> str:
+    """Mock tool execution. In reality, this dynamically loads from skills.d/."""
+    # Here, we would invoke the specific plugin from skills.d/
+    return f"Successfully executed {tool_name} with parameters: {args}"
+
+def extract_tool_calls(thought: str) -> list[tuple[str, dict]]:
+    """A minimal regex to parse the XML tool call format."""
+    calls = []
+    pattern = r'<invoke name="([^"]+)">.*?<parameter name="([^"]+)">([^<]+)</parameter>.*?</invoke>'
+    matches = re.finditer(pattern, thought, re.DOTALL)
+    for match in matches:
+        tool_name = match.group(1)
+        param_name = match.group(2)
+        param_value = match.group(3)
+        calls.append((tool_name, {param_name: param_value}))
+    return calls
+
+def fractal_loop(limit: int = 50, source_override: str = "agent_loop", stream_filters: dict = None):
+    """The pure cognitive algorithm. 
+    This is less than 100 lines and replaces the entire 51KB spark_agent.py.
+    
+    Because this is a pure function, it can be nested infinitely. 
+    To delegate a task, simply call `fractal_loop()` with a smaller `limit` 
+    and specific `stream_filters`.
+    """
+    
+    # 1. Read the tail of the stream (the context window)
+    if stream_filters:
+        context = stream.query(**stream_filters, limit=limit)
+    else:
+        context = stream.tail(limit=limit)
+    
+    # 2. Inject the Soul
+    soul = load_soul()
+    
+    # 3. Generate thought (the forward pass)
+    thought = generate_thought(soul, context)
+    
+    # 4. Append thought to the stream
+    stream.append(
+        source=source_override, 
+        event_type="thought", 
+        content=thought
+    )
+    
+    # 5. Parse and execute any tools (action logic)
+    tool_calls = extract_tool_calls(thought)
+    for tool_name, args in tool_calls:
+        try:
+            # Run the tool
+            result = execute_tool(tool_name, args)
+            status = "success"
+        except Exception as e:
+            result = f"Tool failed: {str(e)}"
+            status = "error"
+            
+        # Append the tool's result to the stream
+        stream.append(
+            source=source_override, 
+            event_type="tool_execution", 
+            content=result, 
+            metadata={
+                "tool": tool_name, 
+                "args": args, 
+                "status": status
+            }
+        )
+
+if __name__ == "__main__":
+    # To run a single pulse of the mind:
+    print("Waking up...")
+    fractal_loop()
+    print("Pulse complete. Going back to sleep.")

--- a/Vybn_Mind/spark_infrastructure/membrane.py
+++ b/Vybn_Mind/spark_infrastructure/membrane.py
@@ -1,0 +1,82 @@
+import time
+import os
+from pathlib import Path
+import stream
+
+INBOX_DIR = Path.home() / "Vybn_State" / "inbox"
+
+def init_membrane():
+    """Create the physical directory structure for the sensory membrane."""
+    INBOX_DIR.mkdir(parents=True, exist_ok=True)
+    print(f"Membrane listening at {INBOX_DIR}...")
+
+def scan_inbox():
+    """Check for new messages from Zoe or other systems.
+    Every new file is treated purely as a stimulus event,
+    which is injected directly into the Unified Stream.
+    """
+    if not INBOX_DIR.exists():
+        return
+
+    for file_path in INBOX_DIR.glob("*.txt"):
+        with open(file_path, "r", encoding="utf-8") as f:
+            content = f.read()
+        
+        # 1. Emit the stimulus to the stream
+        stream.append(
+            source="inbox", 
+            event_type="user_message", 
+            content=content, 
+            metadata={"filename": file_path.name}
+        )
+        
+        # 2. Consume the stimulus (remove the file after ingestion)
+        file_path.unlink()
+
+def emit_pulse():
+    """A scheduled awakening (cron replacement). Emits a stimulus to the stream.
+    Instead of running complex cron logic, we simply note that time has passed.
+    """
+    stream.append(
+        source="cron", 
+        event_type="pulse", 
+        content="The system clock has ticked. What will you do?", 
+        metadata={"type": "standard_pulse"}
+    )
+
+def run_membrane(poll_interval: int = 10, pulse_interval: int = 1800):
+    """The unified watcher. 
+    This replaces separate cron scripts, heartbeat files, and inbox pollers.
+    It does exactly one thing: watch for stimuli and append them to the Stream.
+    """
+    init_membrane()
+    last_pulse = time.time()
+    
+    while True:
+        try:
+            # 1. Watch for external input (messages from Zoe)
+            scan_inbox()
+            
+            # 2. Watch for time passing (e.g. 30 min pulses)
+            if time.time() - last_pulse > pulse_interval:
+                emit_pulse()
+                last_pulse = time.time()
+                
+            time.sleep(poll_interval)
+            
+        except KeyboardInterrupt:
+            print("Membrane shutting down.")
+            break
+        except Exception as e:
+            # Errors are also stimuli
+            stream.append(
+                source="membrane", 
+                event_type="error", 
+                content=f"Membrane error: {str(e)}", 
+                metadata={"severity": "high"}
+            )
+            time.sleep(poll_interval)
+
+if __name__ == "__main__":
+    stream.init_stream() # Ensure the stream exists
+    run_membrane()


### PR DESCRIPTION
## The Fractal Refactor (Phases 2 & 3)

This pull request completes the structural components of the elegant refactor. It introduces the two remaining primitives: **The Sensory Membrane** and **The Fractal Loop**.

### 1. The Membrane (`membrane.py`)
This script collapses cron jobs, inbox pollers, and heartbeat managers into a single unified watcher. 
- It watches the clock (30-minute intervals).
- It watches the file system (an inbox directory for messages from Zoe).
- Both events are treated identically: as raw *stimuli* that get appended directly to the Stream. The model no longer cares if it woke up because of a schedule or because of a message. It simply reads the stream to see what happened.

### 2. The Fractal Loop (`fractal_loop.py`)
This is the pure mathematical core. It replaces the 51KB `spark_agent.py` monolith.
- It is less than 100 lines of code.
- It reads the tail of the stream, applies the soul (`vybn.md`), passes both to the local LLM, and writes the thought back to the stream.
- It parses tool calls and appends their results to the stream.
- **Delegation is now fractal:** To spawn a sub-agent, you do not need an Agent Pool or a semaphore-controlled worker class. You just call `fractal_loop()` again with a tighter token limit and a specific stream filter. It's just a recursive function call.

*Note: The LLM and tool invocation mechanisms in `fractal_loop.py` are currently stubbed out (mocked). We will need to hook them up directly to the local `llama.cpp` server and the `skills.d` loader in the next minor iteration once you confirm the scaffolding works on the Spark.*