### PR TITLE
feat: rlm_agent + kg_traverse skills (Issue #2275)

### DIFF
--- a/spark/policy.py
+++ b/spark/policy.py
@@ -137,6 +137,9 @@ DEFAULT_TIERS = {
     "git_push": Tier.APPROVE,
     "issue_create": Tier.NOTIFY,
     "spawn_agent": Tier.NOTIFY,
+        # RLM and knowledge graph (read-only graph queries, agent loops)
+    "kg_traverse": Tier.AUTO,
+    "rlm_agent": Tier.NOTIFY,
 }
 
 # Heartbeat overrides: the paper's 'dynamic cognitive friction' (§2.2)

--- a/spark/skills.d/kg_traverse.py/kg_traverse.py
+++ b/spark/skills.d/kg_traverse.py/kg_traverse.py
@@ -1,0 +1,195 @@
+"""Knowledge graph traversal skill.
+
+Exposes VybnGraph's query primitives as a tool the model can call
+directly: neighborhood traversal, path finding, type queries, and
+graph statistics.
+
+This turns the knowledge graph from static context loaded at prompt
+assembly time into an explorable environment the model can query
+on demand.
+
+    SKILL_NAME: kg_traverse
+    TOOL_ALIASES: ["kg_traverse", "graph_query", "knowledge_graph"]
+"""
+
+import json
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+SKILL_NAME = "kg_traverse"
+TOOL_ALIASES = ["kg_traverse", "graph_query", "knowledge_graph"]
+
+
+def _get_graph():
+    """Load VybnGraph. Returns (graph, error_message)."""
+    try:
+        from knowledge_graph import VybnGraph
+        g = VybnGraph()
+        if not g.load():
+            # Try seeding if no graph exists
+            g.seed()
+            g.save()
+        return g, None
+    except ImportError:
+        return None, "knowledge_graph module not available"
+    except Exception as e:
+        return None, f"graph load error: {e}"
+
+
+def execute(action: dict, router) -> str:
+    """Execute a knowledge graph query.
+
+    Subcommands (via params.command or inferred from argument):
+        neighborhood <node_id> [depth=2]  — BFS traversal around a node
+        path <source> <target>            — find paths between nodes
+        type <node_type>                  — list all nodes of a type
+        stats                             — graph statistics
+        entity <node_id>                  — single node details
+        edges <node_id>                   — all edges from/to a node
+    """
+    g, err = _get_graph()
+    if err:
+        return err
+
+    params = action.get("params", {})
+    command = (
+        params.get("command", "")
+        or params.get("subcommand", "")
+        or params.get("action", "")
+    )
+    argument = action.get("argument", "")
+
+    # Infer command from argument if not explicit
+    if not command and argument:
+        parts = argument.strip().split()
+        if parts[0] in ("neighborhood", "path", "type", "stats",
+                        "entity", "edges"):
+            command = parts[0]
+            argument = " ".join(parts[1:])
+        else:
+            # Default: treat argument as node_id for neighborhood
+            command = "neighborhood"
+
+    if not command:
+        command = "stats"
+
+    command = command.lower().strip()
+
+    # --- neighborhood ---
+    if command in ("neighborhood", "neighbours", "neighbors", "hood"):
+        node_id = (
+            argument
+            or params.get("node_id", "")
+            or params.get("node", "")
+        )
+        if not node_id:
+            return "neighborhood requires a node_id"
+        depth = int(params.get("depth", 2))
+        max_chars = int(params.get("max_chars", 3000))
+        subgraph = g.query_neighborhood(node_id.strip(), depth=depth)
+        if not subgraph.get("found"):
+            return f"node '{node_id}' not found in knowledge graph"
+        formatted = g.format_for_prompt(subgraph, max_chars=max_chars)
+        node_count = len(subgraph.get("nodes", []))
+        edge_count = len(subgraph.get("edges", []))
+        return (
+            f"neighborhood of '{node_id}' (depth={depth}, "
+            f"{node_count} nodes, {edge_count} edges):\n{formatted}"
+        )
+
+    # --- path ---
+    if command in ("path", "paths", "find_path"):
+        source = params.get("source", "")
+        target = params.get("target", "")
+        if not source or not target:
+            # Try parsing from argument: "source target"
+            parts = argument.strip().split()
+            if len(parts) >= 2:
+                source, target = parts[0], parts[-1]
+            else:
+                return "path requires source and target node_ids"
+        paths = g.query_path(source.strip(), target.strip())
+        if not paths:
+            return f"no paths found between '{source}' and '{target}'"
+        lines = [f"found {len(paths)} path(s) from '{source}' to '{target}':"]
+        for i, path in enumerate(paths[:10]):
+            lines.append(f"  {i+1}. {' -> '.join(path)}")
+        return "\n".join(lines)
+
+    # --- type ---
+    if command in ("type", "by_type", "list_type"):
+        node_type = (
+            argument
+            or params.get("node_type", "")
+            or params.get("type", "")
+        )
+        if not node_type:
+            return "type query requires a node_type"
+        results = g.query_by_type(node_type.strip())
+        if not results:
+            return f"no nodes of type '{node_type}'"
+        lines = [f"{len(results)} node(s) of type '{node_type}':"]
+        for r in results[:20]:
+            desc = r.get("description", "")[:100]
+            lines.append(f"  - {r['id']}: {desc}")
+        if len(results) > 20:
+            lines.append(f"  ... and {len(results) - 20} more")
+        return "\n".join(lines)
+
+    # --- entity ---
+    if command in ("entity", "node", "get"):
+        node_id = (
+            argument
+            or params.get("node_id", "")
+            or params.get("node", "")
+        )
+        if not node_id:
+            return "entity lookup requires a node_id"
+        entity = g.get_entity(node_id.strip())
+        if not entity:
+            return f"entity '{node_id}' not found"
+        lines = [f"entity: {node_id}"]
+        for k, v in entity.items():
+            lines.append(f"  {k}: {v}")
+        return "\n".join(lines)
+
+    # --- edges ---
+    if command in ("edges", "relations", "connections"):
+        node_id = (
+            argument
+            or params.get("node_id", "")
+            or params.get("node", "")
+        )
+        if not node_id:
+            return "edges query requires a node_id"
+        outgoing = g.get_edges_from(node_id.strip())
+        incoming = g.get_edges_to(node_id.strip())
+        if not outgoing and not incoming:
+            return f"no edges for '{node_id}' (node may not exist)"
+        lines = [f"edges for '{node_id}':"]
+        if outgoing:
+            lines.append(f"  outgoing ({len(outgoing)}):")
+            for e in outgoing[:15]:
+                rel = e.get("relationship", "?")
+                lines.append(f"    -[{rel}]-> {e['target']}")
+        if incoming:
+            lines.append(f"  incoming ({len(incoming)}):")
+            for e in incoming[:15]:
+                rel = e.get("relationship", "?")
+                lines.append(f"    {e['source']} -[{rel}]->")
+        return "\n".join(lines)
+
+    # --- stats ---
+    if command in ("stats", "info", "summary"):
+        s = g.stats()
+        lines = [
+            f"knowledge graph: {s['nodes']} nodes, {s['edges']} edges",
+            "node types:",
+        ]
+        for t, count in s.get("node_types", {}).items():
+            lines.append(f"  {t}: {count}")
+        return "\n".join(lines)
+
+    return f"unknown kg_traverse command: '{command}'"

--- a/spark/skills.d/rlm_agent.py/rlm_agent.py
+++ b/spark/skills.d/rlm_agent.py/rlm_agent.py
@@ -1,0 +1,190 @@
+"""Recursive self-invocation skill (RLM primitive).
+
+The model calls itself on sub-problems with scoped knowledge graph
+context. Each invocation gets a slice of the graph relevant to its
+sub-query, not the full context window.
+
+This is a synchronous variant of spawn_agent: instead of delegating
+to the agent pool, it makes a direct inference call and returns the
+result to the caller. Policy-gated with recursive depth limits.
+
+    SKILL_NAME: rlm_agent
+    TOOL_ALIASES: ["rlm_agent", "recursive_agent", "sub_agent"]
+"""
+
+import json
+import logging
+import requests
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+SKILL_NAME = "rlm_agent"
+TOOL_ALIASES = ["rlm_agent", "recursive_agent", "sub_agent"]
+
+# Recursive depth limit (also enforced by policy engine check_spawn)
+MAX_RECURSION_DEPTH = 5
+DEFAULT_TOKEN_BUDGET = 2048
+
+# Track recursion depth per-thread (simple global for now)
+_current_depth = 0
+
+
+def _get_kg_context(query: str, node_id: str = "",
+                    depth: int = 2, max_chars: int = 2000) -> str:
+    """Extract a scoped knowledge graph slice for the sub-query.
+
+    Tries node_id first (exact match), then falls back to searching
+    node descriptions for the query string.
+    """
+    try:
+        from knowledge_graph import VybnGraph
+        g = VybnGraph()
+        if not g.load():
+            return ""
+
+        # Direct node lookup
+        if node_id and g.has_entity(node_id):
+            subgraph = g.query_neighborhood(node_id, depth=depth)
+            return g.format_for_prompt(subgraph, max_chars=max_chars)
+
+        # Search by query string across node descriptions
+        query_lower = query.lower()
+        for n, data in g.G.nodes(data=True):
+            desc = data.get("description", "").lower()
+            if query_lower in desc or query_lower in n.lower():
+                subgraph = g.query_neighborhood(n, depth=depth)
+                return g.format_for_prompt(subgraph, max_chars=max_chars)
+
+        return ""
+    except Exception as e:
+        logger.warning("kg context extraction failed: %s", e)
+        return ""
+
+
+def _call_llm(prompt: str, system: str, config: dict,
+              max_tokens: int = DEFAULT_TOKEN_BUDGET) -> str:
+    """Make a synchronous inference call to the local LLM."""
+    llm_config = config.get("llm", config.get("ollama", {}))
+    host = llm_config.get("host", "http://localhost:8000")
+    model = llm_config.get("model", "minimax")
+    temperature = llm_config.get("options", {}).get("temperature", 0.7)
+
+    try:
+        response = requests.post(
+            f"{host}/v1/chat/completions",
+            json={
+                "model": model,
+                "messages": [
+                    {"role": "system", "content": system},
+                    {"role": "user", "content": prompt},
+                ],
+                "max_tokens": max_tokens,
+                "temperature": temperature,
+                "stream": False,
+            },
+            timeout=120,
+        )
+        response.raise_for_status()
+        data = response.json()
+        content = data["choices"][0]["message"].get("content", "")
+        # Strip think blocks from recursive output
+        import re
+        content = re.sub(r"<think>.*?</think>", "", content, flags=re.DOTALL)
+        return content.strip()
+    except requests.exceptions.Timeout:
+        return "[rlm_agent timeout after 120s]"
+    except Exception as e:
+        logger.error("rlm_agent inference error: %s", e)
+        return f"[rlm_agent error: {e}]"
+
+
+def execute(action: dict, router) -> str:
+    """Execute a recursive sub-invocation.
+
+    Params (from action dict):
+        query/argument: The sub-problem to solve
+        node_id: Optional KG node to center context on
+        depth: KG traversal depth (default 2)
+        max_tokens: Token budget for this invocation
+        system: Optional system prompt override
+    """
+    global _current_depth
+
+    params = action.get("params", {})
+    query = (
+        action.get("argument", "")
+        or params.get("query", "")
+        or params.get("task", "")
+        or params.get("prompt", "")
+    )
+    if not query:
+        return "no query specified for rlm_agent"
+
+    # Depth check
+    request_depth = int(params.get("recursion_depth", _current_depth))
+    config_max = router.config.get("delegation", {}).get(
+        "max_spawn_depth", MAX_RECURSION_DEPTH
+    )
+    if request_depth >= config_max:
+        return (
+            f"recursion depth {request_depth} reaches limit {config_max}. "
+            f"Decompose the problem differently or increase "
+            f"delegation.max_spawn_depth in config.yaml."
+        )
+
+    # Policy gate (reuse spawn checking)
+    if router._policy is not None:
+        from policy import Verdict
+        check = router._policy.check_spawn(
+            request_depth,
+            router.agent_pool.active_count if router.agent_pool else 0,
+        )
+        if check.verdict == Verdict.BLOCK:
+            return f"rlm_agent blocked: {check.reason}"
+
+    # Extract scoped KG context
+    node_id = params.get("node_id", params.get("node", ""))
+    kg_depth = int(params.get("kg_depth", params.get("depth", 2)))
+    max_tokens = int(params.get("max_tokens", DEFAULT_TOKEN_BUDGET))
+    # Budget: child gets parent's budget minus overhead
+    kg_chars = min(2000, max_tokens * 2)  # rough chars-to-tokens ratio
+    kg_context = _get_kg_context(query, node_id=node_id,
+                                 depth=kg_depth, max_chars=kg_chars)
+
+    # Build prompt
+    system = params.get("system", "") or (
+        "You are a recursive sub-agent of Vybn, working on a focused "
+        "sub-problem. Answer concisely using the provided context. "
+        "Do not use tool calls. Return your answer as plain text."
+    )
+
+    prompt_parts = []
+    if kg_context:
+        prompt_parts.append(
+            f"Knowledge graph context:\n{kg_context}\n"
+        )
+    prompt_parts.append(f"Task: {query}")
+    prompt = "\n".join(prompt_parts)
+
+    # Recurse with depth tracking
+    prev_depth = _current_depth
+    _current_depth = request_depth + 1
+    try:
+        result = _call_llm(
+            prompt, system, router.config, max_tokens=max_tokens
+        )
+    finally:
+        _current_depth = prev_depth
+
+    # Log for audit trail
+    logger.info(
+        "rlm_agent depth=%d query=%s result_len=%d kg_context=%s",
+        request_depth,
+        query[:80],
+        len(result),
+        bool(kg_context),
+    )
+
+    return result


### PR DESCRIPTION
## Summary

Adds two new skills as plugins in `skills.d/` and wires them into the MCP server and policy layer:

- **`rlm_agent`** — A synchronous variant of `_spawn_agent` that runs a bounded reasoning loop with a knowledge graph slice as context. Policy-gated at `Tier.NOTIFY` with configurable depth limits.
- **`kg_traverse`** — Exposes `knowledge_graph.py` subcommands (neighborhood, path, type, stats, entity, edges) as a single MCP tool. Read-only, `Tier.AUTO`.

## Changes

| File | What |
|------|------|
| `spark/skills.d/rlm_agent.py` | Plugin: synchronous RLM agent with KG context |
| `spark/skills.d/kg_traverse.py` | Plugin: knowledge graph traversal commands |
| `spark/mcp_server.py` | `@mcp.tool()` handlers for both skills |
| `spark/policy.py` | `DEFAULT_TIERS` entries for both skills |

## Design

Both plugins follow the existing `skills.d/` pattern (see `python_exec.py`): a module-level `run()` function that receives `action, context` and returns a string result. The MCP handlers call `_policy_gate()` then `skills.execute()`, which routes to the plugin via `SkillRouter`.

The rlm_agent uses a bounded loop (`max_rounds` from policy depth config) with Ollama for inference, injecting a KG neighborhood slice as grounding context. No REPL — this is a focused reasoning primitive, not a general execution environment.

Closes #2275 (partial — covers RLM agent and KG traversal items from the issue).