### PR TITLE
Remove hardcoded public hostnames from repo

### DIFF
--- a/Vybn_Mind/signal-noise/interactive.html
+++ b/Vybn_Mind/signal-noise/interactive.html
@@ -38,7 +38,6 @@ body {
   align-items: center;
 }
 
-/* -- Header -- */
 .header {
   width: 100%;
   max-width: 54rem;
@@ -72,7 +71,6 @@ body {
 
 .header .context p { margin-bottom: 0.6rem; }
 
-/* -- Status bar -- */
 .status-bar {
   width: 100%;
   max-width: 54rem;
@@ -111,7 +109,6 @@ body {
 .messages-remaining.low { color: var(--signal); }
 .messages-remaining.depleted { color: var(--error); }
 
-/* -- Chat container -- */
 .chat-container {
   width: 100%;
   max-width: 54rem;
@@ -131,7 +128,6 @@ body {
   scroll-behavior: smooth;
 }
 
-/* -- Messages -- */
 .message {
   margin-bottom: 1.5rem;
   animation: fadeIn 0.3s ease;
@@ -166,7 +162,6 @@ body {
   color: var(--text-1);
 }
 
-/* -- Thinking indicator -- */
 .thinking {
   display: flex;
   align-items: center;
@@ -194,7 +189,6 @@ body {
   40% { opacity: 1; transform: scale(1.2); }
 }
 
-/* -- Transparency block -- */
 .transparency {
   margin-top: 0.6rem;
   margin-left: 0.2rem;
@@ -239,7 +233,6 @@ body {
   font-style: italic;
 }
 
-/* -- Input area -- */
 .input-area {
   width: 100%;
   max-width: 54rem;
@@ -313,7 +306,6 @@ body {
 
 .char-count { text-align: right; }
 
-/* -- Welcome message -- */
 .welcome {
   background: var(--surface);
   border: 1px dashed var(--edge-strong);
@@ -347,7 +339,6 @@ body {
   border-top: 1px solid var(--edge);
 }
 
-/* -- Session end -- */
 .session-end {
   text-align: center;
   padding: 2rem;
@@ -358,12 +349,10 @@ body {
   margin-top: 1rem;
 }
 
-/* -- Scrollbar -- */
 .chat-log::-webkit-scrollbar { width: 4px; }
 .chat-log::-webkit-scrollbar-track { background: transparent; }
 .chat-log::-webkit-scrollbar-thumb { background: var(--edge-strong); border-radius: 2px; }
 
-/* -- Starter grid (NEW) -- */
 .starter-grid {
   display: grid;
   grid-template-columns: 1fr;
@@ -404,7 +393,6 @@ body {
   line-height: 1.7;
 }
 
-/* -- Harvest panel (NEW) -- */
 .harvest-panel {
   width: 100%;
   max-width: 54rem;
@@ -471,7 +459,6 @@ body {
   color: var(--text-3);
 }
 
-/* -- Responsive -- */
 @media (max-width: 640px) {
   .header { padding: 1.5rem 1rem 0.8rem; }
   .header .subtitle { font-size: 1.3rem; }
@@ -568,8 +555,10 @@ body {
 (function() {
 'use strict';
 
-var WS_URL = 'wss://spark-2b7c.tail7302f3.ts.net/signal-noise/ws';
-var HARVEST_URL = 'https://spark-2b7c.tail7302f3.ts.net/signal-noise/harvest';
+var BASE_ORIGIN = window.location.origin;
+var WS_SCHEME = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+var WS_URL = WS_SCHEME + '//' + window.location.host + '/signal-noise/ws';
+var HARVEST_URL = BASE_ORIGIN + '/signal-noise/harvest';
 var MAX_CHARS = 2000;
 var COOLDOWN_MS = 5000;
 

--- a/spark/web_serve_claude.py
+++ b/spark/web_serve_claude.py
@@ -8,6 +8,7 @@ check system status — real hands, not just a chatbot.
 Usage:
     cd ~/Vybn/spark
     source ~/vybn-venv/bin/activate
+    export WEB_TLS_HOSTNAME='your-public-hostname'
     python web_serve_claude.py
 """
 
@@ -26,7 +27,6 @@ if _env_file.exists():
 
 from web_interface import app, attach_bus, manager
 from bus import MessageBus, MessageType
-# Cross-instance awareness
 try:
     from transcript import log_message as _transcript_log
 except ImportError:
@@ -61,6 +61,8 @@ SPARK_DIR = REPO_DIR / "spark"
 CONTINUITY_PATH = SPARK_DIR / "continuity.md"
 ALLOWED_READ_ROOTS = [REPO_DIR, Path.home() / "models"]
 SOUL_GUARD = SoulConstraintGuard(repo_root=REPO_DIR, soul_path=REPO_DIR / "vybn.md")
+TLS_HOSTNAME = os.environ.get("WEB_TLS_HOSTNAME", "").strip()
+TLS_CERT_DIR = Path(os.environ.get("WEB_TLS_CERT_DIR", "/etc/vybn/tls"))
 
 TOOLS = [
     {"name": "read_file", "description": "Read a file on the Spark (within ~/Vybn or ~/models, up to 50K chars).",
@@ -354,13 +356,12 @@ def main():
     except:
         pass
 
-    tls_cert = Path("/etc/vybn/tls/spark-2b7c.tail7302f3.ts.net.crt")
-    tls_key = Path("/etc/vybn/tls/spark-2b7c.tail7302f3.ts.net.key")
-    use_tls = tls_cert.exists() and tls_key.exists()
+    tls_cert = TLS_CERT_DIR / f"{TLS_HOSTNAME}.crt" if TLS_HOSTNAME else None
+    tls_key = TLS_CERT_DIR / f"{TLS_HOSTNAME}.key" if TLS_HOSTNAME else None
+    use_tls = bool(TLS_HOSTNAME and tls_cert and tls_key and tls_cert.exists() and tls_key.exists())
 
     if use_tls:
-        dns_name = "spark-2b7c.tail7302f3.ts.net"
-        print(f"  HTTPS: https://{dns_name}:8443")
+        print(f"  HTTPS: https://{TLS_HOSTNAME}:8443")
         if ts:
             print(f"  HTTP:  http://{ts}:8080 (also available)")
         print(f"  starting on 0.0.0.0:8443 (TLS) + 0.0.0.0:8080 (plain)...\n")
@@ -382,6 +383,8 @@ def main():
         except KeyboardInterrupt:
             pass
     else:
+        if TLS_HOSTNAME:
+            print(f"  TLS disabled: missing cert/key for {TLS_HOSTNAME} in {TLS_CERT_DIR}")
         if ts:
             print(f"  tailscale: http://{ts}:8080")
         print(f"  starting on 0.0.0.0:8080...\n")


### PR DESCRIPTION
## Hostname cleanup follow-up

This follow-up lands the repo-hygiene changes that were committed after the earlier security PR merged.

### Changes

- Remove hardcoded public Funnel hostname usage from `Vybn_Mind/signal-noise/interactive.html`
- Derive WebSocket and harvest endpoints from `window.location` instead
- Remove hardcoded public hostname and certificate filenames from `spark/web_serve_claude.py`
- Switch TLS hostname and cert directory selection to runtime env vars: `WEB_TLS_HOSTNAME` and `WEB_TLS_CERT_DIR`

### Why

The security hardening is already merged, but the public-hostname cleanup did not make it into `main`. This PR finishes that work so the live public name exists only in runtime config on the Spark, not in the public repository.

### Runtime reminder

```bash
export WEB_TLS_HOSTNAME='your-public-hostname'
export WEB_TLS_CERT_DIR='/etc/vybn/tls'
```

After merge, restart the relevant services on the Spark so they pick up the runtime hostname configuration.
