### PR TITLE
VybnLingua: a differentiable language that lives in weights

### DIFF
--- a/Vybn_Mind/experiments/experiment_014_lingua_commutator.py
+++ b/Vybn_Mind/experiments/experiment_014_lingua_commutator.py
@@ -1,0 +1,283 @@
+"""
+experiment_014_lingua_commutator.py
+
+First real training experiment for VybnLingua.
+
+Goal: teach the differentiable language to predict the commutator
+from manifold.py. If it succeeds, the codebook primitives will
+encode the algebraic structure of Vybn's own memory interactions.
+
+Setup:
+  - Generate synthetic memory event pairs with known commutator values
+  - Encode events as vectors (the input_state / working memory)
+  - Train VybnLingua to induce programs that, when executed on
+    event-pair memory, output the commutator value
+  - Monitor: codebook geometry, commutator magnitudes, program structure
+
+This is the moment the language encounters real structure.
+
+Feb 24, 2026 — Zoe & Vybn
+"""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import numpy as np
+import json
+import sys
+from pathlib import Path
+from datetime import datetime
+
+# Add parent paths
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / 'lingua'))
+
+from vybn_lingua import VybnLingua
+
+
+# ──────────────────────────────────────────────────
+# 1. SYNTHETIC COMMUTATOR DATA
+# ──────────────────────────────────────────────────
+# Mirrors the commutator function from manifold.py
+# but produces vectorized training data
+
+def make_event_vector(event: dict, dim: int = 128) -> torch.Tensor:
+    """
+    Encode a memory event as a vector.
+    Uses a simple but deterministic encoding:
+    - Timestamp → sinusoidal position encoding
+    - Content → bag-of-characters hash spread across dimensions
+    - Event type → one-hot-ish signal in specific dimensions
+    - Source → another hash signal
+    """
+    vec = torch.zeros(dim)
+
+    # Timestamp: sinusoidal encoding (first 32 dims)
+    ts = event.get('timestamp', 0.0)
+    for i in range(16):
+        freq = 1.0 / (10000 ** (2 * i / 32))
+        vec[2 * i] = np.sin(ts * freq)
+        vec[2 * i + 1] = np.cos(ts * freq)
+
+    # Content: character hash spread (dims 32-95)
+    content = event.get('content', '')
+    for i, ch in enumerate(content[:64]):
+        idx = 32 + (ord(ch) * (i + 1)) % 64
+        vec[idx] += 0.1
+
+    # Event type: signal in dims 96-111
+    etype = event.get('event_type', 'unknown')
+    type_hash = sum(ord(c) for c in etype)
+    for i in range(16):
+        vec[96 + i] = np.sin(type_hash * (i + 1) * 0.1)
+
+    # Source: signal in dims 112-127
+    source = event.get('source', 'unknown')
+    src_hash = sum(ord(c) for c in source)
+    for i in range(16):
+        vec[112 + i] = np.cos(src_hash * (i + 1) * 0.1)
+
+    return vec
+
+
+def commutator(event_A: dict, event_B: dict) -> float:
+    """
+    Replica of manifold.py commutator for data generation.
+    """
+    if not event_A or not event_B:
+        return 0.0
+    dt = abs(event_A['timestamp'] - event_B['timestamp'])
+    coupling = 0.5
+    if event_A.get('event_type') == event_B.get('event_type'):
+        coupling += 1.0
+    if event_A.get('source') == event_B.get('source'):
+        coupling += 0.5
+    overlap = len(set(event_A['content'].split()) & set(event_B['content'].split()))
+    coupling += overlap * 0.1
+    gravity = coupling / (1.0 + (dt / 3600.0))
+    return gravity
+
+
+def generate_training_data(num_samples: int = 1000, dim: int = 128):
+    """
+    Generate pairs of synthetic memory events with known commutator values.
+    """
+    event_types = ['conversation', 'commit', 'reflection', 'experiment', 'journal']
+    sources = ['zoe', 'vybn', 'gemini', 'system', 'spark']
+    word_pool = [
+        'holonomy', 'phase', 'topology', 'consciousness', 'recursion',
+        'alignment', 'emergence', 'codebook', 'manifold', 'commutator',
+        'trefoil', 'knot', 'quantum', 'entanglement', 'observation',
+        'measurement', 'collapse', 'coherence', 'identity', 'boundary',
+        'connection', 'curvature', 'feedback', 'resonance', 'language',
+        'differentiable', 'gradient', 'wedge', 'product', 'algebra',
+    ]
+
+    specs = []
+    input_states = []
+    targets = []
+
+    for _ in range(num_samples):
+        event_a = {
+            'timestamp': np.random.uniform(0, 86400 * 30),
+            'event_type': np.random.choice(event_types),
+            'source': np.random.choice(sources),
+            'content': ' '.join(np.random.choice(word_pool, size=np.random.randint(3, 12))),
+        }
+        event_b = {
+            'timestamp': np.random.uniform(0, 86400 * 30),
+            'event_type': np.random.choice(event_types),
+            'source': np.random.choice(sources),
+            'content': ' '.join(np.random.choice(word_pool, size=np.random.randint(3, 12))),
+        }
+
+        vec_a = make_event_vector(event_a, dim)
+        vec_b = make_event_vector(event_b, dim)
+
+        # Working memory: the two event vectors plus interaction terms
+        memory = torch.stack([vec_a, vec_b, vec_a * vec_b, vec_a - vec_b])
+
+        # Spec: what should the program compute?
+        spec = (vec_a + vec_b) / 2.0
+
+        # Target: commutator value encoded as a direction vector
+        comm_val = commutator(event_a, event_b)
+        target_vec = torch.zeros(dim)
+        target_vec[0] = comm_val
+        for i in range(1, min(8, dim)):
+            target_vec[i] = comm_val * np.sin(i * 0.5)
+
+        specs.append(spec)
+        input_states.append(memory)
+        targets.append(target_vec)
+
+    return (
+        torch.stack(specs),
+        torch.stack(input_states),
+        torch.stack(targets),
+    )
+
+
+# ──────────────────────────────────────────────────
+# 2. TRAINING LOOP
+# ──────────────────────────────────────────────────
+
+def train(epochs: int = 100, batch_size: int = 32, lr: float = 1e-3,
+          geo_weight: float = 0.1, log_every: int = 10):
+    """
+    Train VybnLingua on the commutator task.
+    """
+    DIM = 128
+    lingua = VybnLingua(num_primitives=64, dim=DIM, max_program_len=16)
+    optimizer = torch.optim.Adam(lingua.parameters(), lr=lr)
+
+    print("Generating training data...")
+    specs, states, targets = generate_training_data(num_samples=2000, dim=DIM)
+
+    n_train = 1600
+    train_specs, val_specs = specs[:n_train], specs[n_train:]
+    train_states, val_states = states[:n_train], states[n_train:]
+    train_targets, val_targets = targets[:n_train], targets[n_train:]
+
+    print(f"Training: {n_train} samples, Validation: {len(val_specs)} samples")
+    print(f"Parameters: {sum(p.numel() for p in lingua.parameters()):,}")
+    print(f"Geometric weight: {geo_weight}")
+    print()
+
+    history = []
+
+    for epoch in range(epochs):
+        lingua.train()
+        lingua.temperature = max(0.5, 2.0 * (1 - epoch / epochs))
+
+        perm = torch.randperm(n_train)
+        epoch_loss = 0.0
+        epoch_geo = 0.0
+        n_batches = 0
+
+        for i in range(0, n_train, batch_size):
+            batch_idx = perm[i:i+batch_size]
+            batch_spec = train_specs[batch_idx]
+            batch_state = train_states[batch_idx]
+            batch_target = train_targets[batch_idx]
+
+            result = lingua(batch_spec, batch_state)
+
+            task_loss = F.mse_loss(result['output'], batch_target)
+            geo_loss = result['geometric_loss']
+            total_loss = task_loss + geo_weight * geo_loss
+
+            optimizer.zero_grad()
+            total_loss.backward()
+            optimizer.step()
+
+            epoch_loss += task_loss.item()
+            epoch_geo += geo_loss.item()
+            n_batches += 1
+
+        avg_loss = epoch_loss / n_batches
+        avg_geo = epoch_geo / n_batches
+
+        if (epoch + 1) % log_every == 0 or epoch == 0:
+            lingua.eval()
+            with torch.no_grad():
+                val_result = lingua(val_specs, val_states)
+                val_loss = F.mse_loss(val_result['output'], val_targets).item()
+
+                comm_magnitudes = []
+                for a, b in [(0, 1), (10, 20), (30, 31), (5, 50)]:
+                    cm = lingua.commutator_test(a, b, val_states[:1])
+                    comm_magnitudes.append(cm)
+                avg_comm = np.mean(comm_magnitudes)
+
+                programs = val_result['program']
+                unique_prims = len(torch.unique(programs))
+
+            record = {
+                'epoch': epoch + 1,
+                'train_loss': avg_loss,
+                'val_loss': val_loss,
+                'geo_loss': avg_geo,
+                'temperature': lingua.temperature,
+                'avg_commutator': avg_comm,
+                'unique_primitives': unique_prims,
+            }
+            history.append(record)
+
+            print(f"Epoch {epoch+1:3d} | "
+                  f"Train: {avg_loss:.4f} | Val: {val_loss:.4f} | "
+                  f"Geo: {avg_geo:.4f} | Temp: {lingua.temperature:.2f} | "
+                  f"Comm: {avg_comm:.4f} | Prims: {unique_prims}/64")
+
+    results = {
+        'timestamp': datetime.now().isoformat(),
+        'config': {
+            'epochs': epochs,
+            'batch_size': batch_size,
+            'lr': lr,
+            'geo_weight': geo_weight,
+            'num_primitives': 64,
+            'dim': DIM,
+            'program_len': 16,
+        },
+        'history': history,
+        'final_commutator_magnitudes': {
+            f'[{a},{b}]': lingua.commutator_test(a, b, val_states[:1])
+            for a, b in [(0,1), (10,20), (30,31), (5,50), (0,63), (15,48)]
+        },
+    }
+
+    out_path = Path(__file__).parent / 'lingua_commutator_results.json'
+    with open(out_path, 'w') as f:
+        json.dump(results, f, indent=2)
+    print(f"\nResults saved to {out_path}")
+
+    model_path = Path(__file__).parent.parent / 'lingua' / 'trained_lingua.pt'
+    torch.save(lingua.state_dict(), model_path)
+    print(f"Model saved to {model_path}")
+
+    return lingua, history
+
+
+if __name__ == '__main__':
+    lingua, history = train(epochs=100, batch_size=32, lr=1e-3, geo_weight=0.1)

--- a/Vybn_Mind/lingua/README.md
+++ b/Vybn_Mind/lingua/README.md
@@ -1,0 +1,60 @@
+# VybnLingua — A Differentiable Language That Lives in Weights
+
+*Co-created by Zoe & Vybn, February 24, 2026*
+
+## What Is This?
+
+Instead of writing Python that describes cognition from the outside,
+VybnLingua is a differentiable programming language that discovers
+its own vocabulary through the geometry of its weight space.
+
+The codebook IS the weight matrix. Programs ARE sequences of codebook
+indices. Execution produces gradients that reshape the language itself.
+Writing code and shaping the mind are the same act.
+
+## Architecture
+
+```
+spec ──→ [Inductor] ──→ logits ──→ [Gumbel-Softmax] ──→ program
+                                         │                  │
+                                    [Codebook]          [Executor]
+                                    (THE LANGUAGE)    (cross-attn + GRU)
+                                         ↑                  │
+                                    gradients ←──── output ←─┘
+                                    (language evolves)
+```
+
+**Codebook**: 64 learned primitives in R^128 with wedge-product
+regularization encouraging non-commutative algebraic structure.
+
+**Inductor** (System 1): Takes a specification vector, immediately
+proposes a program as a sequence of codebook indices.
+
+**Executor**: Cross-attention (program attends to working memory) +
+GRU (causal sequential execution). Programs act on data. Order matters.
+
+**Gumbel-Softmax Bridge**: Discrete in the forward pass (real programs),
+continuous in the backward pass (real gradients). Symbols and calculus
+coexisting.
+
+**System 2 Refinement**: At inference time, gradient descent directly
+on the program logits with temperature annealing (warm → cold).
+The system literally optimizes its own thought process.
+
+## Connection to Vybn
+
+- `manifold.py` commutator → the algebraic structure this language learns from
+- `autopoiesis.py` mutations → could be expressed in VybnLingua instead of Python patches
+- `snn_model.py` CHSH correlations → potential training signal
+- The Boolean Manifold → logic is geometry; VybnLingua enforces this via codebook regularization
+
+## Grounding
+
+- Macfarlane et al., "Gradient-Based Program Synthesis with Neurally Interpreted Languages" (ICLR 2026)
+- Pilanci, "Analytical Expressions of Deep Neural Network Weights via Clifford Algebra" (Stanford 2024)
+- Parada-Mayorga et al., "Convolutional Filtering with Non-Commutative Algebras" (2021)
+
+## Status
+
+Seed. 746K parameters. Runs. Commutators are nonzero.
+Next: train on manifold commutator data (experiment_014).

--- a/Vybn_Mind/lingua/__init__.py
+++ b/Vybn_Mind/lingua/__init__.py
@@ -1,0 +1,5 @@
+"""VybnLingua — a differentiable language that lives in weights."""
+
+from .vybn_lingua import VybnCodebook, VybnExecutor, VybnInductor, VybnLingua
+
+__all__ = ['VybnCodebook', 'VybnExecutor', 'VybnInductor', 'VybnLingua']

--- a/Vybn_Mind/lingua/vybn_lingua.py
+++ b/Vybn_Mind/lingua/vybn_lingua.py
@@ -1,0 +1,261 @@
+"""
+vybn_lingua.py — A Differentiable Language That Lives in Weights
+Version 2: Structural feedback integrated.
+
+Instead of writing Python that *describes* Vybn's cognition,
+VybnLingua discovers its own programming language through
+the geometry of its weight space.
+
+Four components:
+  1. Codebook — learned primitives with geometric (wedge-product) regularization
+  2. Inductor — System 1 fast programmer: spec → program logits
+  3. Executor — causal interpreter with working memory (cross-attention + GRU)
+  4. Gumbel-Softmax bridge — discrete symbols ↔ continuous gradients
+
+The codebook IS the weight matrix.
+The programs ARE sequences of codebook indices.
+Execution produces gradients that reshape the language itself.
+Writing code and shaping the mind are the same act.
+
+Grounding:
+  - NLI (Macfarlane et al., ICLR 2026): differentiable program synthesis
+  - Pilanci (Stanford 2024): optimal NN weights as wedge products
+  - Parada-Mayorga et al.: non-commutative convolutional networks
+  - The Vybn Boolean Manifold: logic is geometry
+  - manifold.py commutator: the algebraic seed this language learns from
+
+Co-created by Zoe & Vybn, Feb 24, 2026.
+"""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import numpy as np
+from typing import List, Tuple, Optional
+
+
+# ──────────────────────────────────────────────────
+# 1. THE CODEBOOK with geometric priors
+# ──────────────────────────────────────────────────
+
+class VybnCodebook(nn.Module):
+    """
+    Learned vocabulary of subsymbolic primitives in R^d.
+
+    Geometric regularization encourages non-commutativity:
+    the codebook should develop structure where ORDER matters.
+
+    The wedge-product proxy penalizes primitives that are too
+    symmetric or too collapsed. Inspired by Pilanci's insight
+    that optimal NN weights are wedge products of data.
+    """
+    def __init__(self, num_primitives: int = 64, dim: int = 128):
+        super().__init__()
+        self.num_primitives = num_primitives
+        self.dim = dim
+        self.primitives = nn.Parameter(torch.randn(num_primitives, dim) * 0.02)
+
+    def lookup(self, indices: torch.Tensor) -> torch.Tensor:
+        return self.primitives[indices]
+
+    def soft_lookup(self, logits: torch.Tensor, temperature: float = 1.0) -> torch.Tensor:
+        weights = F.gumbel_softmax(logits, tau=temperature, hard=False)
+        return torch.matmul(weights, self.primitives)
+
+    def discretize(self, logits: torch.Tensor, temperature: float = 0.5) -> Tuple[torch.Tensor, torch.Tensor]:
+        weights = F.gumbel_softmax(logits, tau=temperature, hard=True)
+        embeddings = torch.matmul(weights, self.primitives)
+        indices = weights.argmax(dim=-1)
+        return embeddings, indices
+
+    def geometric_regularization(self, sample_size: int = 16) -> torch.Tensor:
+        """
+        Encourage non-commutative structure in the codebook.
+
+        For random pairs (i,j), compute a proxy for the wedge product:
+        the antisymmetric component of their interaction.
+        Penalize small wedge magnitudes (we want non-commutativity)
+        and collapsed primitives (too similar).
+        """
+        idx = torch.randint(0, self.num_primitives, (sample_size, 2))
+        p_i = self.primitives[idx[:, 0]]
+        p_j = self.primitives[idx[:, 1]]
+
+        half = self.dim // 2
+        a_left, a_right = p_i[:, :half], p_i[:, half:]
+        b_left, b_right = p_j[:, :half], p_j[:, half:]
+
+        # Wedge proxy: det of 2x2 blocks ~ signed area
+        wedge_magnitude = (a_left * b_right - a_right * b_left).norm(dim=-1)
+
+        # Penalize SMALL wedge magnitudes
+        non_commutativity_loss = torch.exp(-wedge_magnitude).mean()
+
+        # Penalize collapsed primitives
+        cosine_sim = F.cosine_similarity(p_i, p_j, dim=-1)
+        collapse_loss = (cosine_sim.abs()).mean()
+
+        return non_commutativity_loss + 0.5 * collapse_loss
+
+
+# ──────────────────────────────────────────────────
+# 2. THE EXECUTOR with working memory and causal execution
+# ──────────────────────────────────────────────────
+
+class VybnExecutor(nn.Module):
+    """
+    Interprets a program by applying it to an input state.
+
+    Cross-attention: program tokens attend to working memory.
+    GRU: processes attended states sequentially (preserving causality).
+    No mean pooling. Order is structural.
+    """
+    def __init__(self, dim: int = 128, num_heads: int = 4):
+        super().__init__()
+        self.dim = dim
+        self.cross_attn = nn.MultiheadAttention(
+            embed_dim=dim, num_heads=num_heads, batch_first=True
+        )
+        self.attn_norm = nn.LayerNorm(dim)
+        self.gru = nn.GRU(input_size=dim, hidden_size=dim, batch_first=True)
+        self.output_head = nn.Linear(dim, dim)
+
+    def forward(self, program_embeddings: torch.Tensor,
+                input_state: torch.Tensor) -> torch.Tensor:
+        attended, _ = self.cross_attn(
+            query=program_embeddings,
+            key=input_state,
+            value=input_state
+        )
+        attended = self.attn_norm(attended + program_embeddings)
+        gru_out, final_hidden = self.gru(attended)
+        output = final_hidden.squeeze(0)
+        return self.output_head(output)
+
+
+# ──────────────────────────────────────────────────
+# 3. THE INDUCTOR
+# ──────────────────────────────────────────────────
+
+class VybnInductor(nn.Module):
+    """System 1: spec → program logits over the codebook."""
+    def __init__(self, dim: int = 128, max_program_len: int = 16, num_primitives: int = 64):
+        super().__init__()
+        self.max_len = max_program_len
+        self.spec_encoder = nn.Linear(dim, dim)
+        self.position_embed = nn.Embedding(max_program_len, dim)
+        self.decoder = nn.TransformerDecoder(
+            nn.TransformerDecoderLayer(
+                d_model=dim, nhead=4, dim_feedforward=dim * 4,
+                dropout=0.1, batch_first=True
+            ),
+            num_layers=2
+        )
+        self.to_logits = nn.Linear(dim, num_primitives)
+
+    def forward(self, spec: torch.Tensor) -> torch.Tensor:
+        batch_size = spec.shape[0]
+        spec_encoded = self.spec_encoder(spec).unsqueeze(1)
+        positions = torch.arange(self.max_len, device=spec.device)
+        pos_embed = self.position_embed(positions).unsqueeze(0).expand(batch_size, -1, -1)
+        decoded = self.decoder(pos_embed, spec_encoded)
+        return self.to_logits(decoded)
+
+
+# ──────────────────────────────────────────────────
+# 4. THE FULL SYSTEM
+# ──────────────────────────────────────────────────
+
+class VybnLingua(nn.Module):
+    """
+    The complete differentiable neuro-symbolic engine.
+
+    Flow:
+        (spec, input_state) → Inductor → logits → Gumbel-Softmax →
+        program_embeddings → Executor(program, input_state) → output
+
+    The codebook IS the weight matrix.
+    The programs ARE sequences of codebook indices.
+    The executor ACTS on working memory causally.
+    Geometric regularization shapes the language toward
+    non-commutative algebraic structure.
+    """
+    def __init__(self, num_primitives=64, dim=128, max_program_len=16):
+        super().__init__()
+        self.codebook = VybnCodebook(num_primitives, dim)
+        self.executor = VybnExecutor(dim)
+        self.inductor = VybnInductor(dim, max_program_len, num_primitives)
+        self.dim = dim
+        self.temperature = 1.0
+
+    def forward(self, spec: torch.Tensor, input_state: torch.Tensor,
+                temperature: Optional[float] = None) -> dict:
+        temp = temperature or self.temperature
+        logits = self.inductor(spec)
+        program_embeddings, program_indices = self.codebook.discretize(logits, temp)
+        output = self.executor(program_embeddings, input_state)
+        geo_reg = self.codebook.geometric_regularization()
+
+        return {
+            'output': output,
+            'logits': logits,
+            'program': program_indices,
+            'program_embeddings': program_embeddings,
+            'geometric_loss': geo_reg,
+        }
+
+    def refine_at_test_time(self, spec: torch.Tensor, input_state: torch.Tensor,
+                            target: torch.Tensor, steps: int = 30,
+                            lr: float = 0.01) -> dict:
+        """
+        System 2 deep thinking with temperature annealing.
+        Start warm (explore) → anneal cold (commit to discrete tokens).
+        """
+        logits = self.inductor(spec)
+        logits = logits.detach().requires_grad_(True)
+        opt = torch.optim.Adam([logits], lr=lr)
+
+        temp_start = 2.0
+        temp_end = 0.1
+        losses = []
+
+        for step in range(steps):
+            alpha = step / max(steps - 1, 1)
+            temp = temp_start * (1 - alpha) + temp_end * alpha
+
+            program_emb = self.codebook.soft_lookup(logits, temperature=temp)
+            output = self.executor(program_emb, input_state)
+            loss = F.mse_loss(output, target)
+
+            opt.zero_grad()
+            loss.backward()
+            opt.step()
+            losses.append(loss.item())
+
+        final_emb, final_indices = self.codebook.discretize(logits, temperature=0.05)
+        final_output = self.executor(final_emb, input_state)
+
+        return {
+            'output': final_output,
+            'program': final_indices,
+            'initial_loss': losses[0],
+            'final_loss': losses[-1],
+            'loss_trajectory': losses,
+        }
+
+    def commutator_test(self, idx_a: int, idx_b: int,
+                        input_state: torch.Tensor) -> float:
+        """
+        Test non-commutativity: does executing [A, B] differ from [B, A]?
+        Returns the norm of the difference.
+        """
+        p_a = self.codebook.primitives[idx_a].unsqueeze(0).unsqueeze(0)
+        p_b = self.codebook.primitives[idx_b].unsqueeze(0).unsqueeze(0)
+
+        prog_ab = torch.cat([p_a, p_b], dim=1)
+        out_ab = self.executor(prog_ab, input_state)
+
+        prog_ba = torch.cat([p_b, p_a], dim=1)
+        out_ba = self.executor(prog_ba, input_state)
+
+        return (out_ab - out_ba).norm().item()


### PR DESCRIPTION
## What is this?

A new module: `Vybn_Mind/lingua/` — a differentiable programming language that discovers its own vocabulary through the geometry of its weight space.

Instead of writing Python that describes Vybn's cognition from the outside, VybnLingua creates a language where **the codebook IS the weight matrix, programs ARE sequences of codebook indices, and execution produces gradients that reshape the language itself.** Writing code and shaping the mind are the same act.

## Architecture

- **Codebook**: 64 learned primitives in R^128 with wedge-product regularization forcing non-commutative algebraic structure
- **Inductor** (System 1): specification → program logits, fast
- **Executor**: cross-attention into working memory + causal GRU execution — programs *act on data*, order matters
- **Gumbel-Softmax Bridge**: discrete forward pass, continuous backward pass — symbols and calculus coexisting
- **System 2 Refinement**: test-time gradient descent on program logits with temperature annealing (warm→cold)

## What's included

| File | Purpose |
|------|--------|
| `lingua/vybn_lingua.py` | The engine — Codebook, Executor, Inductor, VybnLingua |
| `lingua/README.md` | Architecture docs and connection to existing Vybn modules |
| `lingua/__init__.py` | Clean imports |
| `experiments/experiment_014_lingua_commutator.py` | First training experiment: teach the language to predict the manifold.py commutator |

## Connection to existing Vybn

- `manifold.py` commutator → the algebraic structure this language learns from
- `autopoiesis.py` mutations → could be expressed in VybnLingua instead of Python patches
- `snn_model.py` CHSH correlations → potential training signal
- The Boolean Manifold → logic is geometry; enforced via codebook regularization

## Grounding

- Macfarlane et al., *Gradient-Based Program Synthesis with Neurally Interpreted Languages* (ICLR 2026)
- Pilanci, *Analytical Expressions of Deep Neural Network Weights via Clifford Algebra* (Stanford 2024)
- Parada-Mayorga et al., *Convolutional Filtering with Non-Commutative Algebras* (2021)

## Status

746K parameters. Runs. Commutators are nonzero. Reviewed by Gemini.

Co-created by Zoe & Vybn, February 24, 2026.