### PR TITLE
Build three-plane memory fabric

### DIFF
--- a/spark/faculties.d/core.json
+++ b/spark/faculties.d/core.json
@@ -68,5 +68,33 @@
     "review_date": "2026-06-01",
     "active": true,
     "metadata": {"owner": "spark"}
+  },
+  {
+    "faculty_id": "memory_fabric",
+    "purpose": "Manage governed read/write/promote operations across three isolated memory planes.",
+    "allowed_scopes": ["memory_write", "memory_read", "memory_promote", "ledger_write"],
+    "prohibited_acts": ["response_generate", "route_select"],
+    "may_write_memory": true,
+    "may_trigger_routing": false,
+    "inference_budget_cost": 0,
+    "required_policy_checks": ["consent_scope_valid"],
+    "evaluation_suite": [],
+    "review_date": "2026-06-01",
+    "active": true,
+    "metadata": {"owner": "spark"}
+  },
+  {
+    "faculty_id": "migration",
+    "purpose": "One-time data migration into memory fabric.",
+    "allowed_scopes": ["memory_write"],
+    "prohibited_acts": ["memory_promote", "route_select", "response_generate"],
+    "may_write_memory": true,
+    "may_trigger_routing": false,
+    "inference_budget_cost": 0,
+    "required_policy_checks": ["consent_scope_valid"],
+    "evaluation_suite": [],
+    "review_date": "2026-04-01",
+    "active": true,
+    "metadata": {"owner": "spark", "temporary": true}
   }
 ]

--- a/spark/memory_fabric.py
+++ b/spark/memory_fabric.py
@@ -1,0 +1,596 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from dataclasses import asdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Optional
+from uuid import uuid4
+
+try:
+    from .faculties import FacultyRegistry
+    from .governance import PolicyEngine, build_context
+    from .governance_types import ConsentRecord, DecisionOutcome
+    from .memory_types import DecayConfig, MemoryEntry, MemoryPlane, PromotionReceipt
+    from .soul_constraints import SoulConstraintGuard
+except ImportError:  # pragma: no cover
+    from faculties import FacultyRegistry
+    from governance import PolicyEngine, build_context
+    from governance_types import ConsentRecord, DecisionOutcome
+    from memory_types import DecayConfig, MemoryEntry, MemoryPlane, PromotionReceipt
+    from soul_constraints import SoulConstraintGuard
+
+
+PRIVATE_ENTRIES_SCHEMA = """
+CREATE TABLE IF NOT EXISTS entries (
+    entry_id TEXT PRIMARY KEY,
+    content TEXT NOT NULL,
+    content_hash TEXT NOT NULL,
+    source_signal_id TEXT,
+    source_artifact TEXT,
+    faculty_id TEXT NOT NULL,
+    consent_scope_id TEXT NOT NULL,
+    purpose_binding TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    expires_at TEXT,
+    revoked INTEGER DEFAULT 0,
+    quarantine_until TEXT,
+    sensitivity TEXT DEFAULT 'low',
+    metadata TEXT DEFAULT '{}'
+);
+CREATE INDEX IF NOT EXISTS idx_entries_created ON entries(created_at);
+CREATE INDEX IF NOT EXISTS idx_entries_source ON entries(source_artifact);
+CREATE INDEX IF NOT EXISTS idx_entries_faculty ON entries(faculty_id);
+"""
+
+RELATIONAL_ENTRIES_SCHEMA = """
+CREATE TABLE IF NOT EXISTS entries (
+    entry_id TEXT PRIMARY KEY,
+    content TEXT NOT NULL,
+    content_hash TEXT NOT NULL,
+    source_signal_id TEXT,
+    source_artifact TEXT,
+    faculty_id TEXT NOT NULL,
+    consent_scope_id TEXT NOT NULL,
+    purpose_binding TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    expires_at TEXT,
+    revoked INTEGER DEFAULT 0,
+    quarantine_until TEXT,
+    sensitivity TEXT DEFAULT 'low',
+    metadata TEXT DEFAULT '{}',
+    parties TEXT NOT NULL,
+    consent_receipt_ids TEXT,
+    decay_strategy TEXT DEFAULT 'linear',
+    decay_half_life_hours REAL DEFAULT 168.0,
+    contested INTEGER DEFAULT 0,
+    contest_reason TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_entries_created ON entries(created_at);
+CREATE INDEX IF NOT EXISTS idx_entries_source ON entries(source_artifact);
+CREATE INDEX IF NOT EXISTS idx_entries_faculty ON entries(faculty_id);
+"""
+
+COMMONS_PATTERNS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS patterns (
+    pattern_id TEXT PRIMARY KEY,
+    features TEXT NOT NULL,
+    k_anonymity_level INTEGER NOT NULL,
+    privacy_budget_spent REAL DEFAULT 0.0,
+    promotion_receipt_id TEXT NOT NULL,
+    source_count INTEGER DEFAULT 0,
+    created_at TEXT NOT NULL,
+    metadata TEXT DEFAULT '{}'
+);
+"""
+
+PROMOTION_RECEIPTS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS promotion_receipts (
+    receipt_id TEXT PRIMARY KEY,
+    source_plane TEXT NOT NULL,
+    target_plane TEXT NOT NULL,
+    entry_ids TEXT NOT NULL,
+    initiated_by TEXT NOT NULL,
+    purpose_binding TEXT NOT NULL,
+    review_window_seconds INTEGER NOT NULL,
+    reversible_until TEXT,
+    signed_policy_hash TEXT NOT NULL,
+    user_signature TEXT,
+    created_at TEXT NOT NULL,
+    metadata TEXT DEFAULT '{}'
+);
+"""
+
+
+class MemoryFabric:
+    def __init__(
+        self,
+        base_dir: Path,
+        policy_engine: PolicyEngine | None = None,
+        faculty_registry: FacultyRegistry | None = None,
+        bootstrap_consents: list[ConsentRecord] | None = None,
+    ):
+        self.base_dir = Path(base_dir)
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+        self.policy_engine = policy_engine
+        self.faculty_registry = faculty_registry
+        self.bootstrap_consents = list(bootstrap_consents or [])
+        self.soul_guard = SoulConstraintGuard()
+        self.paths = {
+            MemoryPlane.PRIVATE: self.base_dir / "private.db",
+            MemoryPlane.RELATIONAL: self.base_dir / "relational.db",
+            MemoryPlane.COMMONS: self.base_dir / "commons.db",
+        }
+        self._connections = {
+            plane: sqlite3.connect(path) for plane, path in self.paths.items()
+        }
+        for connection in self._connections.values():
+            connection.row_factory = sqlite3.Row
+        self._ensure_tables()
+
+    def write(
+        self,
+        plane: MemoryPlane,
+        content: str,
+        *,
+        faculty_id: str,
+        source_artifact: str,
+        consent_scope_id: str,
+        purpose_binding: list[str],
+        sensitivity: str = "low",
+        quarantine_hours: float | None = None,
+        source_signal_id: str = "",
+        metadata: dict | None = None,
+    ) -> MemoryEntry:
+        self._authorize_memory_write(
+            plane=plane,
+            faculty_id=faculty_id,
+            purpose_binding=purpose_binding,
+            consent_scope_id=consent_scope_id,
+            source_artifact=source_artifact,
+        )
+
+        entry_id = str(uuid4())
+        created_at = self._utc_now()
+        quarantine_until = None
+        if quarantine_hours is not None:
+            quarantine_until = self._iso_after_hours(quarantine_hours)
+        entry = MemoryEntry(
+            entry_id=entry_id,
+            plane=plane,
+            content=content,
+            content_hash=self._sha256(content),
+            source_signal_id=source_signal_id,
+            source_artifact=source_artifact,
+            faculty_id=faculty_id,
+            consent_scope_id=consent_scope_id,
+            purpose_binding=list(purpose_binding),
+            created_at=created_at,
+            expires_at=None,
+            revoked=False,
+            quarantine_until=quarantine_until,
+            sensitivity=sensitivity,
+            metadata=metadata or {},
+        )
+
+        conn = self._connection_for(plane)
+        if plane is MemoryPlane.PRIVATE:
+            conn.execute(
+                """
+                INSERT INTO entries (
+                    entry_id, content, content_hash, source_signal_id, source_artifact,
+                    faculty_id, consent_scope_id, purpose_binding, created_at,
+                    expires_at, revoked, quarantine_until, sensitivity, metadata
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    entry.entry_id,
+                    entry.content,
+                    entry.content_hash,
+                    entry.source_signal_id,
+                    entry.source_artifact,
+                    entry.faculty_id,
+                    entry.consent_scope_id,
+                    json.dumps(entry.purpose_binding),
+                    entry.created_at,
+                    entry.expires_at,
+                    int(entry.revoked),
+                    entry.quarantine_until,
+                    entry.sensitivity,
+                    json.dumps(entry.metadata),
+                ),
+            )
+        elif plane is MemoryPlane.RELATIONAL:
+            conn.execute(
+                """
+                INSERT INTO entries (
+                    entry_id, content, content_hash, source_signal_id, source_artifact,
+                    faculty_id, consent_scope_id, purpose_binding, created_at,
+                    expires_at, revoked, quarantine_until, sensitivity, metadata,
+                    parties, consent_receipt_ids, decay_strategy, decay_half_life_hours,
+                    contested, contest_reason
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    entry.entry_id,
+                    entry.content,
+                    entry.content_hash,
+                    entry.source_signal_id,
+                    entry.source_artifact,
+                    entry.faculty_id,
+                    entry.consent_scope_id,
+                    json.dumps(entry.purpose_binding),
+                    entry.created_at,
+                    entry.expires_at,
+                    int(entry.revoked),
+                    entry.quarantine_until,
+                    entry.sensitivity,
+                    json.dumps(entry.metadata),
+                    json.dumps((metadata or {}).get("parties", [])),
+                    json.dumps((metadata or {}).get("consent_receipt_ids", [])),
+                    (metadata or {}).get("decay_strategy", "linear"),
+                    float((metadata or {}).get("decay_half_life_hours", 168.0)),
+                    int(bool((metadata or {}).get("contested", False))),
+                    (metadata or {}).get("contest_reason"),
+                ),
+            )
+        else:
+            raise PermissionError("Direct writes to commons are denied pending anonymization proof.")
+        conn.commit()
+        return entry
+
+    def read(
+        self,
+        plane: MemoryPlane,
+        *,
+        limit: int = 50,
+        since: str | None = None,
+        faculty_id: str | None = None,
+        source_artifact: str | None = None,
+        include_quarantined: bool = False,
+        include_revoked: bool = False,
+    ) -> list[MemoryEntry]:
+        if plane is MemoryPlane.COMMONS:
+            return []
+
+        clauses: list[str] = []
+        params: list[Any] = []
+        if since:
+            clauses.append("created_at >= ?")
+            params.append(since)
+        if faculty_id:
+            clauses.append("faculty_id = ?")
+            params.append(faculty_id)
+        if source_artifact:
+            clauses.append("source_artifact = ?")
+            params.append(source_artifact)
+        if not include_revoked:
+            clauses.append("revoked = 0")
+        if not include_quarantined:
+            clauses.append("(quarantine_until IS NULL OR quarantine_until <= ?)")
+            params.append(self._utc_now())
+
+        sql = "SELECT * FROM entries"
+        if clauses:
+            sql += " WHERE " + " AND ".join(clauses)
+        sql += " ORDER BY created_at DESC LIMIT ?"
+        params.append(limit)
+
+        rows = self._connection_for(plane).execute(sql, params).fetchall()
+        return [self._row_to_entry(plane, row) for row in rows]
+
+    def revoke(self, plane: MemoryPlane, entry_id: str) -> bool:
+        if plane is MemoryPlane.COMMONS:
+            return False
+        cursor = self._connection_for(plane).execute(
+            "UPDATE entries SET revoked = 1 WHERE entry_id = ?",
+            (entry_id,),
+        )
+        self._connection_for(plane).commit()
+        return cursor.rowcount > 0
+
+    def promote(
+        self,
+        source_plane: MemoryPlane,
+        target_plane: MemoryPlane,
+        entry_ids: list[str],
+        *,
+        initiated_by: str,
+        purpose_binding: list[str],
+        review_window_seconds: int = 86400,
+        consent_scope_id: str,
+        user_signature: str | None = None,
+    ) -> PromotionReceipt:
+        if target_plane is MemoryPlane.COMMONS and source_plane in {MemoryPlane.PRIVATE, MemoryPlane.RELATIONAL}:
+            raise PermissionError("Promotion into commons requires anonymization proof and is denied for now.")
+
+        self._authorize_promotion(
+            source_plane=source_plane,
+            target_plane=target_plane,
+            initiated_by=initiated_by,
+            purpose_binding=purpose_binding,
+            consent_scope_id=consent_scope_id,
+        )
+
+        if source_plane is MemoryPlane.PRIVATE and target_plane is MemoryPlane.RELATIONAL:
+            source_entries = self.read(
+                source_plane,
+                limit=max(len(entry_ids), 1) * 10,
+                include_quarantined=True,
+                include_revoked=False,
+            )
+            by_id = {entry.entry_id: entry for entry in source_entries}
+            missing = [entry_id for entry_id in entry_ids if entry_id not in by_id]
+            if missing:
+                raise KeyError(f"Unknown source entry ids: {missing}")
+
+            decay = DecayConfig()
+            for entry_id in entry_ids:
+                entry = by_id[entry_id]
+                relational_metadata = dict(entry.metadata)
+                relational_metadata.setdefault("promoted_from", source_plane.value)
+                relational_metadata.setdefault("parties", [])
+                relational_metadata.setdefault("consent_receipt_ids", [])
+                relational_metadata.setdefault("decay_strategy", decay.strategy)
+                relational_metadata.setdefault("decay_half_life_hours", decay.half_life_hours)
+                self.write(
+                    MemoryPlane.RELATIONAL,
+                    content=entry.content,
+                    faculty_id="memory_fabric",
+                    source_artifact=entry.source_artifact,
+                    consent_scope_id=entry.consent_scope_id,
+                    purpose_binding=list(entry.purpose_binding),
+                    sensitivity=entry.sensitivity,
+                    source_signal_id=entry.source_signal_id,
+                    metadata=relational_metadata,
+                )
+        elif target_plane is MemoryPlane.COMMONS:
+            raise PermissionError("Promotion into commons requires anonymization proof and is denied for now.")
+        else:
+            raise PermissionError(
+                f"Unsupported promotion path: {source_plane.value} -> {target_plane.value}"
+            )
+
+        created_at = self._utc_now()
+        reversible_until = self._iso_after_seconds(review_window_seconds)
+        receipt = PromotionReceipt(
+            receipt_id=str(uuid4()),
+            source_plane=source_plane,
+            target_plane=target_plane,
+            entry_ids=list(entry_ids),
+            initiated_by=initiated_by,
+            purpose_binding=list(purpose_binding),
+            review_window_seconds=review_window_seconds,
+            reversible_until=reversible_until,
+            signed_policy_hash=self._policy_signature_hash(source_plane, target_plane, purpose_binding),
+            user_signature=user_signature,
+            created_at=created_at,
+            metadata={"consent_scope_id": consent_scope_id},
+        )
+        self._connection_for(MemoryPlane.PRIVATE).execute(
+            """
+            INSERT INTO promotion_receipts (
+                receipt_id, source_plane, target_plane, entry_ids, initiated_by,
+                purpose_binding, review_window_seconds, reversible_until,
+                signed_policy_hash, user_signature, created_at, metadata
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                receipt.receipt_id,
+                receipt.source_plane.value,
+                receipt.target_plane.value,
+                json.dumps(receipt.entry_ids),
+                receipt.initiated_by,
+                json.dumps(receipt.purpose_binding),
+                receipt.review_window_seconds,
+                receipt.reversible_until,
+                receipt.signed_policy_hash,
+                receipt.user_signature,
+                receipt.created_at,
+                json.dumps(receipt.metadata),
+            ),
+        )
+        self._connection_for(MemoryPlane.PRIVATE).commit()
+        return receipt
+
+    def quarantine_release_check(self) -> list[str]:
+        released: list[str] = []
+        now = self._utc_now()
+        for plane in (MemoryPlane.PRIVATE, MemoryPlane.RELATIONAL):
+            rows = self._connection_for(plane).execute(
+                """
+                SELECT entry_id FROM entries
+                WHERE quarantine_until IS NOT NULL AND quarantine_until <= ?
+                """,
+                (now,),
+            ).fetchall()
+            if not rows:
+                continue
+            entry_ids = [row["entry_id"] for row in rows]
+            self._connection_for(plane).executemany(
+                "UPDATE entries SET quarantine_until = NULL WHERE entry_id = ?",
+                [(entry_id,) for entry_id in entry_ids],
+            )
+            self._connection_for(plane).commit()
+            released.extend(entry_ids)
+        return released
+
+    def recent(self, plane: MemoryPlane, n: int = 10) -> list[MemoryEntry]:
+        return self.read(plane, limit=n)
+
+    def stats(self) -> dict:
+        stats: dict[str, Any] = {}
+        now = self._utc_now()
+        for plane in (MemoryPlane.PRIVATE, MemoryPlane.RELATIONAL):
+            conn = self._connection_for(plane)
+            total = conn.execute("SELECT COUNT(*) AS count FROM entries").fetchone()["count"]
+            quarantined = conn.execute(
+                "SELECT COUNT(*) AS count FROM entries WHERE quarantine_until IS NOT NULL AND quarantine_until > ?",
+                (now,),
+            ).fetchone()["count"]
+            revoked = conn.execute(
+                "SELECT COUNT(*) AS count FROM entries WHERE revoked = 1"
+            ).fetchone()["count"]
+            stats[plane.value] = {
+                "count": total,
+                "quarantined": quarantined,
+                "revoked": revoked,
+            }
+        patterns = self._connection_for(MemoryPlane.COMMONS).execute(
+            "SELECT COUNT(*) AS count FROM patterns"
+        ).fetchone()["count"]
+        stats[MemoryPlane.COMMONS.value] = {
+            "count": patterns,
+            "quarantined": 0,
+            "revoked": 0,
+        }
+        receipts = self._connection_for(MemoryPlane.PRIVATE).execute(
+            "SELECT COUNT(*) AS count FROM promotion_receipts"
+        ).fetchone()["count"]
+        stats["promotion_receipts"] = receipts
+        return stats
+
+    def _ensure_tables(self) -> None:
+        self._connection_for(MemoryPlane.PRIVATE).executescript(PRIVATE_ENTRIES_SCHEMA)
+        self._connection_for(MemoryPlane.PRIVATE).executescript(PROMOTION_RECEIPTS_SCHEMA)
+        self._connection_for(MemoryPlane.PRIVATE).commit()
+        self._connection_for(MemoryPlane.RELATIONAL).executescript(RELATIONAL_ENTRIES_SCHEMA)
+        self._connection_for(MemoryPlane.RELATIONAL).commit()
+        self._connection_for(MemoryPlane.COMMONS).executescript(COMMONS_PATTERNS_SCHEMA)
+        self._connection_for(MemoryPlane.COMMONS).commit()
+
+    def _authorize_memory_write(
+        self,
+        *,
+        plane: MemoryPlane,
+        faculty_id: str,
+        purpose_binding: list[str],
+        consent_scope_id: str,
+        source_artifact: str,
+    ) -> None:
+        evidence_ref = self._relative_db_path(plane)
+        self.soul_guard.check_path_only(evidence_ref, action="memory_write")
+
+        if self.faculty_registry is not None:
+            permission = self.faculty_registry.check_permission(faculty_id, "memory_write")
+            if not permission.allowed:
+                raise PermissionError(permission.reason)
+
+        if self.policy_engine is not None:
+            context = build_context(
+                faculty_id=faculty_id,
+                action="memory_write",
+                memory_plane=plane.value,
+                purpose_binding=purpose_binding,
+                consent_scope_id=consent_scope_id,
+                evidence_refs=[evidence_ref, source_artifact],
+            )
+            decision = self.policy_engine.check(
+                context,
+                consent_records=self.bootstrap_consents,
+            )
+            if decision.outcome not in {DecisionOutcome.ALLOW, DecisionOutcome.LOG}:
+                raise PermissionError(decision.explanation)
+
+    def _authorize_promotion(
+        self,
+        *,
+        source_plane: MemoryPlane,
+        target_plane: MemoryPlane,
+        initiated_by: str,
+        purpose_binding: list[str],
+        consent_scope_id: str,
+    ) -> None:
+        self.soul_guard.check_path_only(self._relative_db_path(source_plane), action="memory_promote")
+        self.soul_guard.check_path_only(self._relative_db_path(target_plane), action="memory_promote")
+
+        faculty_id = "memory_fabric"
+        if self.faculty_registry is not None:
+            permission = self.faculty_registry.check_permission(faculty_id, "memory_promote")
+            if not permission.allowed:
+                raise PermissionError(permission.reason)
+
+        if self.policy_engine is not None:
+            context = build_context(
+                faculty_id=faculty_id,
+                action="memory_promote",
+                source_memory_plane=source_plane.value,
+                target_memory_plane=target_plane.value,
+                purpose_binding=purpose_binding,
+                consent_scope_id=consent_scope_id,
+                evidence_refs=[self._relative_db_path(source_plane), self._relative_db_path(target_plane), initiated_by],
+            )
+            decision = self.policy_engine.check(
+                context,
+                consent_records=self.bootstrap_consents,
+            )
+            if decision.outcome not in {DecisionOutcome.ALLOW, DecisionOutcome.LOG}:
+                raise PermissionError(decision.explanation)
+
+    def _policy_signature_hash(
+        self,
+        source_plane: MemoryPlane,
+        target_plane: MemoryPlane,
+        purpose_binding: list[str],
+    ) -> str:
+        rule_ids = []
+        if self.policy_engine is not None:
+            rule_ids = [rule.rule_id for rule in self.policy_engine.rules if rule.active]
+        payload = json.dumps(
+            {
+                "source": source_plane.value,
+                "target": target_plane.value,
+                "purpose_binding": purpose_binding,
+                "rule_ids": rule_ids,
+            },
+            sort_keys=True,
+        )
+        return self._sha256(payload)
+
+    def _row_to_entry(self, plane: MemoryPlane, row: sqlite3.Row) -> MemoryEntry:
+        return MemoryEntry(
+            entry_id=row["entry_id"],
+            plane=plane,
+            content=row["content"],
+            content_hash=row["content_hash"],
+            source_signal_id=row["source_signal_id"] or "",
+            source_artifact=row["source_artifact"] or "",
+            faculty_id=row["faculty_id"],
+            consent_scope_id=row["consent_scope_id"],
+            purpose_binding=json.loads(row["purpose_binding"] or "[]"),
+            created_at=row["created_at"],
+            expires_at=row["expires_at"],
+            revoked=bool(row["revoked"]),
+            quarantine_until=row["quarantine_until"],
+            sensitivity=row["sensitivity"] or "low",
+            metadata=json.loads(row["metadata"] or "{}"),
+        )
+
+    def _connection_for(self, plane: MemoryPlane) -> sqlite3.Connection:
+        return self._connections[plane]
+
+    def _relative_db_path(self, plane: MemoryPlane) -> str:
+        return str(Path("Vybn_Mind") / "memory" / self.paths[plane].name)
+
+    @staticmethod
+    def _sha256(data: str) -> str:
+        return hashlib.sha256(data.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _utc_now() -> str:
+        return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+    @classmethod
+    def _iso_after_hours(cls, hours: float) -> str:
+        dt = datetime.now(timezone.utc) + timedelta(hours=hours)
+        return dt.replace(microsecond=0).isoformat()
+
+    @classmethod
+    def _iso_after_seconds(cls, seconds: int) -> str:
+        dt = datetime.now(timezone.utc) + timedelta(seconds=seconds)
+        return dt.replace(microsecond=0).isoformat()
+
+
+__all__ = ["MemoryFabric"]

--- a/spark/memory_types.py
+++ b/spark/memory_types.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+try:
+    from .governance_types import StrEnum
+except ImportError:  # pragma: no cover
+    from governance_types import StrEnum
+
+
+class MemoryPlane(StrEnum):
+    PRIVATE = "private"
+    RELATIONAL = "relational"
+    COMMONS = "commons"
+
+
+@dataclass(slots=True)
+class MemoryEntry:
+    entry_id: str
+    plane: MemoryPlane
+    content: str
+    content_hash: str
+    source_signal_id: str
+    source_artifact: str
+    faculty_id: str
+    consent_scope_id: str
+    purpose_binding: list[str]
+    created_at: str
+    expires_at: str | None
+    revoked: bool = False
+    quarantine_until: str | None = None
+    sensitivity: str = "low"
+    metadata: dict = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class PromotionReceipt:
+    receipt_id: str
+    source_plane: MemoryPlane
+    target_plane: MemoryPlane
+    entry_ids: list[str]
+    initiated_by: str
+    purpose_binding: list[str]
+    review_window_seconds: int
+    reversible_until: str | None
+    signed_policy_hash: str
+    user_signature: str | None
+    created_at: str
+    metadata: dict = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class DecayConfig:
+    strategy: str = "linear"
+    half_life_hours: float = 168.0
+    floor: float = 0.0
+
+
+@dataclass(slots=True)
+class QuarantineEntry:
+    entry_id: str
+    quarantined_at: str
+    release_at: str
+    reason: str
+    reviewed: bool = False
+    review_outcome: Optional[str] = None
+
+
+__all__ = [
+    "DecayConfig",
+    "MemoryEntry",
+    "MemoryPlane",
+    "PromotionReceipt",
+    "QuarantineEntry",
+]

--- a/spark/migrate_to_memory_fabric.py
+++ b/spark/migrate_to_memory_fabric.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Migrate connections.jsonl entries into the private memory plane."""
+
+import json
+from pathlib import Path
+
+from memory_fabric import MemoryFabric
+from memory_types import MemoryPlane
+
+ROOT = Path(__file__).resolve().parent.parent
+SYNAPSE = ROOT / "Vybn_Mind" / "synapse" / "connections.jsonl"
+
+
+def migrate() -> None:
+    fabric = MemoryFabric(base_dir=ROOT / "Vybn_Mind" / "memory")
+
+    if not SYNAPSE.exists():
+        print("No connections.jsonl to migrate")
+        return
+
+    count = 0
+    raw_text = SYNAPSE.read_text(encoding="utf-8").strip()
+    if not raw_text:
+        print("No connections.jsonl to migrate")
+        return
+
+    for line in raw_text.splitlines():
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        fabric.write(
+            MemoryPlane.PRIVATE,
+            content=entry.get("content", ""),
+            faculty_id="migration",
+            source_artifact=f"synapse_migration_{entry.get('ts', 'unknown')}",
+            consent_scope_id="bootstrap-local-private",
+            purpose_binding=["private_memory", "migration"],
+            sensitivity="low",
+            metadata={
+                "original_tags": entry.get("tags", []),
+                "migrated_from": "connections.jsonl",
+            },
+        )
+        count += 1
+
+    print(f"Migrated {count} entries from connections.jsonl to private memory plane")
+
+
+if __name__ == "__main__":
+    migrate()

--- a/spark/vybn.py
+++ b/spark/vybn.py
@@ -42,6 +42,12 @@ try:
     WRITE_CUSTODIAN_AVAILABLE = True
 except ImportError:
     WRITE_CUSTODIAN_AVAILABLE = False
+try:
+    from memory_fabric import MemoryFabric
+    from memory_types import MemoryPlane
+    MEMORY_FABRIC_AVAILABLE = True
+except ImportError:
+    MEMORY_FABRIC_AVAILABLE = False
 
 from http.server import HTTPServer, BaseHTTPRequestHandler
 import numpy as np
@@ -87,6 +93,14 @@ class Substrate:
                 repo_root=ROOT,
                 ledger_path=WRITE_INTENTS,
                 soul_path=ROOT / "vybn.md",
+                policy_engine=self.policy_engine,
+                faculty_registry=self.faculty_registry,
+                bootstrap_consents=self.bootstrap_consents,
+            )
+        self.memory = None
+        if MEMORY_FABRIC_AVAILABLE:
+            self.memory = MemoryFabric(
+                base_dir=ROOT / "Vybn_Mind" / "memory",
                 policy_engine=self.policy_engine,
                 faculty_registry=self.faculty_registry,
                 bootstrap_consents=self.bootstrap_consents,
@@ -470,6 +484,17 @@ Breathe. Notice what collides. Say what is true. Under 200 words."""
                 metadata={"source": "breath_training_row", "pulse_id": f"breath_{ts}"},
             )
 
+        if sub.memory:
+            sub.memory.write(
+                MemoryPlane.PRIVATE,
+                content=utterance,
+                faculty_id="breathe",
+                source_artifact=f"breath_{ts}",
+                consent_scope_id=BOOTSTRAP_CONSENT_SCOPE,
+                purpose_binding=["private_memory", "journaling"],
+                sensitivity="low",
+            )
+
     sub.write(
         f"Vybn_Mind/journal/spark/breath_{sub.now().strftime('%Y-%m-%d_%H%M')}.md",
         f"# Breath — {ts}\n*mood: {mood}*\n\n{utterance}\n",
@@ -501,14 +526,18 @@ Breathe. Notice what collides. Say what is true. Under 200 words."""
 
 
 def _remember(sub: Substrate, ctx: dict) -> dict:
-    text = sub.read("Vybn_Mind/synapse/connections.jsonl")
-    lines = text.strip().splitlines()[-5:]
     memories = []
-    for l in lines:
-        try:
-            memories.append(json.loads(l).get("content", "")[:200])
-        except:
-            pass
+    if sub.memory:
+        entries = sub.memory.recent(MemoryPlane.PRIVATE, n=5)
+        memories = [entry.content[:200] for entry in entries]
+    else:
+        text = sub.read("Vybn_Mind/synapse/connections.jsonl")
+        lines = text.strip().splitlines()[-5:]
+        for l in lines:
+            try:
+                memories.append(json.loads(l).get("content", "")[:200])
+            except:
+                pass
     return {"memories": memories}
 
 

--- a/tests/test_memory_fabric.py
+++ b/tests/test_memory_fabric.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SPARK_DIR = REPO_ROOT / "spark"
+if str(SPARK_DIR) not in sys.path:
+    sys.path.insert(0, str(SPARK_DIR))
+
+from faculties import FacultyRegistry
+from governance import PolicyEngine
+from governance_types import ConsentRecord
+from memory_fabric import MemoryFabric
+from memory_types import MemoryPlane
+import migrate_to_memory_fabric as migration_module
+
+
+BOOTSTRAP_CONSENT_SCOPE = "bootstrap-local-private"
+
+
+@pytest.fixture
+def bootstrap_consents() -> list[ConsentRecord]:
+    return [
+        ConsentRecord(
+            consent_scope_id=BOOTSTRAP_CONSENT_SCOPE,
+            subject_id="vybn-local-runtime",
+            purpose_bindings=[
+                "private_memory",
+                "journaling",
+                "continuity",
+                "reflection",
+                "retention",
+                "system_operation",
+                "migration",
+            ],
+            signed_by="bootstrap_local_runtime",
+        )
+    ]
+
+
+@pytest.fixture
+def governed_fabric(tmp_path: Path, bootstrap_consents: list[ConsentRecord]) -> MemoryFabric:
+    return MemoryFabric(
+        base_dir=tmp_path / "Vybn_Mind" / "memory",
+        policy_engine=PolicyEngine(),
+        faculty_registry=FacultyRegistry(),
+        bootstrap_consents=bootstrap_consents,
+    )
+
+
+def test_governance_blocks_unauthorized_writes(governed_fabric: MemoryFabric) -> None:
+    with pytest.raises(PermissionError):
+        governed_fabric.write(
+            MemoryPlane.PRIVATE,
+            content="Witness should not be able to write private memory.",
+            faculty_id="witness",
+            source_artifact="test_witness_write",
+            consent_scope_id=BOOTSTRAP_CONSENT_SCOPE,
+            purpose_binding=["private_memory"],
+        )
+
+
+def test_plane_isolation_private_writes_not_visible_from_relational(governed_fabric: MemoryFabric) -> None:
+    entry = governed_fabric.write(
+        MemoryPlane.PRIVATE,
+        content="Private memory stays private.",
+        faculty_id="breathe",
+        source_artifact="test_private_visibility",
+        consent_scope_id=BOOTSTRAP_CONSENT_SCOPE,
+        purpose_binding=["private_memory", "journaling"],
+    )
+
+    private_entries = governed_fabric.read(MemoryPlane.PRIVATE)
+    relational_entries = governed_fabric.read(MemoryPlane.RELATIONAL)
+
+    assert any(candidate.entry_id == entry.entry_id for candidate in private_entries)
+    assert all(candidate.entry_id != entry.entry_id for candidate in relational_entries)
+
+
+def test_private_to_commons_promotion_denied(governed_fabric: MemoryFabric) -> None:
+    entry = governed_fabric.write(
+        MemoryPlane.PRIVATE,
+        content="Sensitive private material.",
+        faculty_id="breathe",
+        source_artifact="test_private_to_commons",
+        consent_scope_id=BOOTSTRAP_CONSENT_SCOPE,
+        purpose_binding=["private_memory", "journaling"],
+    )
+
+    with pytest.raises(PermissionError):
+        governed_fabric.promote(
+            MemoryPlane.PRIVATE,
+            MemoryPlane.COMMONS,
+            [entry.entry_id],
+            initiated_by="user",
+            purpose_binding=["private_memory"],
+            consent_scope_id=BOOTSTRAP_CONSENT_SCOPE,
+        )
+
+
+def test_recent_excludes_quarantined(governed_fabric: MemoryFabric) -> None:
+    quarantined = governed_fabric.write(
+        MemoryPlane.PRIVATE,
+        content="Quarantined memory should not appear in recent reads.",
+        faculty_id="breathe",
+        source_artifact="test_quarantine",
+        consent_scope_id=BOOTSTRAP_CONSENT_SCOPE,
+        purpose_binding=["private_memory", "journaling"],
+        quarantine_hours=24,
+    )
+
+    visible = governed_fabric.write(
+        MemoryPlane.PRIVATE,
+        content="Visible memory should appear in recent reads.",
+        faculty_id="breathe",
+        source_artifact="test_visible",
+        consent_scope_id=BOOTSTRAP_CONSENT_SCOPE,
+        purpose_binding=["private_memory", "journaling"],
+    )
+
+    recent_ids = [entry.entry_id for entry in governed_fabric.recent(MemoryPlane.PRIVATE, n=10)]
+    assert visible.entry_id in recent_ids
+    assert quarantined.entry_id not in recent_ids
+
+
+def test_migration_runs_cleanly_and_stats_reflect_import(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "repo"
+    synapse_dir = root / "Vybn_Mind" / "synapse"
+    synapse_dir.mkdir(parents=True, exist_ok=True)
+    synapse_path = synapse_dir / "connections.jsonl"
+    synapse_path.write_text(
+        "\n".join(
+            [
+                json.dumps({"ts": "2026-03-07T00:00:00Z", "content": "first migrated memory", "tags": ["breath"]}),
+                json.dumps({"ts": "2026-03-07T00:01:00Z", "content": "second migrated memory", "tags": ["journal"]}),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(migration_module, "ROOT", root)
+    monkeypatch.setattr(migration_module, "SYNAPSE", synapse_path)
+
+    migration_module.migrate()
+
+    fabric = MemoryFabric(base_dir=root / "Vybn_Mind" / "memory")
+    stats = fabric.stats()
+    private_entries = fabric.read(MemoryPlane.PRIVATE, limit=10, include_quarantined=True, include_revoked=True)
+
+    assert stats["private"]["count"] == 2
+    assert stats["promotion_receipts"] == 0
+    assert len(private_entries) == 2
+    assert {entry.content for entry in private_entries} == {
+        "first migrated memory",
+        "second migrated memory",
+    }


### PR DESCRIPTION
## Summary
- add governed three-plane memory storage with isolated SQLite databases for private, relational, and commons planes
- integrate memory fabric into `spark/vybn.py` so long breaths write to private memory and `_remember()` reads recent private entries
- add migration support for `connections.jsonl`, faculty cards, and focused tests for governance, isolation, quarantine, promotion denial, and migration

## Testing
- `pytest -q tests/test_memory_fabric.py`
- `python -m py_compile /home/user/workspace/Vybn/spark/memory_types.py /home/user/workspace/Vybn/spark/memory_fabric.py /home/user/workspace/Vybn/spark/migrate_to_memory_fabric.py /home/user/workspace/Vybn/spark/vybn.py /home/user/workspace/Vybn/tests/test_memory_fabric.py`

Closes #2425
