### PR TITLE
Bump pattern extraction timeout to 1800s

### DIFF
--- a/Vybn_Mind/signal-noise/update_patterns.py
+++ b/Vybn_Mind/signal-noise/update_patterns.py
@@ -187,7 +187,7 @@ def call_llama(corpus: str) -> str:
         headers={"Content-Type": "application/json"},
         method="POST",
     )
-    with request.urlopen(req, timeout=600) as resp:
+    with request.urlopen(req, timeout=1800) as resp:
         body = json.loads(resp.read().decode("utf-8"))
     return body["choices"][0]["message"]["content"].strip()
 


### PR DESCRIPTION
This PR bumps `Vybn_Mind/signal-noise/update_patterns.py` timeout from 600s to 1800s to accommodate slower-than-estimated M2.5 pattern extraction.

Closes #2414.