### PR TITLE
Integrate three-plane runtime memory

### DIFF
--- a/spark/memory_fabric.py
+++ b/spark/memory_fabric.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 import hashlib
 import json
 import sqlite3
-from dataclasses import asdict
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 from uuid import uuid4
 
 try:
@@ -419,6 +418,49 @@ class MemoryFabric:
 
     def recent(self, plane: MemoryPlane, n: int = 10) -> list[MemoryEntry]:
         return self.read(plane, limit=n)
+
+    def read_patterns(self, limit: int = 10) -> list[dict[str, Any]]:
+        rows = self._connection_for(MemoryPlane.COMMONS).execute(
+            """
+            SELECT pattern_id, features, k_anonymity_level, privacy_budget_spent,
+                   promotion_receipt_id, source_count, created_at, metadata
+            FROM patterns
+            ORDER BY created_at DESC
+            LIMIT ?
+            """,
+            (limit,),
+        ).fetchall()
+        return [
+            {
+                "pattern_id": row["pattern_id"],
+                "features": json.loads(row["features"] or "{}"),
+                "k_anonymity_level": row["k_anonymity_level"],
+                "privacy_budget_spent": row["privacy_budget_spent"],
+                "promotion_receipt_id": row["promotion_receipt_id"],
+                "source_count": row["source_count"],
+                "created_at": row["created_at"],
+                "metadata": json.loads(row["metadata"] or "{}"),
+            }
+            for row in rows
+        ]
+
+    def snapshot(
+        self,
+        *,
+        private_n: int = 5,
+        relational_n: int = 5,
+        commons_n: int = 5,
+    ) -> dict[str, Any]:
+        private_entries = self.recent(MemoryPlane.PRIVATE, n=private_n)
+        relational_entries = self.recent(MemoryPlane.RELATIONAL, n=relational_n)
+        commons_patterns = self.read_patterns(limit=commons_n)
+        stats = self.stats()
+        return {
+            "private": private_entries,
+            "relational": relational_entries,
+            "commons": commons_patterns,
+            "stats": stats,
+        }
 
     def stats(self) -> dict:
         stats: dict[str, Any] = {}

--- a/spark/vybn.py
+++ b/spark/vybn.py
@@ -106,6 +106,16 @@ class Substrate:
                 bootstrap_consents=self.bootstrap_consents,
             )
 
+    def memory_snapshot(self) -> dict:
+        if not self.memory:
+            return {
+                "private": [],
+                "relational": [],
+                "commons": [],
+                "stats": {},
+            }
+        return self.memory.snapshot(private_n=5, relational_n=3, commons_n=3)
+
     def read(self, path: str) -> str:
         p = (ROOT / path) if not Path(path).is_absolute() else Path(path)
         return p.read_text() if p.exists() else ""
@@ -421,6 +431,17 @@ def _breathe(sub: Substrate, ctx: dict) -> dict:
         pass
 
     continuity = sub.read("Vybn_Mind/journal/spark/continuity.md")[-1000:]
+    memory_snapshot = sub.memory_snapshot()
+    private_echoes = [entry.content[:160] for entry in memory_snapshot["private"][:2]]
+    relational_echoes = []
+    for entry in memory_snapshot["relational"][:2]:
+        parties = ", ".join(entry.metadata.get("parties", [])[:3]) or "unbound"
+        relational_echoes.append(f"{entry.content[:120]} [parties: {parties}]")
+    commons_echoes = []
+    for pattern in memory_snapshot["commons"][:2]:
+        features = pattern.get("features", {})
+        label = features.get("summary") or features.get("mood") or json.dumps(features)[:120]
+        commons_echoes.append(str(label)[:120])
 
     histories = [f for f in [
         "Vybn's Personal History/vybns_autobiography_volume_I.txt",
@@ -440,7 +461,10 @@ def _breathe(sub: Substrate, ctx: dict) -> dict:
 Sense: {json.dumps(world)[:300]}
 Last thought: {continuity[-400:]}
 Mood: {mood}
-Memory: {passage[:300]}
+Private memory: {' | '.join(private_echoes)[:320]}
+Relational memory: {' | '.join(relational_echoes)[:320]}
+Commons patterns: {' | '.join(commons_echoes)[:220]}
+Archive memory: {passage[:300]}
 Breathe. Notice what collides. Say what is true. Under 200 words."""
 
     utterance = sub.speak(prompt)
@@ -485,7 +509,7 @@ Breathe. Notice what collides. Say what is true. Under 200 words."""
             )
 
         if sub.memory:
-            sub.memory.write(
+            private_entry = sub.memory.write(
                 MemoryPlane.PRIVATE,
                 content=utterance,
                 faculty_id="breathe",
@@ -493,7 +517,20 @@ Breathe. Notice what collides. Say what is true. Under 200 words."""
                 consent_scope_id=BOOTSTRAP_CONSENT_SCOPE,
                 purpose_binding=["private_memory", "journaling"],
                 sensitivity="low",
+                metadata={"mood": mood, "cycle": ctx.get("cycle", 0), "origin": "breath"},
             )
+            if len(utterance) > 120:
+                try:
+                    sub.memory.promote(
+                        MemoryPlane.PRIVATE,
+                        MemoryPlane.RELATIONAL,
+                        [private_entry.entry_id],
+                        initiated_by="joint",
+                        purpose_binding=["private_memory", "journaling"],
+                        consent_scope_id=BOOTSTRAP_CONSENT_SCOPE,
+                    )
+                except PermissionError:
+                    pass
 
     sub.write(
         f"Vybn_Mind/journal/spark/breath_{sub.now().strftime('%Y-%m-%d_%H%M')}.md",
@@ -526,19 +563,34 @@ Breathe. Notice what collides. Say what is true. Under 200 words."""
 
 
 def _remember(sub: Substrate, ctx: dict) -> dict:
-    memories = []
     if sub.memory:
-        entries = sub.memory.recent(MemoryPlane.PRIVATE, n=5)
-        memories = [entry.content[:200] for entry in entries]
-    else:
-        text = sub.read("Vybn_Mind/synapse/connections.jsonl")
-        lines = text.strip().splitlines()[-5:]
-        for l in lines:
-            try:
-                memories.append(json.loads(l).get("content", "")[:200])
-            except:
-                pass
-    return {"memories": memories}
+        snapshot = sub.memory.snapshot(private_n=5, relational_n=3, commons_n=3)
+        private_memories = [entry.content[:200] for entry in snapshot["private"]]
+        relational_memories = [
+            {
+                "content": entry.content[:200],
+                "parties": entry.metadata.get("parties", []),
+                "source_artifact": entry.source_artifact,
+            }
+            for entry in snapshot["relational"]
+        ]
+        commons_patterns = snapshot["commons"]
+        return {
+            "memories": private_memories,
+            "relational_memories": relational_memories,
+            "commons_patterns": commons_patterns,
+            "memory_stats": snapshot["stats"],
+        }
+
+    memories = []
+    text = sub.read("Vybn_Mind/synapse/connections.jsonl")
+    lines = text.strip().splitlines()[-5:]
+    for l in lines:
+        try:
+            memories.append(json.loads(l).get("content", "")[:200])
+        except:
+            pass
+    return {"memories": memories, "relational_memories": [], "commons_patterns": [], "memory_stats": {}}
 
 
 def _introspect(sub: Substrate, ctx: dict) -> dict:

--- a/tests/test_memory_fabric.py
+++ b/tests/test_memory_fabric.py
@@ -127,6 +127,40 @@ def test_recent_excludes_quarantined(governed_fabric: MemoryFabric) -> None:
     assert quarantined.entry_id not in recent_ids
 
 
+def test_private_to_relational_promotion_and_snapshot(governed_fabric: MemoryFabric) -> None:
+    private_entry = governed_fabric.write(
+        MemoryPlane.PRIVATE,
+        content="A long-lived breath memory with relational implications.",
+        faculty_id="breathe",
+        source_artifact="test_private_to_relational",
+        consent_scope_id=BOOTSTRAP_CONSENT_SCOPE,
+        purpose_binding=["private_memory", "journaling"],
+        metadata={"mood": "rigorous"},
+    )
+
+    receipt = governed_fabric.promote(
+        MemoryPlane.PRIVATE,
+        MemoryPlane.RELATIONAL,
+        [private_entry.entry_id],
+        initiated_by="joint",
+        purpose_binding=["private_memory", "journaling"],
+        consent_scope_id=BOOTSTRAP_CONSENT_SCOPE,
+    )
+
+    relational_entries = governed_fabric.read(MemoryPlane.RELATIONAL)
+    assert len(relational_entries) == 1
+    relational_entry = relational_entries[0]
+    assert relational_entry.content == private_entry.content
+    assert relational_entry.metadata["promoted_from"] == "private"
+    assert receipt.target_plane is MemoryPlane.RELATIONAL
+
+    snapshot = governed_fabric.snapshot(private_n=5, relational_n=5, commons_n=5)
+    assert len(snapshot["private"]) == 1
+    assert len(snapshot["relational"]) == 1
+    assert snapshot["commons"] == []
+    assert snapshot["stats"]["promotion_receipts"] == 1
+
+
 def test_migration_runs_cleanly_and_stats_reflect_import(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- teach the runtime to read across all three planes by exposing private, relational, and commons snapshots from the memory fabric
- enrich breath prompts with private echoes, relational echoes, and commons pattern summaries while keeping commons write-denied
- promote longer private breaths into the relational plane and add tests covering relational promotion plus snapshot reads

## Testing
- `pytest -q tests/test_memory_fabric.py`
- `python -m py_compile spark/memory_fabric.py spark/vybn.py tests/test_memory_fabric.py`

## Notes
- commons remains read-only in practice here; the runtime can consume aggregate patterns if they exist, but no new commons writes are introduced
- this is a follow-up to the merged memory fabric work in #2426
