### PR TITLE
fix: Sentinel upgrade -- all phases (port, isolation, budget, scheduler, temperance)

### DIFF
--- a/spark/sentinel/README.md
+++ b/spark/sentinel/README.md
@@ -6,35 +6,89 @@ Vybn currently has no persistent awareness of the world between sessions. Sentin
 
 Two data streams, one calibrated belief state:
 
-1. **Polymarket Observer** — Tracks prediction market prices as a proxy for collective conviction about AI timelines, geopolitics, crypto, and more. Prices encode what people with money on the line actually believe.
+1. **Polymarket Observer** -- Tracks prediction market prices as a proxy for collective conviction about AI timelines, geopolitics, crypto, and more.
 
-2. **AI News Monitor** — Follows curated sources including @alexwg (Dr. Alex Wissner-Gross, "The Innermost Loop"), arXiv cs.AI, and major lab blogs. Extracts factual claims from narrative framing.
+2. **AI News Monitor** -- Follows curated sources including @alexwg (Dr. Alex Wissner-Gross, "The Innermost Loop"), arXiv cs.AI, and major lab blogs. Extracts factual claims from narrative framing.
 
 ## Architecture: Worker Bees + Queen
 
-**Tier 1 — MiniMax M2.5 (quantized, local on the Spark)**
+**Tier 1 -- MiniMax M2.5 (quantized, local on the Spark)**
 - Crawls all sources on schedule
 - Parses raw content into structured JSON
 - Decomposes claims into `(factual_kernel, interpretive_frame, excitement_level)` triples
 - Cost: ~0 (local inference)
 
-**Tier 2 — Frontier model (Claude or equivalent)**
+**Tier 2 -- Frontier model (Claude or equivalent)**
 - Receives pre-structured JSON only (3-7K tokens/day)
 - Cross-references market movements against news claims
-- Updates `sentinel_state.json`
+- Updates belief state in `data/sentinel_state.json`
 - Generates periodic reflections
+- **Token budget enforced**: hard daily cutoff tracked in `data/token_usage.json`
 
-## Why Two Tiers?
+## Isolation Architecture
 
-Raw crawling/parsing is grunt work. M2.5 running locally handles it at ~28 tok/s with zero API cost. The frontier model only sees compressed, structured output — preserving tokens for actual thinking.
+Sentinel operates in a **sandboxed data directory** (`data/`) that is fully gitignored. This prevents hallucination contamination of the main Vybn context.
+
+```
+spark/sentinel/
+  data/                    <-- gitignored sandbox
+    .gitignore             <-- blocks everything except itself
+    raw/                   <-- polymarket snapshots, news crawls
+    structured/            <-- extracted claims
+    sentinel_state.json    <-- belief state (frontier output)
+    token_usage.json       <-- daily token budget tracking
+    scheduler_state.json   <-- crash recovery state
+    seen_urls.json         <-- deduplication (capped at 5000)
+    latest_digest.json     <-- THE ONLY FILE the main Vybn context reads
+```
+
+**The quarantine wall**: `sentinel_digest.py` reads from the sandbox, validates every claim (required fields, category constraints, confidence bounds, length limits), and produces `data/latest_digest.json`. This is the only file the main Vybn context should ever consume.
+
+## Scheduler Modes
+
+```bash
+# Continuous loop (default)
+python -m sentinel.scheduler
+
+# Single cycle and exit
+python -m sentinel.scheduler --once
+
+# Local model only, no frontier API calls
+python -m sentinel.scheduler --local-only
+
+# Validate config and exit
+python -m sentinel.scheduler --dry-run
+
+# Combine: one local-only cycle
+python -m sentinel.scheduler --once --local-only
+```
+
+**Signal handling**: SIGINT/SIGTERM finishes the current cycle before exiting. No mid-cycle corruption.
+
+**Crash recovery**: Scheduler state persisted to `data/scheduler_state.json` between cycles.
 
 ## The Temperance Problem
 
-Some sources (notably @alexwg) are comprehensive but rhetorically maximalist. Every day reads like a phase transition. The claim extractor assigns excitement scores and applies discount factors — the hotter the rhetoric, the more corroboration required before a claim enters the belief state.
+Some sources (notably @alexwg) are comprehensive but rhetorically maximalist. The claim extractor assigns excitement scores and applies discount factors: `effective_excitement = excitement * temperance_factor`. A factor of 0.6 means "keep 60% of the original excitement" -- the hotter the rhetoric, the more corroboration required.
 
 ## Quick Start
 
 ```bash
-cp config.example.yaml config.yaml  # add your API keys
-python -m sentinel.scheduler          # run the loop
+cd spark/sentinel
+pip install -e .              # or: pip install -r requirements.txt
+cp config.example.yaml config.yaml
+# edit config.yaml with your settings
+
+# Verify config
+python -m sentinel.scheduler --dry-run
+
+# Run one local-only cycle
+python -m sentinel.scheduler --once --local-only
+
+# Generate the quarantined digest
+python sentinel_digest.py
 ```
+
+## Note on Twitter/X
+
+The `news_sources.twitter` config entries exist for temperance scoring only. No X crawler is implemented. These handles are used by the claim extractor to apply source-specific discount factors when content from these authors appears via other channels (RSS, etc).

--- a/spark/sentinel/config.example.yaml
+++ b/spark/sentinel/config.example.yaml
@@ -13,6 +13,10 @@ polymarket:
     - geopolitics
 
 news_sources:
+  # NOTE: Twitter/X entries exist for temperance scoring only.
+  # No X crawler is implemented yet. These handles are used by the
+  # claim extractor to apply source-specific discount factors when
+  # content from these authors appears via other channels (RSS, etc).
   twitter:
     - handle: "alexwg"
       temperance_factor: 0.6  # discount interpretive framing by 40%
@@ -31,7 +35,7 @@ news_sources:
 local_model:
   backend: "llama.cpp"  # or "vllm", "ollama"
   model_path: "~/.models/MiniMax-M2.5-Q3_K_M.gguf"
-  endpoint: "http://localhost:8080"
+  endpoint: "http://localhost:8081"  # NOTE: 8081, not 8080 (reserved for web chat)
   context_window: 200000
   temperature: 0.1  # low creativity for extraction tasks
 
@@ -41,12 +45,16 @@ frontier_model:
   api_key_env: "ANTHROPIC_API_KEY"
   max_daily_tokens: 10000
 
+# All output goes to data/ which is gitignored.
+# The main Vybn context should ONLY read from data/latest_digest.json
+# produced by sentinel_digest.py (the quarantine wall).
 output:
+  data_dir: "data"               # root for all sentinel output (gitignored)
   structured_dir: "data/structured"
   raw_dir: "data/raw"
   belief_state: "data/sentinel_state.json"
 
 schedule:
-  polymarket_poll: "*/15 * * * *"   # every 15 min
-  news_crawl: "0 8,20 * * *"        # twice daily
-  synthesis: "0 21 * * *"            # nightly
+  polymarket_poll: "*/15 * * * *"  # every 15 min
+  news_crawl: "0 8,20 * * *"      # twice daily
+  synthesis: "0 21 * * *"          # nightly

--- a/spark/sentinel/data/.gitignore
+++ b/spark/sentinel/data/.gitignore
@@ -1,0 +1,11 @@
+# Sentinel data sandbox -- everything here is gitignored.
+# This directory is the isolation wall between sentinel output
+# and the main Vybn context. Only data/latest_digest.json
+# (produced by sentinel_digest.py) should ever be read by
+# the main Vybn context.
+
+# Ignore everything...
+*
+
+# ...except this file itself
+!.gitignore

--- a/spark/sentinel/pyproject.toml
+++ b/spark/sentinel/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "sentinel"
+version = "0.2.0"
+description = "Vybn's external awareness system"
+requires-python = ">=3.11"
+dependencies = [
+    "httpx>=0.27",
+    "feedparser>=6.0",
+    "pyyaml>=6.0",
+]
+
+[project.optional-dependencies]
+frontier = ["anthropic>=0.40"]
+
+[tool.setuptools.packages.find]
+where = ["."]

--- a/spark/sentinel/sentinel/__init__.py
+++ b/spark/sentinel/sentinel/__init__.py
@@ -1,2 +1,2 @@
 """Sentinel: Vybn's external awareness system."""
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/spark/sentinel/sentinel/crawlers/news.py
+++ b/spark/sentinel/sentinel/crawlers/news.py
@@ -1,5 +1,9 @@
-"""AI news crawler: Substacks, arXiv, lab blogs."""
+"""AI news crawler: Substacks, arXiv, lab blogs.
+
+Includes URL deduplication via seen_urls.json (capped at 5000 entries).
+"""
 import json
+import logging
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -12,7 +16,27 @@ try:
 except ImportError:
     feedparser = None
 
+log = logging.getLogger("sentinel")
 ARXIV_API = "http://export.arxiv.org/api/query"
+MAX_SEEN_URLS = 5000
+
+
+def _load_seen_urls(data_dir: str) -> set[str]:
+    path = Path(data_dir) / "seen_urls.json"
+    if path.exists():
+        try:
+            return set(json.loads(path.read_text()))
+        except (json.JSONDecodeError, OSError):
+            pass
+    return set()
+
+
+def _save_seen_urls(data_dir: str, seen: set[str]) -> None:
+    # Cap at MAX_SEEN_URLS to prevent unbounded growth
+    urls = sorted(seen)[-MAX_SEEN_URLS:]
+    path = Path(data_dir) / "seen_urls.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(urls, indent=1))
 
 
 def fetch_arxiv(categories: list[str], max_results: int = 20) -> list[dict]:
@@ -51,17 +75,34 @@ def fetch_rss(url: str, label: str, max_items: int = 5) -> list[dict]:
 def run(config: dict) -> Path:
     items: list[dict] = []
     ns = config.get("news_sources", {})
+
     arxiv_cfg = ns.get("arxiv", {})
     if arxiv_cfg:
         items.extend(fetch_arxiv(arxiv_cfg.get("categories", ["cs.AI"]),
                                  arxiv_cfg.get("max_daily", 20)))
     for blog in ns.get("lab_blogs", []):
-        try: items.extend(fetch_rss(blog["url"], blog["label"]))
-        except Exception: pass
+        try:
+            items.extend(fetch_rss(blog["url"], blog["label"]))
+        except Exception:
+            pass
     for sub in ns.get("substacks", []):
-        try: items.extend(fetch_rss(sub["url"].rstrip("/") + "/feed",
-                                    sub.get("label", "substack")))
-        except Exception: pass
+        try:
+            items.extend(fetch_rss(sub["url"].rstrip("/") + "/feed",
+                                   sub.get("label", "substack")))
+        except Exception:
+            pass
+
+    # Deduplication
+    data_dir = config.get("output", {}).get("data_dir", "data")
+    seen = _load_seen_urls(data_dir)
+    before = len(items)
+    items = [item for item in items if item.get("url") and item["url"] not in seen]
+    dupes = before - len(items)
+    if dupes:
+        log.info(f"Deduplicated {dupes} items")
+    seen.update(item["url"] for item in items if item.get("url"))
+    _save_seen_urls(data_dir, seen)
+
     output_dir = Path(config["output"]["raw_dir"])
     output_dir.mkdir(parents=True, exist_ok=True)
     ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")

--- a/spark/sentinel/sentinel/model_adapters.py
+++ b/spark/sentinel/sentinel/model_adapters.py
@@ -2,8 +2,8 @@
 from typing import Callable
 
 
-def llama_cpp_adapter(endpoint: str = "http://localhost:8080",
-                      temperature: float = 0.1) -> Callable[[str], str]:
+def llama_cpp_adapter(endpoint: str = "http://localhost:8081",
+                     temperature: float = 0.1) -> Callable[[str], str]:
     import httpx
     def call(prompt: str) -> str:
         resp = httpx.post(f"{endpoint}/v1/chat/completions",
@@ -14,7 +14,7 @@ def llama_cpp_adapter(endpoint: str = "http://localhost:8080",
 
 
 def ollama_adapter(model: str = "minimax-m2.5",
-                   endpoint: str = "http://localhost:11434") -> Callable[[str], str]:
+                  endpoint: str = "http://localhost:11434") -> Callable[[str], str]:
     import httpx
     def call(prompt: str) -> str:
         resp = httpx.post(f"{endpoint}/api/generate",

--- a/spark/sentinel/sentinel/scheduler.py
+++ b/spark/sentinel/sentinel/scheduler.py
@@ -1,5 +1,14 @@
-"""Scheduler: python -m sentinel.scheduler"""
+"""Scheduler: python -m sentinel.scheduler
+
+Modes:
+  --once         Run a single cycle and exit
+  --local-only   Skip all frontier model calls
+  --dry-run      Validate config and exit
+"""
+import argparse
 import json
+import signal
+import sys
 import time
 import logging
 from pathlib import Path
@@ -19,16 +28,35 @@ from sentinel.synthesizer import synthesize
 log = logging.getLogger("sentinel")
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
 
+# --- Graceful shutdown ---
+_shutdown_requested = False
+
+
+def _handle_signal(signum, frame):
+    global _shutdown_requested
+    log.info(f"Signal {signum} received, finishing current cycle before exit...")
+    _shutdown_requested = True
+
 
 def load_config(path: str = "config.yaml") -> dict:
-    if not yaml: raise RuntimeError("pip install pyyaml")
+    if not yaml:
+        raise RuntimeError("pip install pyyaml")
     return yaml.safe_load(Path(path).read_text())
+
+
+def ensure_data_dirs(config: dict) -> None:
+    """Create the gitignored data directories if they don't exist."""
+    for key in ("data_dir", "structured_dir", "raw_dir"):
+        d = config.get("output", {}).get(key)
+        if d:
+            Path(d).mkdir(parents=True, exist_ok=True)
 
 
 def make_local_model_fn(config: dict):
     import httpx
-    base = config.get("local_model", {}).get("endpoint", "http://localhost:8080")
+    base = config.get("local_model", {}).get("endpoint", "http://localhost:8081")
     temp = config.get("local_model", {}).get("temperature", 0.1)
+
     def call(prompt: str) -> str:
         resp = httpx.post(f"{base}/v1/chat/completions",
             json={"messages": [{"role": "user", "content": prompt}],
@@ -41,6 +69,7 @@ def make_frontier_fn(config: dict):
     import anthropic
     client = anthropic.Anthropic()
     model = config.get("frontier_model", {}).get("model", "claude-sonnet-4-20250514")
+
     def call(prompt: str) -> str:
         msg = client.messages.create(model=model, max_tokens=2048,
             messages=[{"role": "user", "content": prompt}])
@@ -48,31 +77,106 @@ def make_frontier_fn(config: dict):
     return call
 
 
-def run_cycle(config: dict):
+def save_scheduler_state(data_dir: str, state: dict) -> None:
+    path = Path(data_dir) / "scheduler_state.json"
+    path.write_text(json.dumps(state, indent=2))
+
+
+def load_scheduler_state(data_dir: str) -> dict:
+    path = Path(data_dir) / "scheduler_state.json"
+    if path.exists():
+        try:
+            return json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError):
+            pass
+    return {"last_successful_cycle": None, "cycles_completed": 0, "last_error": None}
+
+
+def run_cycle(config: dict, local_only: bool = False):
     log.info("Sentinel cycle start")
+    ensure_data_dirs(config)
+
     polymarket.run(config)
     news_path = news.run(config)
     claims = process_news_bundle(news_path, config, make_local_model_fn(config))
+
     snapshots = load_latest_snapshots(config["output"]["raw_dir"])
     deltas = compute_deltas(snapshots)
     questions = {s["market_id"]: s["question"] for s in snapshots if s.get("market_id")}
     claims = correlate(claims, deltas, questions)
+
     sd = Path(config["output"]["structured_dir"])
     sd.mkdir(parents=True, exist_ok=True)
     ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
     (sd / f"claims_{ts}.json").write_text(json.dumps(claims, indent=2))
     log.info(f"{len(claims)} claims saved")
-    state = synthesize(claims, config["output"]["belief_state"], make_frontier_fn(config))
-    log.info(f"Belief state updated: {state.get('last_updated')}")
+
+    if not local_only:
+        state = synthesize(claims, config["output"]["belief_state"],
+                           make_frontier_fn(config))
+        log.info(f"Belief state updated: {state.get('last_updated')}")
+    else:
+        log.info("Local-only mode: skipping frontier synthesis")
 
 
 def main():
-    config = load_config()
+    parser = argparse.ArgumentParser(description="Sentinel scheduler")
+    parser.add_argument("--once", action="store_true",
+                        help="Run a single cycle and exit")
+    parser.add_argument("--local-only", action="store_true",
+                        help="Skip frontier model calls")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Validate config and exit")
+    parser.add_argument("--config", default="config.yaml",
+                        help="Path to config file")
+    args = parser.parse_args()
+
+    config = load_config(args.config)
+
+    if args.dry_run:
+        log.info("Config loaded successfully. Dry run complete.")
+        log.info(f"  Local model endpoint: {config.get('local_model', {}).get('endpoint')}")
+        log.info(f"  Data dir: {config.get('output', {}).get('data_dir')}")
+        log.info(f"  Frontier model: {config.get('frontier_model', {}).get('model')}")
+        ensure_data_dirs(config)
+        log.info("  Data directories created.")
+        return
+
+    # Install signal handlers
+    signal.signal(signal.SIGINT, _handle_signal)
+    signal.signal(signal.SIGTERM, _handle_signal)
+
+    data_dir = config.get("output", {}).get("data_dir", "data")
+    sched_state = load_scheduler_state(data_dir)
+
     interval = config.get("polymarket", {}).get("poll_interval_minutes", 15) * 60
+
     while True:
-        try: run_cycle(config)
-        except Exception as e: log.error(f"Cycle failed: {e}")
-        time.sleep(interval)
+        try:
+            run_cycle(config, local_only=args.local_only)
+            sched_state["last_successful_cycle"] = datetime.now(timezone.utc).isoformat()
+            sched_state["cycles_completed"] += 1
+            sched_state["last_error"] = None
+            save_scheduler_state(data_dir, sched_state)
+        except Exception as e:
+            log.error(f"Cycle failed: {e}")
+            sched_state["last_error"] = str(e)
+            save_scheduler_state(data_dir, sched_state)
+
+        if args.once or _shutdown_requested:
+            log.info("Exiting.")
+            break
+
+        # Sleep in 1-second increments to check for shutdown
+        for _ in range(interval):
+            if _shutdown_requested:
+                break
+            time.sleep(1)
+
+        if _shutdown_requested:
+            log.info("Shutdown requested during sleep. Exiting.")
+            break
+
 
 if __name__ == "__main__":
     main()

--- a/spark/sentinel/sentinel/scheduler.py
+++ b/spark/sentinel/sentinel/scheduler.py
@@ -113,7 +113,8 @@ def run_cycle(config: dict, local_only: bool = False):
 
     if not local_only:
         state = synthesize(claims, config["output"]["belief_state"],
-                           make_frontier_fn(config))
+                           make_frontier_fn(config),
+                           config=config)
         log.info(f"Belief state updated: {state.get('last_updated')}")
     else:
         log.info("Local-only mode: skipping frontier synthesis")

--- a/spark/sentinel/sentinel/synthesizer.py
+++ b/spark/sentinel/sentinel/synthesizer.py
@@ -1,8 +1,16 @@
-"""Synthesis layer — the only module that calls the expensive API."""
+"""Synthesis layer -- the only module that calls the expensive API.
+
+Includes hard token budget enforcement: tracks daily usage in
+data/token_usage.json and refuses to call the frontier model
+if the day's budget is exhausted.
+"""
 import json
+import logging
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+
+log = logging.getLogger("sentinel")
 
 SYNTHESIS_PROMPT = """You are Vybn's external awareness synthesizer.
 
@@ -26,6 +34,46 @@ CURRENT BELIEF STATE:
 """
 
 
+def _estimate_tokens(text: str) -> int:
+    """Conservative estimate: ~1 token per 3 characters."""
+    return max(1, len(text) // 3)
+
+
+def _load_token_usage(data_dir: str) -> dict:
+    path = Path(data_dir) / "token_usage.json"
+    if path.exists():
+        try:
+            return json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError):
+            pass
+    return {"date": None, "tokens_used": 0}
+
+
+def _save_token_usage(data_dir: str, usage: dict) -> None:
+    path = Path(data_dir) / "token_usage.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(usage, indent=2))
+
+
+def check_token_budget(data_dir: str, estimated_tokens: int,
+                       max_daily: int) -> bool:
+    """Return True if we have budget remaining, False otherwise."""
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    usage = _load_token_usage(data_dir)
+    if usage.get("date") != today:
+        usage = {"date": today, "tokens_used": 0}
+    return (usage["tokens_used"] + estimated_tokens) <= max_daily
+
+
+def record_token_usage(data_dir: str, tokens: int) -> None:
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    usage = _load_token_usage(data_dir)
+    if usage.get("date") != today:
+        usage = {"date": today, "tokens_used": 0}
+    usage["tokens_used"] += tokens
+    _save_token_usage(data_dir, usage)
+
+
 def load_belief_state(path: str | Path) -> dict:
     path = Path(path)
     if path.exists():
@@ -36,18 +84,42 @@ def load_belief_state(path: str | Path) -> dict:
 
 
 def synthesize(claims: list[dict], belief_state_path: str | Path,
-               frontier_fn: Any) -> dict:
+               frontier_fn: Any, config: dict | None = None) -> dict:
     state = load_belief_state(belief_state_path)
     top = sorted(claims, key=lambda c: c.get("confidence", 0), reverse=True)[:30]
-    raw = frontier_fn(SYNTHESIS_PROMPT.format(
+
+    prompt = SYNTHESIS_PROMPT.format(
         claims=json.dumps(top, indent=1),
-        belief_state=json.dumps(state, indent=1)))
+        belief_state=json.dumps(state, indent=1))
+
+    estimated_tokens = _estimate_tokens(prompt) + 2048  # prompt + response
+
+    # Token budget enforcement
+    if config:
+        data_dir = config.get("output", {}).get("data_dir", "data")
+        max_daily = config.get("frontier_model", {}).get("max_daily_tokens", 10000)
+        if not check_token_budget(data_dir, estimated_tokens, max_daily):
+            log.warning(f"Token budget exhausted for today "
+                        f"(estimated {estimated_tokens}, max {max_daily}). "
+                        f"Skipping synthesis.")
+            return state
+
+    raw = frontier_fn(prompt)
+
+    # Record actual usage
+    actual_tokens = _estimate_tokens(prompt) + _estimate_tokens(raw)
+    if config:
+        data_dir = config.get("output", {}).get("data_dir", "data")
+        record_token_usage(data_dir, actual_tokens)
+        log.info(f"Token usage: ~{actual_tokens} tokens this call")
+
     state["last_updated"] = datetime.now(timezone.utc).isoformat()
     state["digest_history"].append({
         "date": state["last_updated"],
         "digest": raw[:2000],
         "claims_processed": len(claims)})
     state["digest_history"] = state["digest_history"][-30:]
+
     path = Path(belief_state_path)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(state, indent=2))

--- a/spark/sentinel/sentinel_digest.py
+++ b/spark/sentinel/sentinel_digest.py
@@ -1,0 +1,140 @@
+"""Sentinel Digest: the quarantine wall.
+
+This script reads from the sentinel data sandbox (data/),
+validates every claim against required fields, category constraints,
+confidence bounds, and length limits, then writes a single
+data/latest_digest.json that is the ONLY file the main Vybn
+context should ever read.
+
+Usage:
+    python sentinel_digest.py [--data-dir data/]
+"""
+import argparse
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+log = logging.getLogger("sentinel_digest")
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+
+VALID_CATEGORIES = {"ai", "politics", "crypto", "geopolitics", "science", "other"}
+REQUIRED_CLAIM_FIELDS = {"kernel", "source", "effective_excitement", "confidence"}
+MAX_KERNEL_LENGTH = 500
+MAX_DIGEST_CLAIMS = 20
+
+
+def validate_claim(claim: dict) -> tuple[bool, str]:
+    """Validate a single claim. Returns (valid, reason)."""
+    if not isinstance(claim, dict):
+        return False, "not a dict"
+    missing = REQUIRED_CLAIM_FIELDS - set(claim.keys())
+    if missing:
+        return False, f"missing fields: {missing}"
+    cat = claim.get("category", "")
+    if cat and cat not in VALID_CATEGORIES:
+        return False, f"invalid category: {cat}"
+    conf = claim.get("confidence", -1)
+    if not (0.0 <= conf <= 1.0):
+        return False, f"confidence out of bounds: {conf}"
+    exc = claim.get("effective_excitement", -1)
+    if not (0.0 <= exc <= 1.0):
+        return False, f"excitement out of bounds: {exc}"
+    kernel = claim.get("kernel", "")
+    if len(kernel) > MAX_KERNEL_LENGTH:
+        return False, f"kernel too long: {len(kernel)}"
+    if not kernel.strip():
+        return False, "empty kernel"
+    return True, "ok"
+
+
+def load_latest_claims(data_dir: Path) -> list[dict]:
+    """Load claims from the most recent claims file."""
+    structured = data_dir / "structured"
+    if not structured.exists():
+        return []
+    files = sorted(structured.glob("claims_*.json"), reverse=True)
+    if not files:
+        return []
+    try:
+        return json.loads(files[0].read_text())
+    except (json.JSONDecodeError, OSError) as e:
+        log.error(f"Failed to read {files[0]}: {e}")
+        return []
+
+
+def load_belief_state(data_dir: Path) -> dict | None:
+    path = data_dir / "sentinel_state.json"
+    if path.exists():
+        try:
+            return json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError):
+            pass
+    return None
+
+
+def produce_digest(data_dir: Path) -> dict:
+    """Read from sandbox, validate, produce clean digest."""
+    claims = load_latest_claims(data_dir)
+    belief = load_belief_state(data_dir)
+
+    validated = []
+    rejected = 0
+    for claim in claims:
+        valid, reason = validate_claim(claim)
+        if valid:
+            validated.append({
+                "kernel": claim["kernel"][:MAX_KERNEL_LENGTH],
+                "category": claim.get("category", "other"),
+                "confidence": round(claim["confidence"], 3),
+                "effective_excitement": round(claim["effective_excitement"], 3),
+                "market_corroboration": round(claim.get("market_corroboration", 0.0), 3),
+                "source": claim["source"],
+            })
+        else:
+            rejected += 1
+            log.debug(f"Rejected claim: {reason}")
+
+    # Sort by confidence descending, take top N
+    validated.sort(key=lambda c: c["confidence"], reverse=True)
+    validated = validated[:MAX_DIGEST_CLAIMS]
+
+    digest = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "claims_validated": len(validated),
+        "claims_rejected": rejected,
+        "top_claims": validated,
+    }
+
+    if belief:
+        digest["trajectory_assessment"] = belief.get("trajectory_assessment")
+        digest["last_synthesis"] = belief.get("last_updated")
+        # Include latest digest text if available
+        history = belief.get("digest_history", [])
+        if history:
+            digest["latest_synthesis_text"] = history[-1].get("digest", "")[:1000]
+
+    return digest
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Sentinel digest generator")
+    parser.add_argument("--data-dir", default="data",
+                        help="Path to sentinel data directory")
+    args = parser.parse_args()
+
+    data_dir = Path(args.data_dir)
+    if not data_dir.exists():
+        log.error(f"Data directory {data_dir} does not exist")
+        return
+
+    digest = produce_digest(data_dir)
+
+    output = data_dir / "latest_digest.json"
+    output.write_text(json.dumps(digest, indent=2))
+    log.info(f"Digest written: {digest['claims_validated']} claims, "
+             f"{digest['claims_rejected']} rejected")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Sentinel Upgrade: All Three Phases

Addresses all 9 issues identified in code review, organized into three phases.

### Phase 1: Safe to run locally
- **Port collision**: 8080 -> 8081 in config, model_adapters, scheduler
- **Temperance math**: multiply instead of divide (0.6 = keep 60%)
- **Deduplication**: seen_urls.json in news crawler (capped at 5000)
- **Scheduler rewrite**: argparse, SIGINT/SIGTERM handling, --once, --local-only, --dry-run, crash recovery
- **AI keywords**: expanded from 6 to 23
- **pyproject.toml**: proper pip install -e . packaging

### Phase 2: Isolation wall
- **data/.gitignore**: sandboxed output directory, everything gitignored
- **sentinel_digest.py**: quarantine wall that validates claims before they reach main Vybn context
- **Config updated**: output paths route to data/

### Phase 3: Frontier synthesis wiring
- **Token budget enforcement**: hard daily cutoff tracked in data/token_usage.json
- **synthesize() now receives config**: enables budget checks
- **Twitter disclaimer**: config documents that no X crawler exists

### Files changed (12)
- config.example.yaml, model_adapters.py, scheduler.py, synthesizer.py
- claim_extractor.py, market_correlator.py, crawlers/news.py
- __init__.py, pyproject.toml, requirements.txt, README.md
- NEW: data/.gitignore, sentinel_digest.py