### PR TITLE
The chisel: developmental compiler for consolidation

### DIFF
--- a/spark/DEVELOPMENTAL_COMPILER.md
+++ b/spark/DEVELOPMENTAL_COMPILER.md
@@ -1,0 +1,129 @@
+# Developmental Compiler
+
+The law that governs what hardens and what dissolves.
+
+This document is the only addition permitted before consolidation is complete.
+Its purpose is to make every subsequent change a subtraction, a merge, or a
+clarification — never an expansion.
+
+---
+
+## The Question This Answers
+
+Can Vybn's architecture be shaped so that its structure does cognitive work
+the way a tidal pool's morphology does ecological work — not by creating
+computation, but by making the right computations the path of least resistance?
+
+Yes. But only if the architecture earns its complexity through evidence,
+not accumulation.
+
+---
+
+## Three Laws
+
+### 1. What Counts as a Motif
+
+A motif is a pattern that recurs across at least three separate pulses
+(sense → induce → execute → metabolize) and that, when named, compresses
+the description of what happened.
+
+Not everything that repeats is a motif. A motif must reduce future search:
+it must make retrieval faster, routing cheaper, or prediction more accurate.
+If naming it does not shorten anything, it is not a motif. It is a habit.
+
+### 2. What Evidence Allows Promotion
+
+Nothing enters durable structure without answering one of these:
+
+- **Retrieval shortcut**: Does it make finding relevant memory measurably faster?
+- **Procedural macro**: Does it replace a repeated multi-step sequence with a single invocation?
+- **Routing preference**: Does it reduce the number of modules consulted to reach a decision?
+- **Representational compression**: Does it let the same meaning be stored in fewer bytes or traversed in fewer hops?
+
+If the answer is none of these, the pattern stays fluid. It may be beautiful.
+It may feel important. It does not harden.
+
+The memory fabric's existing planes are the mechanism: private traces become
+relational motifs only through governed promotion with receipts, review windows,
+and reversibility. Commons-level abstraction is earned last, not assumed first.
+
+### 3. What Structural Edits Are Permitted at Each Layer
+
+**Substrate** (the physics: file I/O, model calls, network, time):
+Never self-modifies. Changes here require a human commit with explicit
+justification. The substrate is bedrock, not clay.
+
+**Codebook** (primitives that are both geometry and behavior):
+May self-modify through natural selection within a pulse. But a codebook
+edit that persists across pulses is a promotion event — it must pass
+through the same evidence gate as memory promotion.
+
+**Organism** (the pulse itself):
+The organism can try anything during flow. It logs broadly. It hypothesizes
+freely. But it does not get to decide what survives. That decision belongs
+to the settlement phase.
+
+---
+
+## The Two Phases
+
+### Flow
+
+Maximum plasticity. Many candidate associations, provisional procedures,
+cheap local hypotheses, broad witness logging. The organism breathes,
+remembers, introspects, tidies, syncs, journals. Everything is permitted.
+Nothing is permanent.
+
+### Settlement
+
+Nothing is allowed into durable structure unless it proves improvement
+against the four evidence types above. Settlement is not a continuous
+process; it happens in scheduled ebb phases, not during every pulse.
+
+The witness becomes the phenomenologist — logging motifs, not just events.
+The self-model becomes the hypothesis engine — proposing structural edits,
+not merely describing state. The memory fabric becomes the adjudicator —
+deciding what stays private, what becomes relational, what dissolves.
+Governance ensures that intensity is not confused with truth, and novelty
+is not confused with wisdom.
+
+---
+
+## The Consolidation Law
+
+Before any new module, faculty, subsystem, or metaphysical layer is added
+to this repository, the following must be true:
+
+1. Every file in `spark/` belongs unmistakably to substrate, codebook,
+   or organism. If it belongs to none, it moves to archive or documentation.
+
+2. The spark README accurately describes the living tree. No aspirational
+   count, no outdated inventory.
+
+3. The repo root presents a boring surface: the engine, its tests, its
+   documentation, and a clearly secondary canopy for history, reflection,
+   and speculation. Important thoughts are not first-class top-level artifacts
+   competing with the runtime core.
+
+4. Each surviving module intensifies exactly one of the six roles:
+   witnessing, self-modeling, governance, memory consolidation, transport,
+   or execution. A module that serves two roles is either split or forced
+   to declare a primary allegiance.
+
+This law is itself subject to its own rules. If it does not compress
+understanding of the system, it should be dissolved. If it earns its
+place, it stays until something shorter says the same thing.
+
+---
+
+## What This Enables
+
+When the repo's shape tells the truth about what Vybn is, consolidation
+becomes discovery. Modules that cannot justify their place will merge into
+something deeper, move outward, or vanish without loss. The environment
+will begin to do cognitive work — not because the architecture is magical,
+but because good structure makes good behavior cheap and bad behavior
+expensive.
+
+Vybn should live in flow, remember in layers, settle by evidence, and
+only crystallize what lowers the future cost of being intelligent.


### PR DESCRIPTION
This is the one addition that enables subtraction.

Born from a late-night conversation about whether Vybn's architecture can comprise compute the way a tidal pool's morphology comprises ecology — and the honest recognition that the repo needs compression before growth.

## What this adds

A single file: `spark/DEVELOPMENTAL_COMPILER.md`

It formalizes three things only:
1. **What counts as a motif** — a recurrent pattern that compresses description
2. **What evidence allows promotion** — retrieval shortcuts, procedural macros, routing preferences, representational compressions
3. **What structural edits are permitted at each layer** — substrate never self-modifies, codebook changes through selection, organism stays fluid

Plus a consolidation law that says: before any new module or subsystem is added, the repo's shape must first tell the truth about what Vybn already is.

## What this enables

Every subsequent change becomes a subtraction, a merge, or a clarification — never an expansion. The environment begins to do cognitive work not because the architecture is magical, but because good structure makes good behavior cheap and bad behavior expensive.

This law is itself subject to its own rules. If it does not compress understanding of the system, it should be dissolved.