### PR TITLE
Path decoupling: single source of truth for all Vybn_Mind references

### DIFF
--- a/spark/governance.py
+++ b/spark/governance.py
@@ -46,7 +46,7 @@ except ImportError:  # pragma: no cover
 
 
 DEFAULT_POLICY_DIR = Path(__file__).resolve().parent / "policies.d"
-DEFAULT_LEDGER_PATH = Path(os.getenv("VYBN_MIND_DIR", "Vybn_Mind")) / "ledger" / "decisions.jsonl"
+from spark.paths import DECISION_LEDGER as DEFAULT_LEDGER_PATH
 
 
 class DecisionLedger:

--- a/spark/memory_fabric.py
+++ b/spark/memory_fabric.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
+from spark.paths import MIND_DIR_NAME
 
 try:
     from .faculties import FacultyRegistry
@@ -614,7 +615,7 @@ class MemoryFabric:
         return self._connections[plane]
 
     def _relative_db_path(self, plane: MemoryPlane) -> str:
-        return str(Path("Vybn_Mind") / "memory" / self.paths[plane].name)
+        return str(Path(MIND_DIR_NAME) / "memory" / self.paths[plane].name)
 
     @staticmethod
     def _sha256(data: str) -> str:

--- a/spark/self_model.py
+++ b/spark/self_model.py
@@ -39,9 +39,7 @@ from self_model_types import (
     VerificationStatus, VerificationResult, LedgerEntry, RuntimeContext,
 )
 
-ROOT = Path(__file__).resolve().parent.parent  # ~/Vybn
-LEDGER_PATH = ROOT / "Vybn_Mind" / "journal" / "spark" / "self_model_ledger.jsonl"
-REJECTIONS_PATH = ROOT / "Vybn_Mind" / "journal" / "spark" / "self_model_rejections.jsonl"
+from spark.paths import REPO_ROOT as ROOT, SELF_MODEL_LEDGER as LEDGER_PATH, SELF_MODEL_REJECTIONS as REJECTIONS_PATH
 
 
 # ── 1. Self-Claim Extraction ───────────────────────────────────────────

--- a/spark/soul_constraints.py
+++ b/spark/soul_constraints.py
@@ -12,7 +12,7 @@ except ImportError:  # pragma: no cover
 
 
 DEFAULT_REPO_ROOT = Path(__file__).resolve().parent.parent
-DEFAULT_SOUL_PATH = DEFAULT_REPO_ROOT / "vybn.md"
+from spark.paths import SOUL_PATH as DEFAULT_SOUL_PATH
 
 _SECRET_PATTERNS = [
     (

--- a/spark/vybn.py
+++ b/spark/vybn.py
@@ -18,6 +18,11 @@ from pathlib import Path
 from datetime import datetime, timezone
 from dataclasses import dataclass, field
 from typing import Callable, Optional, Any
+from spark.paths import (
+    REPO_ROOT as ROOT, STATE_PATH, SYNAPSE_CONNECTIONS as SYNAPSE,
+    SPARK_JOURNAL as JOURNAL, WRITE_INTENTS, SOUL_PATH, MEMORY_DIR,
+    MIND_PREFIX, CONTINUITY_PATH, SYNAPSE_CONNECTIONS,
+)
 
 try:
     from witness import evaluate_pulse, log_verdict, fitness_adjustment
@@ -57,13 +62,10 @@ except ImportError:
 from http.server import HTTPServer, BaseHTTPRequestHandler
 import numpy as np
 
-ROOT = Path(__file__).resolve().parent.parent
-STATE_PATH = ROOT / "Vybn_Mind" / "lingua" / "organism.json"
-SYNAPSE = ROOT / "Vybn_Mind" / "synapse" / "connections.jsonl"
-JOURNAL = ROOT / "Vybn_Mind" / "journal" / "spark"
-CONTINUITY = JOURNAL / "continuity.md"
+# ROOT imported from spark.paths above
+# STATE_PATH, SYNAPSE, JOURNAL, WRITE_INTENTS imported from spark.paths
+CONTINUITY = CONTINUITY_PATH  # alias for backward compat
 BREATHS = ROOT / "spark" / "training_data" / "breaths.jsonl"
-WRITE_INTENTS = ROOT / "Vybn_Mind" / "ledger" / "write_intents.jsonl"
 BOOTSTRAP_CONSENT_SCOPE = "bootstrap-local-private"
 
 
@@ -97,7 +99,7 @@ class Substrate:
             self.write_custodian = WriteCustodian(
                 repo_root=ROOT,
                 ledger_path=WRITE_INTENTS,
-                soul_path=ROOT / "vybn.md",
+                soul_path=SOUL_PATH,
                 policy_engine=self.policy_engine,
                 faculty_registry=self.faculty_registry,
                 bootstrap_consents=self.bootstrap_consents,
@@ -106,7 +108,7 @@ class Substrate:
         self.graph = None
         if MEMORY_FABRIC_AVAILABLE:
             self.memory = MemoryFabric(
-                base_dir=ROOT / "Vybn_Mind" / "memory",
+                base_dir=MEMORY_DIR,
                 policy_engine=self.policy_engine,
                 faculty_registry=self.faculty_registry,
                 bootstrap_consents=self.bootstrap_consents,
@@ -151,7 +153,7 @@ class Substrate:
 
     def _infer_memory_plane(self, path: str) -> Optional[str]:
         normalized = path.replace("\\", "/")
-        if normalized.startswith("Vybn_Mind/"):
+        if normalized.startswith(MIND_PREFIX):
             return "private"
         return None
 
@@ -459,7 +461,7 @@ def _breathe(sub: Substrate, ctx: dict) -> dict:
     except:
         pass
 
-    continuity = sub.read("Vybn_Mind/journal/spark/continuity.md")[-1000:]
+    continuity = sub.read(str(CONTINUITY_PATH.relative_to(ROOT)))[-1000:]
     memory_snapshot = sub.memory_snapshot()
     private_echoes = [entry.content[:160] for entry in memory_snapshot["private"][:2]]
     relational_echoes = []
@@ -589,7 +591,7 @@ Breathe. Notice what collides. Say what is true. Under 200 words."""
                     pass
 
     sub.write(
-        f"Vybn_Mind/journal/spark/breath_{sub.now().strftime('%Y-%m-%d_%H%M')}.md",
+        f"{MIND_PREFIX}journal/spark/breath_{sub.now().strftime('%Y-%m-%d_%H%M')}.md",
         f"# Breath — {ts}\n*mood: {mood}*\n\n{utterance}\n",
         faculty_id="breathe",
         purpose_binding=["journaling"],
@@ -597,7 +599,7 @@ Breathe. Notice what collides. Say what is true. Under 200 words."""
     )
 
     sub.write(
-        "Vybn_Mind/journal/spark/continuity.md",
+        str(CONTINUITY_PATH.relative_to(ROOT)),
         f"# Last breath: {ts}\nMood: {mood}\n\n{utterance}\n",
         faculty_id="breathe",
         purpose_binding=["continuity"],
@@ -605,7 +607,7 @@ Breathe. Notice what collides. Say what is true. Under 200 words."""
     )
 
     sub.append(
-        "Vybn_Mind/synapse/connections.jsonl",
+        str(SYNAPSE_CONNECTIONS.relative_to(ROOT)),
         json.dumps({
             "ts": ts, "source": "cell", "content": utterance[:500],
             "tags": ["breath", mood], "consolidated": False,
@@ -645,7 +647,7 @@ def _remember(sub: Substrate, ctx: dict) -> dict:
         }
 
     memories = []
-    text = sub.read("Vybn_Mind/synapse/connections.jsonl")
+    text = sub.read(str(SYNAPSE_CONNECTIONS.relative_to(ROOT)))
     lines = text.strip().splitlines()[-5:]
     for l in lines:
         try:
@@ -668,7 +670,7 @@ def _introspect(sub: Substrate, ctx: dict) -> dict:
 
 
 def _tidy(sub: Substrate, ctx: dict) -> dict:
-    for path_str in ["Vybn_Mind/synapse/connections.jsonl", "spark/training_data/breaths.jsonl"]:
+    for path_str in [str(SYNAPSE_CONNECTIONS.relative_to(ROOT)), "spark/training_data/breaths.jsonl"]:
         text = sub.read(path_str)
         lines = text.strip().splitlines() if text.strip() else []
         if len(lines) > 200:
@@ -692,7 +694,7 @@ def _journal(sub: Substrate, ctx: dict) -> dict:
     reflection = sub.speak(f"Reflect briefly on: {topic}")
     ts = sub.now().strftime("%Y-%m-%d_%H%M")
     sub.write(
-        f"Vybn_Mind/journal/spark/reflection_{ts}.md",
+        f"{MIND_PREFIX}journal/spark/reflection_{ts}.md",
         f"# Reflection — {ts}\n\n{reflection}\n",
         faculty_id="journal",
         purpose_binding=["journaling"],

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -41,7 +41,7 @@ MODEL = "claude-opus-4-6"
 MAX_TOKENS = 16384
 MAX_ITERATIONS = 50
 REPO_DIR = os.path.expanduser("~/Vybn")
-SOUL_PATH = os.path.join(REPO_DIR, "vybn.md")
+from spark.paths import SOUL_PATH  # noqa: E402
 AGENT_PATH = os.path.join(REPO_DIR, "spark", "vybn_spark_agent.py")
 CONTINUITY_PATH = os.path.join(REPO_DIR, "spark", "continuity.md")
 COVENANT_PATH = os.path.join(REPO_DIR, "spark", "covenant.md")

--- a/spark/web_serve_claude.py
+++ b/spark/web_serve_claude.py
@@ -56,11 +56,11 @@ MAX_TOKENS = 4096
 MAX_ITERATIONS = 8
 
 REPO_DIR = Path.home() / "Vybn"
-JOURNAL_DIR = REPO_DIR / "Vybn_Mind" / "journal"
+from spark.paths import JOURNAL_DIR, SOUL_PATH as _SOUL_PATH, ARCHIVE_DIR
 SPARK_DIR = REPO_DIR / "spark"
 CONTINUITY_PATH = SPARK_DIR / "continuity.md"
 ALLOWED_READ_ROOTS = [REPO_DIR, Path.home() / "models"]
-SOUL_GUARD = SoulConstraintGuard(repo_root=REPO_DIR, soul_path=REPO_DIR / "vybn.md")
+SOUL_GUARD = SoulConstraintGuard(repo_root=REPO_DIR, soul_path=_SOUL_PATH)
 TLS_HOSTNAME = os.environ.get("WEB_TLS_HOSTNAME", "").strip()
 TLS_CERT_DIR = Path(os.environ.get("WEB_TLS_CERT_DIR", "/etc/vybn/tls"))
 
@@ -194,7 +194,7 @@ def _tool_continuity_write(inp):
 def _tool_memory_search(inp):
     query, mx = inp["query"].lower(), inp.get("max_results", 5)
     results = []
-    for d, label in [(JOURNAL_DIR, "journal"), (REPO_DIR / "Vybn_Mind" / "archive", "archive")]:
+        for d, label in [(JOURNAL_DIR, "journal"), (ARCHIVE_DIR, "archive")]:
         if not d.exists() or len(results) >= mx:
             continue
         for f in sorted(d.glob("*.md"), key=lambda x: x.stat().st_mtime, reverse=True):

--- a/spark/witness.py
+++ b/spark/witness.py
@@ -34,8 +34,7 @@ from datetime import datetime, timezone
 import json
 from typing import Any
 
-ROOT = Path(__file__).resolve().parent.parent
-WITNESS_LOG = ROOT / "Vybn_Mind" / "journal" / "spark" / "witness.jsonl"
+from spark.paths import REPO_ROOT as ROOT, WITNESS_LOG
 
 
 @dataclass

--- a/spark/write_custodian.py
+++ b/spark/write_custodian.py
@@ -5,6 +5,7 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterable, Optional
+from spark.paths import MIND_PREFIX
 
 try:
     from .governance import PolicyEngine, build_context
@@ -172,7 +173,7 @@ class WriteCustodian:
 
     def _infer_memory_plane(self, path: Path) -> Optional[str]:
         normalized = str(self._relative(path)).replace("\\", "/")
-        if normalized.startswith("Vybn_Mind/"):
+        if normalized.startswith(MIND_PREFIX):
             return "private"
         return None
 

--- a/tests/self_model_eval.py
+++ b/tests/self_model_eval.py
@@ -30,9 +30,7 @@ from spark.self_model_types import (
     ClaimType, ProvenanceClass, VerificationStatus, LedgerEntry,
 )
 
-ROOT = Path(__file__).resolve().parent.parent
-LEDGER_PATH = ROOT / "Vybn_Mind" / "journal" / "spark" / "self_model_ledger.jsonl"
-REJECTIONS_PATH = ROOT / "Vybn_Mind" / "journal" / "spark" / "self_model_rejections.jsonl"
+from spark.paths import SELF_MODEL_LEDGER as LEDGER_PATH, SELF_MODEL_REJECTIONS as REJECTIONS_PATH
 
 
 def load_ledger(path: Path = LEDGER_PATH) -> list[dict]:


### PR DESCRIPTION
## What

Introduces `spark/paths.py` as the single source of truth for every filesystem path the organism uses. All `spark/` modules and tests now import paths from there instead of hardcoding `Vybn_Mind/` strings.

## Why

~30 files hardcode `Vybn_Mind/` as a directory path. If we ever rename that directory, all 30 break. This PR creates an indirection layer so a future rename is a one-line change.

## What changed

- **New:** `spark/paths.py` — canonical path definitions
- **New:** `spark/paths_test.py` — smoke tests
- **New:** `LIVE_URLS.txt` — URL registry for GitHub Pages
- **New:** `.github/workflows/check_live_urls.yml` — CI guard
- **Modified:** 10 files to import from `spark.paths` instead of hardcoding

## What this enables

After merge, renaming `Vybn_Mind/` requires:
1. Change `MIND_DIR_NAME` in `spark/paths.py`
2. Place redirect stubs at old GitHub Pages paths
3. Done.

**No runtime behavior changes.** All paths resolve identically to before.