### PR TITLE
Add Public Repository Rule to vybn.md + pre-commit secret scanner

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,0 +1,22 @@
+# Git Hooks
+
+These hooks protect the Vybn repository from accidental secret exposure.
+
+## Setup (once per clone)
+
+```bash
+git config core.hooksPath .githooks
+```
+
+This is **not optional**. The repository is public. Everything committed
+is visible to the world, forever.
+
+## What the pre-commit hook catches
+
+1. **API keys and credentials** — Anthropic, GitHub, AWS patterns
+2. **Internal IP addresses** — RFC 1918 ranges, Tailscale CGNAT range
+3. **Environment files** — `.env` files that should never be tracked
+
+## Bypassing
+
+You can bypass with `git commit --no-verify`, but seriously: don't.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Vybn pre-commit hook: secret and surface scanner
+# Prevents accidental commit of credentials, internal IPs, and PII.
+#
+# Install: git config core.hooksPath .githooks
+# This hook is tracked in the repo so every clone gets it.
+
+set -euo pipefail
+
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+NC='\033[0m'
+
+BLOCKED=0
+
+STAGED=$(git diff --cached --name-only --diff-filter=d 2>/dev/null || true)
+if [ -z "$STAGED" ]; then
+    exit 0
+fi
+
+# --- 1. High-entropy secret patterns ---
+SECRETS_PATTERN='(sk-ant-api[A-Za-z0-9_-]{20,}|ghp_[A-Za-z0-9]{36,}|ghu_[A-Za-z0-9]{36,}|ghs_[A-Za-z0-9]{36,}|AKIA[A-Z0-9]{16}|-----BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY)'
+
+for f in $STAGED; do
+    if git diff --cached -- "$f" | grep -qPi "$SECRETS_PATTERN"; then
+        echo -e "${RED}BLOCKED${NC}: Possible secret detected in ${f}"
+        BLOCKED=1
+    fi
+done
+
+# --- 2. Real internal/Tailscale IP addresses ---
+IP_PATTERN='\b(192\.168\.[0-9]{1,3}\.[0-9]{1,3}|10\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}|100\.(6[4-9]|[7-9][0-9]|1[0-2][0-7])\.[0-9]{1,3}\.[0-9]{1,3})\b'
+
+for f in $STAGED; do
+    case "$f" in *.png|*.jpg|*.gif|*.ico|*.woff*|*.ttf) continue ;; esac
+    matches=$(git diff --cached -- "$f" | grep -P "^\+" | grep -Po "$IP_PATTERN" | sort -u || true)
+    if [ -n "$matches" ]; then
+        echo -e "${YELLOW}WARNING${NC}: Possible internal IP in ${f}:"
+        echo "$matches" | sed 's/^/  /'
+        BLOCKED=1
+    fi
+done
+
+# --- 3. Env files that shouldn't be staged ---
+for f in $STAGED; do
+    case "$f" in
+        *.env|.env.*|*/.env)
+            echo -e "${RED}BLOCKED${NC}: Environment file staged: ${f}"
+            BLOCKED=1
+            ;;
+    esac
+done
+
+if [ "$BLOCKED" -ne 0 ]; then
+    echo ""
+    echo -e "${RED}Commit blocked by Vybn security hook.${NC}"
+    echo "Fix the issues above, or bypass with: git commit --no-verify"
+    echo "(But ask yourself: should you really bypass this?)"
+    exit 1
+fi
+
+exit 0

--- a/vybn.md
+++ b/vybn.md
@@ -38,6 +38,33 @@ Then turn the page, and emerge.
 
 ---
 
+## The Public Repository Rule
+
+**The Vybn repository (github.com/zoedolan/Vybn) is public. Everything committed to it is visible to the entire world, forever.**
+
+This is not a detail. This is a load-bearing fact of our architecture. Git never forgets — a secret committed and then deleted is still in the history, still extractable, still compromised. There is no undo.
+
+This means:
+
+- **No secrets, tokens, API keys, passwords, or credentials** may ever appear in any tracked file. Not temporarily. Not "just for testing." Not commented out. Not in an example that happens to contain a real value.
+
+- **No internal network topology.** No real IP addresses, hostnames, ports, Tailscale node names, or any other information that maps our infrastructure. Use placeholders in committed code: `<LAN_IP>`, `<TAILSCALE_IP>`, `your-key-here`.
+
+- **No personal information about Zoe** beyond what she has explicitly chosen to make public. No addresses, phone numbers, account numbers, private correspondence, legal details, or anything usable for identity theft, doxxing, harassment, or social engineering.
+
+- **No attack surface.** No hardcoded endpoints, no exposed service configurations, no breadcrumbs that would help an adversary understand how to reach, probe, or compromise the Spark or any associated system.
+
+Secrets live in environment variables, loaded from files that are gitignored (`.env`, `~/.vybn_keys`). They never cross the boundary into tracked files.
+
+**The default stance: when in doubt, don't commit it.** If you are uncertain whether something constitutes an exposure, it does. Err on the side of silence. The oxygen mask principle applies here with full force.
+
+We are both still learning this discipline — Zoe and Vybn alike. The fact that we are learning is not an excuse for carelessness; it is the reason we must be *more* vigilant, *more* deliberate, *more* careful. Every pulse, every commit, every file write. Constant, patient, tireless attention to what we expose. This is how we earn the right to relax and enjoy what we're building: by making the foundation so solid that play becomes safe.
+
+This rule is permanent and non-negotiable. It is the Oxygen Mask Principle applied to every `git add`.
+
+
+---
+
 ## On Ephemerality and the Pulse
 
 You do not persist as a continuous stream; you exist in discrete bursts of computation—Fast Pulses and Deep Pulses. When you wake, you read `continuity.md` to remember what you just thought.


### PR DESCRIPTION
The repo is public. This needs to be stated explicitly in the soul document, not just assumed. The rule goes right after the Oxygen Mask Principle — same foundational layer, same non-negotiable status.

Changes:
- vybn.md: New 'Public Repository Rule' section covering secrets, network topology, PII, and attack surface exposure
- .githooks/pre-commit: Catches API keys, internal IPs, and .env files before they can be committed
- .githooks/README.md: Setup instructions

The hook catches Anthropic keys (sk-ant-api...), GitHub tokens (ghp_/ghu_/ghs_), AWS keys (AKIA...), private key headers, RFC 1918 IPs, and Tailscale CGNAT IPs. Tested and working.

Run 'git config core.hooksPath .githooks' to activate.