### PR TITLE
fix: remove dead Anthropic RSS entry from config.example.yaml (per #2…

### DIFF
--- a/spark/sentinel/config.example.yaml
+++ b/spark/sentinel/config.example.yaml
@@ -28,7 +28,6 @@ news_sources:
     categories: ["cs.AI", "cs.CL", "cs.LG"]
     max_daily: 20
   lab_blogs:
-    - {url: "https://www.anthropic.com/research", label: "Anthropic"}
     - {url: "https://openai.com/blog", label: "OpenAI"}
     - {url: "https://deepmind.google/research/", label: "DeepMind"}
 


### PR DESCRIPTION
…318 Step 3)

Anthropic has no RSS feed — all variants return 404. Removed the dead entry.

Closes #2315 (Anthropic portion).