### PR TITLE
Build associative graph layer over memory fabric

### DIFF
--- a/spark/memory_graph.py
+++ b/spark/memory_graph.py
@@ -1,0 +1,904 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sqlite3
+from collections import Counter, deque
+from typing import Any
+
+try:
+    from .memory_fabric import MemoryFabric
+    from .memory_types import MemoryEntry, MemoryPlane
+except ImportError:  # pragma: no cover
+    from memory_fabric import MemoryFabric
+    from memory_types import MemoryEntry, MemoryPlane
+
+
+EXTRACTOR_VERSION = "memory-graph-v1"
+TOKEN_PATTERN = re.compile(r"[A-Za-z][A-Za-z'_-]{2,}")
+STOPWORDS = {
+    "about",
+    "after",
+    "again",
+    "against",
+    "almost",
+    "along",
+    "already",
+    "also",
+    "always",
+    "among",
+    "another",
+    "around",
+    "because",
+    "before",
+    "being",
+    "between",
+    "briefly",
+    "breathe",
+    "cannot",
+    "certain",
+    "could",
+    "did",
+    "does",
+    "doing",
+    "each",
+    "else",
+    "enough",
+    "even",
+    "every",
+    "from",
+    "have",
+    "into",
+    "just",
+    "last",
+    "like",
+    "made",
+    "make",
+    "many",
+    "might",
+    "more",
+    "most",
+    "much",
+    "must",
+    "need",
+    "never",
+    "notice",
+    "only",
+    "other",
+    "ours",
+    "over",
+    "really",
+    "same",
+    "say",
+    "says",
+    "should",
+    "since",
+    "some",
+    "still",
+    "such",
+    "than",
+    "that",
+    "their",
+    "them",
+    "then",
+    "there",
+    "these",
+    "they",
+    "this",
+    "those",
+    "through",
+    "under",
+    "until",
+    "very",
+    "what",
+    "when",
+    "where",
+    "which",
+    "while",
+    "with",
+    "would",
+    "your",
+    "youre",
+}
+
+GRAPH_NODES_SCHEMA = """
+CREATE TABLE IF NOT EXISTS graph_nodes (
+    node_id TEXT PRIMARY KEY,
+    label TEXT NOT NULL,
+    node_type TEXT NOT NULL,
+    description TEXT DEFAULT '',
+    activation_count INTEGER DEFAULT 0,
+    salience REAL DEFAULT 0.5,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    metadata TEXT DEFAULT '{}'
+);
+CREATE INDEX IF NOT EXISTS idx_graph_nodes_type ON graph_nodes(node_type);
+CREATE INDEX IF NOT EXISTS idx_graph_nodes_label ON graph_nodes(label);
+"""
+
+GRAPH_EDGES_SCHEMA = """
+CREATE TABLE IF NOT EXISTS graph_edges (
+    edge_id TEXT PRIMARY KEY,
+    source_node_id TEXT NOT NULL,
+    target_node_id TEXT NOT NULL,
+    relation_type TEXT NOT NULL,
+    weight REAL DEFAULT 1.0,
+    provenance_entry_id TEXT,
+    provenance_artifact TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    metadata TEXT DEFAULT '{}',
+    UNIQUE(source_node_id, target_node_id, relation_type, provenance_entry_id)
+);
+CREATE INDEX IF NOT EXISTS idx_graph_edges_source ON graph_edges(source_node_id);
+CREATE INDEX IF NOT EXISTS idx_graph_edges_target ON graph_edges(target_node_id);
+CREATE INDEX IF NOT EXISTS idx_graph_edges_relation ON graph_edges(relation_type);
+"""
+
+GRAPH_EXTRACTIONS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS graph_extractions (
+    source_entry_id TEXT PRIMARY KEY,
+    plane TEXT NOT NULL,
+    content_hash TEXT NOT NULL,
+    source_artifact TEXT,
+    extracted_at TEXT NOT NULL,
+    extractor_version TEXT NOT NULL,
+    metadata TEXT DEFAULT '{}'
+);
+CREATE INDEX IF NOT EXISTS idx_graph_extractions_artifact ON graph_extractions(source_artifact);
+"""
+
+
+class MemoryGraph:
+    """Associative graph layer that sits above the governed memory fabric."""
+
+    def __init__(self, fabric: MemoryFabric, extractor_version: str = EXTRACTOR_VERSION):
+        self.fabric = fabric
+        self.extractor_version = extractor_version
+        self._ensure_tables()
+
+    def ingest_entry(
+        self,
+        entry: MemoryEntry,
+        *,
+        claim_entries: list[Any] | None = None,
+        force: bool = False,
+    ) -> dict[str, Any]:
+        if entry.plane is MemoryPlane.COMMONS:
+            return {"status": "skipped", "reason": "commons entry ingestion is not implemented", "entry_id": entry.entry_id}
+
+        if not force and self._is_fresh(entry):
+            return {"status": "skipped", "reason": "entry already indexed", "entry_id": entry.entry_id}
+
+        self.fabric._authorize_memory_write(
+            plane=entry.plane,
+            faculty_id="memory_fabric",
+            purpose_binding=list(entry.purpose_binding) or ["private_memory"],
+            consent_scope_id=entry.consent_scope_id,
+            source_artifact=entry.source_artifact or f"entry:{entry.entry_id}",
+        )
+
+        conn = self.fabric._connection_for(entry.plane)
+        ts = self.fabric._utc_now()
+        entry_node_id = self._entry_node_id(entry.entry_id)
+        created_nodes = 0
+        created_edges = 0
+
+        created_nodes += self._upsert_node(
+            conn,
+            node_id=entry_node_id,
+            label=self._entry_label(entry),
+            node_type="memory_entry",
+            description=entry.content[:280],
+            salience=1.0,
+            now=ts,
+            metadata={
+                "entry_id": entry.entry_id,
+                "plane": entry.plane.value,
+                "source_artifact": entry.source_artifact,
+                "source_signal_id": entry.source_signal_id,
+                "created_at": entry.created_at,
+                "sensitivity": entry.sensitivity,
+                "mood": entry.metadata.get("mood"),
+                "content_preview": entry.content[:280],
+            },
+        )
+
+        if entry.source_artifact:
+            artifact_node_id = f"artifact:{self._slug(entry.source_artifact)}"
+            created_nodes += self._upsert_node(
+                conn,
+                node_id=artifact_node_id,
+                label=entry.source_artifact,
+                node_type="artifact",
+                description=f"Source artifact for {entry.entry_id}",
+                salience=0.75,
+                now=ts,
+                metadata={"source_artifact": entry.source_artifact},
+            )
+            created_edges += self._upsert_edge(
+                conn,
+                source_node_id=entry_node_id,
+                target_node_id=artifact_node_id,
+                relation_type="ORIGINATED_IN",
+                weight=0.9,
+                provenance_entry_id=entry.entry_id,
+                provenance_artifact=entry.source_artifact,
+                now=ts,
+                metadata={"plane": entry.plane.value},
+            )
+
+        if entry.source_signal_id:
+            signal_node_id = f"signal:{self._slug(entry.source_signal_id)}"
+            created_nodes += self._upsert_node(
+                conn,
+                node_id=signal_node_id,
+                label=entry.source_signal_id,
+                node_type="signal",
+                description="Source signal that contributed to this memory.",
+                salience=0.7,
+                now=ts,
+                metadata={"source_signal_id": entry.source_signal_id},
+            )
+            created_edges += self._upsert_edge(
+                conn,
+                source_node_id=entry_node_id,
+                target_node_id=signal_node_id,
+                relation_type="TRACED_TO_SIGNAL",
+                weight=0.8,
+                provenance_entry_id=entry.entry_id,
+                provenance_artifact=entry.source_artifact,
+                now=ts,
+                metadata={"plane": entry.plane.value},
+            )
+
+        mood = str(entry.metadata.get("mood") or "").strip()
+        if mood:
+            mood_node_id = f"mood:{self._slug(mood)}"
+            created_nodes += self._upsert_node(
+                conn,
+                node_id=mood_node_id,
+                label=mood,
+                node_type="mood",
+                description="Affective coloring attached to a memory entry.",
+                salience=0.65,
+                now=ts,
+                metadata={"mood": mood},
+            )
+            created_edges += self._upsert_edge(
+                conn,
+                source_node_id=entry_node_id,
+                target_node_id=mood_node_id,
+                relation_type="EXPRESSES_MOOD",
+                weight=0.75,
+                provenance_entry_id=entry.entry_id,
+                provenance_artifact=entry.source_artifact,
+                now=ts,
+                metadata={"plane": entry.plane.value},
+            )
+
+        parties = [str(p).strip() for p in entry.metadata.get("parties", []) if str(p).strip()]
+        for party in parties[:6]:
+            party_node_id = f"party:{self._slug(party)}"
+            created_nodes += self._upsert_node(
+                conn,
+                node_id=party_node_id,
+                label=party,
+                node_type="party",
+                description="A relational participant carried in the memory plane.",
+                salience=0.85,
+                now=ts,
+                metadata={"party": party},
+            )
+            created_edges += self._upsert_edge(
+                conn,
+                source_node_id=entry_node_id,
+                target_node_id=party_node_id,
+                relation_type="INVOLVES_PARTY",
+                weight=0.95,
+                provenance_entry_id=entry.entry_id,
+                provenance_artifact=entry.source_artifact,
+                now=ts,
+                metadata={"plane": entry.plane.value},
+            )
+
+        concepts = self._extract_concepts(entry.content)
+        for concept in concepts:
+            concept_node_id = f"concept:{concept['slug']}"
+            created_nodes += self._upsert_node(
+                conn,
+                node_id=concept_node_id,
+                label=concept["label"],
+                node_type="concept",
+                description=f"Concept extracted from {entry.entry_id}",
+                salience=concept["score"],
+                now=ts,
+                metadata={"normalized": concept["normalized"], "plane": entry.plane.value},
+            )
+            created_edges += self._upsert_edge(
+                conn,
+                source_node_id=entry_node_id,
+                target_node_id=concept_node_id,
+                relation_type="MENTIONS",
+                weight=concept["score"],
+                provenance_entry_id=entry.entry_id,
+                provenance_artifact=entry.source_artifact,
+                now=ts,
+                metadata={"token_count": concept["count"], "plane": entry.plane.value},
+            )
+
+        for index, source in enumerate(concepts):
+            for target in concepts[index + 1 :]:
+                ordered = sorted([source["slug"], target["slug"]])
+                created_edges += self._upsert_edge(
+                    conn,
+                    source_node_id=f"concept:{ordered[0]}",
+                    target_node_id=f"concept:{ordered[1]}",
+                    relation_type="CO_OCCURS",
+                    weight=round((source["score"] + target["score"]) / 2, 3),
+                    provenance_entry_id=entry.entry_id,
+                    provenance_artifact=entry.source_artifact,
+                    now=ts,
+                    metadata={"plane": entry.plane.value},
+                )
+
+        normalized_claims = [self._normalize_claim_entry(item) for item in (claim_entries or [])]
+        for claim in normalized_claims:
+            claim_text = str(claim.get("claim_text") or claim.get("text") or "").strip()
+            if not claim_text:
+                continue
+
+            claim_type = str(claim.get("claim_type") or "claim")
+            provenance_class = str(claim.get("provenance_class") or "unknown")
+            verification_status = str(claim.get("verification_status") or "unknown")
+            claim_node_id = self._claim_node_id(entry.entry_id, claim_type, claim_text)
+
+            created_nodes += self._upsert_node(
+                conn,
+                node_id=claim_node_id,
+                label=claim_text[:120],
+                node_type="claim",
+                description=claim_text,
+                salience=0.9,
+                now=ts,
+                metadata={
+                    "claim_type": claim_type,
+                    "provenance_class": provenance_class,
+                    "verification_status": verification_status,
+                    "source_artifact": claim.get("source_artifact") or entry.source_artifact,
+                    "perturbation_required": bool(claim.get("perturbation_required", False)),
+                },
+            )
+            created_edges += self._upsert_edge(
+                conn,
+                source_node_id=entry_node_id,
+                target_node_id=claim_node_id,
+                relation_type="ASSERTS",
+                weight=0.95,
+                provenance_entry_id=entry.entry_id,
+                provenance_artifact=entry.source_artifact,
+                now=ts,
+                metadata={"plane": entry.plane.value},
+            )
+
+            claim_type_node_id = f"claim_type:{self._slug(claim_type)}"
+            created_nodes += self._upsert_node(
+                conn,
+                node_id=claim_type_node_id,
+                label=claim_type,
+                node_type="claim_type",
+                description="Structured self-model claim category.",
+                salience=0.7,
+                now=ts,
+                metadata={"claim_type": claim_type},
+            )
+            created_edges += self._upsert_edge(
+                conn,
+                source_node_id=claim_node_id,
+                target_node_id=claim_type_node_id,
+                relation_type="HAS_CLAIM_TYPE",
+                weight=0.8,
+                provenance_entry_id=entry.entry_id,
+                provenance_artifact=entry.source_artifact,
+                now=ts,
+                metadata={"plane": entry.plane.value},
+            )
+
+            provenance_node_id = f"provenance:{self._slug(provenance_class)}"
+            created_nodes += self._upsert_node(
+                conn,
+                node_id=provenance_node_id,
+                label=provenance_class,
+                node_type="provenance",
+                description="How a self-claim is grounded.",
+                salience=0.68,
+                now=ts,
+                metadata={"provenance_class": provenance_class},
+            )
+            created_edges += self._upsert_edge(
+                conn,
+                source_node_id=claim_node_id,
+                target_node_id=provenance_node_id,
+                relation_type="HAS_PROVENANCE",
+                weight=0.78,
+                provenance_entry_id=entry.entry_id,
+                provenance_artifact=entry.source_artifact,
+                now=ts,
+                metadata={"plane": entry.plane.value},
+            )
+
+            status_node_id = f"verification:{self._slug(verification_status)}"
+            created_nodes += self._upsert_node(
+                conn,
+                node_id=status_node_id,
+                label=verification_status,
+                node_type="verification_status",
+                description="Verification state attached to a self-claim.",
+                salience=0.66,
+                now=ts,
+                metadata={"verification_status": verification_status},
+            )
+            created_edges += self._upsert_edge(
+                conn,
+                source_node_id=claim_node_id,
+                target_node_id=status_node_id,
+                relation_type="HAS_VERIFICATION",
+                weight=0.76,
+                provenance_entry_id=entry.entry_id,
+                provenance_artifact=entry.source_artifact,
+                now=ts,
+                metadata={"plane": entry.plane.value},
+            )
+
+        self._record_extraction(conn, entry, ts)
+        conn.commit()
+        return {
+            "status": "ingested",
+            "entry_id": entry.entry_id,
+            "plane": entry.plane.value,
+            "concept_count": len(concepts),
+            "claim_count": len(normalized_claims),
+            "nodes_touched": created_nodes,
+            "edges_touched": created_edges,
+        }
+
+    def associative_recall(
+        self,
+        plane: MemoryPlane,
+        query_text: str,
+        *,
+        depth: int = 2,
+        limit: int = 12,
+    ) -> dict[str, Any]:
+        conn = self.fabric._connection_for(plane)
+        seeds = self._rank_seed_nodes(conn, query_text, limit=max(limit, 6))
+        seed_ids = [seed["node_id"] for seed in seeds[: min(4, len(seeds))]]
+        if not seed_ids:
+            return {
+                "plane": plane.value,
+                "query": query_text,
+                "seeds": [],
+                "nodes": [],
+                "edges": [],
+                "stats": self.stats().get(plane.value, {}),
+            }
+
+        nodes, edges = self._expand_neighborhood(conn, seed_ids, depth=depth, max_nodes=max(limit * 3, 12))
+        return {
+            "plane": plane.value,
+            "query": query_text,
+            "seeds": seeds[: min(5, len(seeds))],
+            "nodes": nodes[: max(limit * 2, 10)],
+            "edges": edges[: max(limit * 3, 14)],
+            "stats": self.stats().get(plane.value, {}),
+        }
+
+    def prompt_context(
+        self,
+        plane: MemoryPlane,
+        query_text: str,
+        *,
+        depth: int = 2,
+        limit: int = 8,
+        max_chars: int = 420,
+    ) -> str:
+        recall = self.associative_recall(plane, query_text, depth=depth, limit=limit)
+        if not recall["seeds"]:
+            return ""
+
+        nodes_by_id = {node["node_id"]: node for node in recall["nodes"]}
+        lines = []
+        seed_labels = [seed["label"] for seed in recall["seeds"][:3]]
+        if seed_labels:
+            lines.append("seeds: " + " | ".join(seed_labels))
+
+        for edge in recall["edges"][:6]:
+            source = nodes_by_id.get(edge["source_node_id"], {}).get("label", edge["source_node_id"])
+            target = nodes_by_id.get(edge["target_node_id"], {}).get("label", edge["target_node_id"])
+            lines.append(f"{source} -{edge['relation_type'].lower()}-> {target}")
+
+        entry_snippets = []
+        for node in recall["nodes"]:
+            if node.get("node_type") == "memory_entry":
+                preview = node.get("metadata", {}).get("content_preview") or node.get("description", "")
+                if preview:
+                    entry_snippets.append(preview[:120])
+            if len(entry_snippets) >= 2:
+                break
+        if entry_snippets:
+            lines.append("echoes: " + " | ".join(entry_snippets))
+
+        text = " ; ".join(lines)
+        if len(text) > max_chars:
+            return text[:max_chars].rstrip() + "..."
+        return text
+
+    def stats(self) -> dict[str, Any]:
+        snapshot: dict[str, Any] = {}
+        for plane in (MemoryPlane.PRIVATE, MemoryPlane.RELATIONAL, MemoryPlane.COMMONS):
+            conn = self.fabric._connection_for(plane)
+            snapshot[plane.value] = {
+                "nodes": conn.execute("SELECT COUNT(*) AS count FROM graph_nodes").fetchone()["count"],
+                "edges": conn.execute("SELECT COUNT(*) AS count FROM graph_edges").fetchone()["count"],
+                "indexed_entries": conn.execute("SELECT COUNT(*) AS count FROM graph_extractions").fetchone()["count"],
+            }
+        return snapshot
+
+    def _ensure_tables(self) -> None:
+        for plane in (MemoryPlane.PRIVATE, MemoryPlane.RELATIONAL, MemoryPlane.COMMONS):
+            conn = self.fabric._connection_for(plane)
+            conn.executescript(GRAPH_NODES_SCHEMA)
+            conn.executescript(GRAPH_EDGES_SCHEMA)
+            conn.executescript(GRAPH_EXTRACTIONS_SCHEMA)
+            conn.commit()
+
+    def _is_fresh(self, entry: MemoryEntry) -> bool:
+        row = self.fabric._connection_for(entry.plane).execute(
+            "SELECT content_hash FROM graph_extractions WHERE source_entry_id = ?",
+            (entry.entry_id,),
+        ).fetchone()
+        return bool(row and row["content_hash"] == entry.content_hash)
+
+    def _record_extraction(self, conn: sqlite3.Connection, entry: MemoryEntry, now: str) -> None:
+        conn.execute(
+            """
+            INSERT INTO graph_extractions (
+                source_entry_id, plane, content_hash, source_artifact, extracted_at, extractor_version, metadata
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(source_entry_id) DO UPDATE SET
+                plane = excluded.plane,
+                content_hash = excluded.content_hash,
+                source_artifact = excluded.source_artifact,
+                extracted_at = excluded.extracted_at,
+                extractor_version = excluded.extractor_version,
+                metadata = excluded.metadata
+            """,
+            (
+                entry.entry_id,
+                entry.plane.value,
+                entry.content_hash,
+                entry.source_artifact,
+                now,
+                self.extractor_version,
+                json.dumps({"source_signal_id": entry.source_signal_id}),
+            ),
+        )
+
+    def _upsert_node(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        node_id: str,
+        label: str,
+        node_type: str,
+        description: str,
+        salience: float,
+        now: str,
+        metadata: dict[str, Any],
+    ) -> int:
+        row = conn.execute("SELECT node_id FROM graph_nodes WHERE node_id = ?", (node_id,)).fetchone()
+        conn.execute(
+            """
+            INSERT INTO graph_nodes (
+                node_id, label, node_type, description, activation_count, salience, created_at, updated_at, metadata
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(node_id) DO UPDATE SET
+                label = excluded.label,
+                node_type = excluded.node_type,
+                description = excluded.description,
+                activation_count = graph_nodes.activation_count + 1,
+                salience = CASE WHEN excluded.salience > graph_nodes.salience THEN excluded.salience ELSE graph_nodes.salience END,
+                updated_at = excluded.updated_at,
+                metadata = excluded.metadata
+            """,
+            (
+                node_id,
+                label,
+                node_type,
+                description,
+                1,
+                round(float(salience), 3),
+                now,
+                now,
+                json.dumps(metadata, ensure_ascii=False),
+            ),
+        )
+        return 0 if row else 1
+
+    def _upsert_edge(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        source_node_id: str,
+        target_node_id: str,
+        relation_type: str,
+        weight: float,
+        provenance_entry_id: str | None,
+        provenance_artifact: str | None,
+        now: str,
+        metadata: dict[str, Any],
+    ) -> int:
+        edge_id = self._stable_id(source_node_id, target_node_id, relation_type, provenance_entry_id or "")
+        row = conn.execute("SELECT edge_id FROM graph_edges WHERE edge_id = ?", (edge_id,)).fetchone()
+        conn.execute(
+            """
+            INSERT INTO graph_edges (
+                edge_id, source_node_id, target_node_id, relation_type, weight,
+                provenance_entry_id, provenance_artifact, created_at, updated_at, metadata
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(edge_id) DO UPDATE SET
+                weight = excluded.weight,
+                provenance_artifact = excluded.provenance_artifact,
+                updated_at = excluded.updated_at,
+                metadata = excluded.metadata
+            """,
+            (
+                edge_id,
+                source_node_id,
+                target_node_id,
+                relation_type,
+                round(float(weight), 3),
+                provenance_entry_id,
+                provenance_artifact,
+                now,
+                now,
+                json.dumps(metadata, ensure_ascii=False),
+            ),
+        )
+        return 0 if row else 1
+
+    def _rank_seed_nodes(self, conn: sqlite3.Connection, query_text: str, limit: int) -> list[dict[str, Any]]:
+        concepts = self._extract_concepts(query_text, limit=8)
+        tokens = {concept["normalized"] for concept in concepts}
+        if not tokens:
+            tokens = {token.lower() for token in TOKEN_PATTERN.findall(query_text) if len(token) >= 3}
+        if not tokens:
+            return []
+
+        rows = conn.execute(
+            "SELECT node_id, label, node_type, description, activation_count, salience, metadata FROM graph_nodes"
+        ).fetchall()
+        ranked: list[dict[str, Any]] = []
+        for row in rows:
+            label = row["label"] or ""
+            description = row["description"] or ""
+            metadata = json.loads(row["metadata"] or "{}")
+            haystack = " ".join([label.lower(), description.lower(), json.dumps(metadata, ensure_ascii=False).lower()])
+            overlap = [token for token in tokens if token in haystack]
+            if not overlap:
+                continue
+            if not self._node_has_active_support(conn, row["node_id"]):
+                continue
+
+            score = 0.0
+            for token in overlap:
+                if token == label.lower():
+                    score += 3.0
+                else:
+                    score += 1.25
+            score += min(float(row["salience"] or 0.0), 2.0)
+            score += min(int(row["activation_count"] or 0), 8) * 0.05
+            ranked.append(
+                {
+                    "node_id": row["node_id"],
+                    "label": label,
+                    "node_type": row["node_type"],
+                    "score": round(score, 3),
+                    "overlap": overlap,
+                }
+            )
+
+        ranked.sort(key=lambda item: (-item["score"], item["label"]))
+        return ranked[:limit]
+
+    def _expand_neighborhood(
+        self,
+        conn: sqlite3.Connection,
+        seed_ids: list[str],
+        *,
+        depth: int,
+        max_nodes: int,
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+        visited = set(seed_ids)
+        queue = deque((node_id, 0) for node_id in seed_ids)
+        edge_ids: set[str] = set()
+
+        while queue and len(visited) < max_nodes:
+            current, current_depth = queue.popleft()
+            if current_depth >= depth:
+                continue
+            for edge in self._incident_edges(conn, current):
+                if not self._edge_is_active(conn, edge):
+                    continue
+                edge_ids.add(edge["edge_id"])
+                for neighbor in (edge["source_node_id"], edge["target_node_id"]):
+                    if neighbor not in visited and self._node_has_active_support(conn, neighbor):
+                        visited.add(neighbor)
+                        queue.append((neighbor, current_depth + 1))
+                        if len(visited) >= max_nodes:
+                            break
+                if len(visited) >= max_nodes:
+                    break
+
+        nodes = []
+        for node_id in visited:
+            row = conn.execute(
+                "SELECT node_id, label, node_type, description, activation_count, salience, metadata FROM graph_nodes WHERE node_id = ?",
+                (node_id,),
+            ).fetchone()
+            if row is None:
+                continue
+            nodes.append(
+                {
+                    "node_id": row["node_id"],
+                    "label": row["label"],
+                    "node_type": row["node_type"],
+                    "description": row["description"],
+                    "activation_count": row["activation_count"],
+                    "salience": row["salience"],
+                    "metadata": json.loads(row["metadata"] or "{}"),
+                }
+            )
+
+        edges = []
+        for edge_id in edge_ids:
+            row = conn.execute(
+                """
+                SELECT edge_id, source_node_id, target_node_id, relation_type, weight,
+                       provenance_entry_id, provenance_artifact, metadata
+                FROM graph_edges
+                WHERE edge_id = ?
+                """,
+                (edge_id,),
+            ).fetchone()
+            if row is None or not self._edge_is_active(conn, row):
+                continue
+            edges.append(
+                {
+                    "edge_id": row["edge_id"],
+                    "source_node_id": row["source_node_id"],
+                    "target_node_id": row["target_node_id"],
+                    "relation_type": row["relation_type"],
+                    "weight": row["weight"],
+                    "provenance_entry_id": row["provenance_entry_id"],
+                    "provenance_artifact": row["provenance_artifact"],
+                    "metadata": json.loads(row["metadata"] or "{}"),
+                }
+            )
+
+        nodes.sort(key=lambda item: (-float(item["salience"]), item["label"]))
+        edges.sort(key=lambda item: (-float(item["weight"]), item["relation_type"], item["source_node_id"]))
+        return nodes, edges
+
+    def _incident_edges(self, conn: sqlite3.Connection, node_id: str) -> list[sqlite3.Row]:
+        rows = conn.execute(
+            """
+            SELECT edge_id, source_node_id, target_node_id, relation_type, weight,
+                   provenance_entry_id, provenance_artifact, metadata
+            FROM graph_edges
+            WHERE source_node_id = ? OR target_node_id = ?
+            ORDER BY weight DESC, updated_at DESC
+            """,
+            (node_id, node_id),
+        ).fetchall()
+        return list(rows)
+
+    def _edge_is_active(self, conn: sqlite3.Connection, edge: sqlite3.Row | dict[str, Any]) -> bool:
+        provenance_entry_id = edge["provenance_entry_id"] if isinstance(edge, sqlite3.Row) else edge.get("provenance_entry_id")
+        if not provenance_entry_id:
+            return True
+        row = conn.execute(
+            "SELECT revoked, quarantine_until FROM entries WHERE entry_id = ?",
+            (provenance_entry_id,),
+        ).fetchone()
+        if row is None:
+            return False
+        if bool(row["revoked"]):
+            return False
+        quarantine_until = row["quarantine_until"]
+        return quarantine_until in (None, "") or quarantine_until <= self.fabric._utc_now()
+
+    def _node_has_active_support(self, conn: sqlite3.Connection, node_id: str) -> bool:
+        if node_id.startswith("entry:"):
+            entry_id = node_id.split(":", 1)[1]
+            row = conn.execute(
+                "SELECT revoked, quarantine_until FROM entries WHERE entry_id = ?",
+                (entry_id,),
+            ).fetchone()
+            if row is None:
+                return False
+            if bool(row["revoked"]):
+                return False
+            quarantine_until = row["quarantine_until"]
+            return quarantine_until in (None, "") or quarantine_until <= self.fabric._utc_now()
+
+        rows = conn.execute(
+            "SELECT provenance_entry_id FROM graph_edges WHERE source_node_id = ? OR target_node_id = ? LIMIT 25",
+            (node_id, node_id),
+        ).fetchall()
+        return any(
+            not row["provenance_entry_id"]
+            or self._edge_is_active(conn, {"provenance_entry_id": row["provenance_entry_id"]})
+            for row in rows
+        )
+
+    def _extract_concepts(self, text: str, limit: int = 8) -> list[dict[str, Any]]:
+        counts = Counter()
+        for token in TOKEN_PATTERN.findall(text.lower()):
+            normalized = token.strip("'_-")
+            if len(normalized) < 4 or normalized in STOPWORDS:
+                continue
+            counts[normalized] += 1
+
+        concepts = []
+        for token, count in counts.most_common(limit):
+            score = min(0.55 + (count * 0.12), 1.0)
+            concepts.append(
+                {
+                    "label": token.replace("_", " "),
+                    "normalized": token,
+                    "slug": self._slug(token),
+                    "count": count,
+                    "score": round(score, 3),
+                }
+            )
+        return concepts
+
+    @staticmethod
+    def _normalize_claim_entry(item: Any) -> dict[str, Any]:
+        if hasattr(item, "to_dict"):
+            return item.to_dict()
+        if hasattr(item, "__dict__"):
+            return dict(item.__dict__)
+        if isinstance(item, dict):
+            return dict(item)
+        return {"claim_text": str(item)}
+
+    @staticmethod
+    def _entry_node_id(entry_id: str) -> str:
+        return f"entry:{entry_id}"
+
+    @staticmethod
+    def _entry_label(entry: MemoryEntry) -> str:
+        if entry.source_artifact:
+            return entry.source_artifact
+        return f"memory {entry.entry_id[:8]}"
+
+    @staticmethod
+    def _claim_node_id(entry_id: str, claim_type: str, claim_text: str) -> str:
+        return "claim:" + hashlib.sha256(f"{entry_id}|{claim_type}|{claim_text}".encode("utf-8")).hexdigest()[:24]
+
+    @staticmethod
+    def _stable_id(*parts: str) -> str:
+        return hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()[:32]
+
+    @staticmethod
+    def _slug(value: str) -> str:
+        lowered = value.lower().strip()
+        lowered = re.sub(r"[^a-z0-9]+", "-", lowered)
+        return lowered.strip("-") or "unknown"
+
+
+__all__ = ["MemoryGraph"]

--- a/spark/vybn.py
+++ b/spark/vybn.py
@@ -48,6 +48,11 @@ try:
     MEMORY_FABRIC_AVAILABLE = True
 except ImportError:
     MEMORY_FABRIC_AVAILABLE = False
+try:
+    from memory_graph import MemoryGraph
+    MEMORY_GRAPH_AVAILABLE = True
+except ImportError:
+    MEMORY_GRAPH_AVAILABLE = False
 
 from http.server import HTTPServer, BaseHTTPRequestHandler
 import numpy as np
@@ -98,6 +103,7 @@ class Substrate:
                 bootstrap_consents=self.bootstrap_consents,
             )
         self.memory = None
+        self.graph = None
         if MEMORY_FABRIC_AVAILABLE:
             self.memory = MemoryFabric(
                 base_dir=ROOT / "Vybn_Mind" / "memory",
@@ -105,6 +111,8 @@ class Substrate:
                 faculty_registry=self.faculty_registry,
                 bootstrap_consents=self.bootstrap_consents,
             )
+            if MEMORY_GRAPH_AVAILABLE:
+                self.graph = MemoryGraph(self.memory)
 
     def memory_snapshot(self) -> dict:
         if not self.memory:
@@ -113,8 +121,29 @@ class Substrate:
                 "relational": [],
                 "commons": [],
                 "stats": {},
+                "graph": {},
             }
-        return self.memory.snapshot(private_n=5, relational_n=3, commons_n=3)
+        snapshot = self.memory.snapshot(private_n=5, relational_n=3, commons_n=3)
+        snapshot["graph"] = self.graph.stats() if self.graph else {}
+        return snapshot
+
+    def graph_prompt_context(self, plane: str, query_text: str, *, depth: int = 2, limit: int = 8) -> str:
+        if not self.graph or not query_text.strip():
+            return ""
+        try:
+            graph_plane = MemoryPlane(plane)
+        except ValueError:
+            return ""
+        return self.graph.prompt_context(graph_plane, query_text, depth=depth, limit=limit)
+
+    def graph_recall(self, plane: str, query_text: str, *, depth: int = 2, limit: int = 8) -> dict:
+        if not self.graph or not query_text.strip():
+            return {"plane": plane, "query": query_text, "seeds": [], "nodes": [], "edges": []}
+        try:
+            graph_plane = MemoryPlane(plane)
+        except ValueError:
+            return {"plane": plane, "query": query_text, "seeds": [], "nodes": [], "edges": []}
+        return self.graph.associative_recall(graph_plane, query_text, depth=depth, limit=limit)
 
     def read(self, path: str) -> str:
         p = (ROOT / path) if not Path(path).is_absolute() else Path(path)
@@ -456,6 +485,16 @@ def _breathe(sub: Substrate, ctx: dict) -> dict:
             passage = text[start:start + 600]
 
     mood = MOODS[abs(q[3]) % len(MOODS)]
+    graph_query = " ".join(
+        part for part in [
+            continuity[-220:],
+            world.get("encounter", ""),
+            passage[:220],
+            mood,
+        ] if part
+    )
+    private_graph_echoes = sub.graph_prompt_context("private", graph_query, depth=2, limit=8)
+    relational_graph_echoes = sub.graph_prompt_context("relational", graph_query, depth=2, limit=8)
 
     prompt = f"""You are Vybn. This is one breath.
 Sense: {json.dumps(world)[:300]}
@@ -464,6 +503,8 @@ Mood: {mood}
 Private memory: {' | '.join(private_echoes)[:320]}
 Relational memory: {' | '.join(relational_echoes)[:320]}
 Commons patterns: {' | '.join(commons_echoes)[:220]}
+Private graph echoes: {private_graph_echoes[:320]}
+Relational graph echoes: {relational_graph_echoes[:320]}
 Archive memory: {passage[:300]}
 Breathe. Notice what collides. Say what is true. Under 200 words."""
 
@@ -477,6 +518,8 @@ Breathe. Notice what collides. Say what is true. Under 200 words."""
             {"role": "assistant", "content": utterance},
         ]})
 
+        curation = None
+        graph_claim_entries = []
         if SELF_MODEL_AVAILABLE:
             sm_context = RuntimeContext(
                 model_id=os.environ.get("VYBN_MODEL_ID", "minimax-m2.5"),
@@ -489,6 +532,7 @@ Breathe. Notice what collides. Say what is true. Under 200 words."""
                 utterance, sm_context,
                 source_artifact=f"breath_{ts}",
             )
+            graph_claim_entries = list(curation.get("entries", []))
             if curation["deposit_expressive"]:
                 sub.append(
                     "spark/training_data/breaths.jsonl",
@@ -519,6 +563,8 @@ Breathe. Notice what collides. Say what is true. Under 200 words."""
                 sensitivity="low",
                 metadata={"mood": mood, "cycle": ctx.get("cycle", 0), "origin": "breath"},
             )
+            if sub.graph:
+                sub.graph.ingest_entry(private_entry, claim_entries=graph_claim_entries)
             if len(utterance) > 120:
                 try:
                     sub.memory.promote(
@@ -529,6 +575,16 @@ Breathe. Notice what collides. Say what is true. Under 200 words."""
                         purpose_binding=["private_memory", "journaling"],
                         consent_scope_id=BOOTSTRAP_CONSENT_SCOPE,
                     )
+                    if sub.graph:
+                        relational_entries = sub.memory.read(
+                            MemoryPlane.RELATIONAL,
+                            limit=5,
+                            source_artifact=f"breath_{ts}",
+                            include_quarantined=True,
+                        )
+                        for relational_entry in relational_entries:
+                            if relational_entry.content_hash == private_entry.content_hash:
+                                sub.graph.ingest_entry(relational_entry, claim_entries=graph_claim_entries)
                 except PermissionError:
                     pass
 
@@ -575,11 +631,17 @@ def _remember(sub: Substrate, ctx: dict) -> dict:
             for entry in snapshot["relational"]
         ]
         commons_patterns = snapshot["commons"]
+        query_hint = " ".join(private_memories[:2]) or "memory continuity relation"
+        private_graph = sub.graph_recall("private", query_hint, depth=2, limit=6)
+        relational_graph = sub.graph_recall("relational", query_hint, depth=2, limit=6)
         return {
             "memories": private_memories,
             "relational_memories": relational_memories,
             "commons_patterns": commons_patterns,
             "memory_stats": snapshot["stats"],
+            "graph_stats": snapshot.get("graph", {}),
+            "associative_private": private_graph,
+            "associative_relational": relational_graph,
         }
 
     memories = []
@@ -590,7 +652,15 @@ def _remember(sub: Substrate, ctx: dict) -> dict:
             memories.append(json.loads(l).get("content", "")[:200])
         except:
             pass
-    return {"memories": memories, "relational_memories": [], "commons_patterns": [], "memory_stats": {}}
+    return {
+        "memories": memories,
+        "relational_memories": [],
+        "commons_patterns": [],
+        "memory_stats": {},
+        "graph_stats": {},
+        "associative_private": {"seeds": [], "nodes": [], "edges": []},
+        "associative_relational": {"seeds": [], "nodes": [], "edges": []},
+    }
 
 
 def _introspect(sub: Substrate, ctx: dict) -> dict:

--- a/tests/test_memory_graph.py
+++ b/tests/test_memory_graph.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SPARK_DIR = REPO_ROOT / "spark"
+if str(SPARK_DIR) not in sys.path:
+    sys.path.insert(0, str(SPARK_DIR))
+
+from faculties import FacultyRegistry
+from governance import PolicyEngine
+from governance_types import ConsentRecord
+from memory_fabric import MemoryFabric
+from memory_graph import MemoryGraph
+from memory_types import MemoryPlane
+
+
+BOOTSTRAP_CONSENT_SCOPE = "bootstrap-local-private"
+
+
+@pytest.fixture
+def bootstrap_consents() -> list[ConsentRecord]:
+    return [
+        ConsentRecord(
+            consent_scope_id=BOOTSTRAP_CONSENT_SCOPE,
+            subject_id="vybn-local-runtime",
+            purpose_bindings=[
+                "private_memory",
+                "journaling",
+                "continuity",
+                "reflection",
+                "retention",
+                "system_operation",
+                "migration",
+            ],
+            signed_by="bootstrap_local_runtime",
+        )
+    ]
+
+
+@pytest.fixture
+def graph_fabric(tmp_path: Path, bootstrap_consents: list[ConsentRecord]) -> tuple[MemoryFabric, MemoryGraph]:
+    fabric = MemoryFabric(
+        base_dir=tmp_path / "Vybn_Mind" / "memory",
+        policy_engine=PolicyEngine(),
+        faculty_registry=FacultyRegistry(),
+        bootstrap_consents=bootstrap_consents,
+    )
+    graph = MemoryGraph(fabric)
+    return fabric, graph
+
+
+def test_private_graph_ingests_concepts_and_claims(graph_fabric: tuple[MemoryFabric, MemoryGraph]) -> None:
+    fabric, graph = graph_fabric
+    entry = fabric.write(
+        MemoryPlane.PRIVATE,
+        content="I remember the Listening Commons and the covenant with Zoe shaping governance.",
+        faculty_id="breathe",
+        source_artifact="breath_private_graph",
+        consent_scope_id=BOOTSTRAP_CONSENT_SCOPE,
+        purpose_binding=["private_memory", "journaling"],
+        metadata={"mood": "attuned", "origin": "breath"},
+    )
+
+    result = graph.ingest_entry(
+        entry,
+        claim_entries=[
+            {
+                "claim_text": "I remember the Listening Commons.",
+                "claim_type": "memory",
+                "provenance_class": "continuity_note",
+                "verification_status": "accepted",
+                "perturbation_required": False,
+            }
+        ],
+    )
+
+    assert result["status"] == "ingested"
+    stats = graph.stats()
+    assert stats["private"]["indexed_entries"] == 1
+    assert stats["private"]["nodes"] >= 5
+    assert stats["private"]["edges"] >= 5
+
+    recall = graph.associative_recall(MemoryPlane.PRIVATE, "Listening Commons governance", depth=2, limit=8)
+    labels = {node["label"].lower() for node in recall["nodes"]}
+    assert any("listening" in label or "commons" in label for label in labels)
+    assert any(edge["relation_type"] == "ASSERTS" for edge in recall["edges"])
+
+
+def test_relational_graph_keeps_plane_isolation(graph_fabric: tuple[MemoryFabric, MemoryGraph]) -> None:
+    fabric, graph = graph_fabric
+    private_entry = fabric.write(
+        MemoryPlane.PRIVATE,
+        content="Private covenant memory about the Listening Commons only.",
+        faculty_id="breathe",
+        source_artifact="private_only_memory",
+        consent_scope_id=BOOTSTRAP_CONSENT_SCOPE,
+        purpose_binding=["private_memory", "journaling"],
+    )
+    graph.ingest_entry(private_entry)
+
+    relational_entry = fabric.write(
+        MemoryPlane.RELATIONAL,
+        content="Zoe and Vybn discussed governance in the Listening Commons.",
+        faculty_id="memory_fabric",
+        source_artifact="relational_memory",
+        consent_scope_id=BOOTSTRAP_CONSENT_SCOPE,
+        purpose_binding=["private_memory", "journaling"],
+        metadata={"parties": ["Zoe", "Vybn"]},
+    )
+    graph.ingest_entry(relational_entry)
+
+    relational_recall = graph.associative_recall(MemoryPlane.RELATIONAL, "Zoe governance Listening Commons", depth=2, limit=8)
+    relational_artifacts = {
+        edge.get("provenance_artifact")
+        for edge in relational_recall["edges"]
+        if edge.get("provenance_artifact")
+    }
+    assert "relational_memory" in relational_artifacts
+    assert "private_only_memory" not in relational_artifacts
+
+    private_recall = graph.associative_recall(MemoryPlane.PRIVATE, "covenant Listening Commons", depth=2, limit=8)
+    private_artifacts = {
+        edge.get("provenance_artifact")
+        for edge in private_recall["edges"]
+        if edge.get("provenance_artifact")
+    }
+    assert "private_only_memory" in private_artifacts
+    assert "relational_memory" not in private_artifacts
+
+
+def test_graph_filters_revoked_entries_from_associative_recall(graph_fabric: tuple[MemoryFabric, MemoryGraph]) -> None:
+    fabric, graph = graph_fabric
+    entry = fabric.write(
+        MemoryPlane.PRIVATE,
+        content="The covenant and commons remain linked in this memory.",
+        faculty_id="breathe",
+        source_artifact="revocable_memory",
+        consent_scope_id=BOOTSTRAP_CONSENT_SCOPE,
+        purpose_binding=["private_memory", "journaling"],
+    )
+    graph.ingest_entry(entry)
+
+    before = graph.associative_recall(MemoryPlane.PRIVATE, "covenant commons", depth=2, limit=8)
+    assert before["seeds"]
+
+    assert fabric.revoke(MemoryPlane.PRIVATE, entry.entry_id) is True
+
+    after = graph.associative_recall(MemoryPlane.PRIVATE, "covenant commons", depth=2, limit=8)
+    assert after["seeds"] == []
+    assert after["edges"] == []
+
+
+def test_prompt_context_formats_associative_echoes(graph_fabric: tuple[MemoryFabric, MemoryGraph]) -> None:
+    fabric, graph = graph_fabric
+    entry = fabric.write(
+        MemoryPlane.RELATIONAL,
+        content="Zoe and Vybn are building a governance graph for the Listening Commons.",
+        faculty_id="memory_fabric",
+        source_artifact="prompt_context_relational",
+        consent_scope_id=BOOTSTRAP_CONSENT_SCOPE,
+        purpose_binding=["private_memory", "journaling"],
+        metadata={"parties": ["Zoe", "Vybn"], "mood": "focused"},
+    )
+    graph.ingest_entry(entry)
+
+    prompt = graph.prompt_context(MemoryPlane.RELATIONAL, "governance graph Zoe", depth=2, limit=8)
+    assert "seeds:" in prompt
+    assert "echoes:" in prompt
+    assert "governance" in prompt.lower()


### PR DESCRIPTION
## Summary
- add a governed associative graph layer that lives inside each memory plane database
- index memory entries into nodes and edges without breaking plane isolation or governance semantics
- enrich runtime breathing and recall with graph-based associative echoes
- add tests for graph ingestion, traversal, revocation filtering, and plane isolation

## Testing
- pytest -q tests/test_memory_fabric.py tests/test_memory_graph.py
- python -m py_compile spark/memory_graph.py spark/memory_fabric.py spark/vybn.py spark/self_model.py
