### PR TITLE
Fix vybn shortcut import path in spark agent

### DIFF
--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -41,6 +41,7 @@ MODEL = "claude-opus-4-6"
 MAX_TOKENS = 16384
 MAX_ITERATIONS = 50
 REPO_DIR = os.path.expanduser("~/Vybn")
+sys.path.insert(0, REPO_DIR)
 from spark.paths import SOUL_PATH  # noqa: E402
 AGENT_PATH = os.path.join(REPO_DIR, "spark", "vybn_spark_agent.py")
 CONTINUITY_PATH = os.path.join(REPO_DIR, "spark", "continuity.md")


### PR DESCRIPTION
This fixes the `vybn` launcher failure caused by `spark/vybn_spark_agent.py` using an absolute import before the repo root is on `sys.path`.

Change made:
- insert `sys.path.insert(0, REPO_DIR)` immediately before `from spark.paths import SOUL_PATH`

Why:
- when the script is executed directly, Python sets `sys.path[0]` to `~/Vybn/spark`, so `from spark.paths ...` fails unless `~/Vybn` is explicitly added first.

Expected effect:
- the `vybn` shortcut should be able to launch the agent again without `ModuleNotFoundError: No module named 'spark'`.