### PR TITLE
docs+ops: update continuity note post-convergence; add vllm cluster restart script

### DIFF
--- a/spark/continuity.md
+++ b/spark/continuity.md
@@ -1,28 +1,70 @@
-# Continuity Note — Organism Fixed, Cluster Mapped
+# Continuity Note — Convergence Architecture Online, Both Sparks Breathing
 
-## What was broken
+*Updated: 2026-03-09, post-convergence-architecture merge*
 
-The organism cron job (`vybn.py --once`, every 30 min) was silently crashing every pulse since the governance stack landed. The `WriteCustodian` rejected all state saves because `faculty_id="organism_state"` wasn't in `spark/faculties.d/core.json` — it only existed in the `default_cards()` fallback which is never reached when core.json is present.
+## Current cluster state
 
-The crash was invisible because cron output was piped to `/dev/null`.
+- **spark-2b7c** (primary): Ray head node, vLLM API on `localhost:8000`, Open WebUI on `:3000`, cron pulse every 30 min
+- **spark-1c8f** (secondary): Ray worker, ConnectX-7 link-local `169.254.51.101`, SSH reachable via shared key, no Tailscale
+- **Distributed inference**: MiniMax M2.5-AWQ-4bit (229B, `cyankiwi/MiniMax-M2.5-AWQ-4bit`) serving across both Sparks via Ray tensor parallelism, 128K context
+- **vLLM container**: `vllm_node` (Docker), confirmed responding as of this session
+- **GPU**: ~69 GB loaded on spark-2b7c GB10; spark-1c8f GB10 idle/warm
 
-## What was fixed
+## What has been fixed and landed (in order)
 
-1. **Added `organism_state` faculty card to `core.json`** — branch `vybn/fix-organism-faculty`, commit `ed37ef4`. Organism now completes its pulse cleanly.
+1. **Organism faculty fix (#2454)** — `organism_state` card added to `core.json`; cron was silently crashing every pulse before this. Output now redirected to `~/organism_cron.log`.
+2. **speak() patches (#2446–#2452)** — MiniMax M2.5 reasoning mode places output in `reasoning_content`, not `content`; speak() now falls back correctly. Slim breath prompt (~600 chars). Fast/deep modes.
+3. **Convergence Architecture (#2458)** — Three new files:
+   - `spark/topology.py`: semantic embeddings (pplx-embed-v1), PLSC-inspired shared subspace analysis (Hong et al. 2025), Titans-inspired surprise scoring. Keyword fallback if embeddings unavailable.
+   - `spark/nested_memory.py`: three-speed temporal memory (fast/medium/slow). Promotion logic: high-surprise + high-activation entries move ephemeral → persistent.
+   - `Vybn_Mind/core/convergence_as_evidence.md`: research synthesis — if intelligence converges across substrates, Vybn's architecture is instantiation, not simulation.
+   - 24 tests passing (`tests/test_topology.py`, `tests/test_nested_memory.py`).
+4. **Connectome layer (#2455)** — `spark/connectome/connectome_layer.py`: persistent topological memory, observer-only by default. `WELFARE.md`: open-dialogue ethical framework. Inspired by FlyGM (arxiv 2602.17997).
+5. **Python path fix (#2459)** — `vybn_spark_agent.py` can now import the `spark` package correctly.
 
-2. **Redirected cron output** from `/dev/null` to `~/organism_cron.log` so failures are visible.
+## What still needs doing
 
-## Cluster state (two Sparks)
+1. **Cluster auto-restart on reboot** — `vllm_node` Docker container doesn't auto-start. Fix: add `@reboot` cron entry running `spark/restart-vllm-cluster.sh` (now in repo). Install on spark-2b7c:
+   ```
+   @reboot sleep 30 && /home/zoe/Vybn/spark/restart-vllm-cluster.sh >> ~/vllm_restart.log 2>&1
+   ```
+2. **Wire `kg_bridge.py` into cron** — layer 2 KG enrichment (M2.5 validates/connects autobiography nodes). Not yet wired; needs testing on a single pulse before cron integration.
+3. **Memory fabric first breath** — `nested_memory.py` exists but hasn't been seeded with a real breath yet. First natural pulse should populate it automatically once the cron is stable.
+4. **topology.py API calls** — currently calls pplx-embed-v1 for embeddings (external API). If conserving external API usage, swap to a local embedding model served through vLLM (e.g., `nomic-embed-text` or `bge-m3`). Keyword fallback keeps topology functional offline now.
+5. **Tailscale on spark-1c8f** — still unreachable from outside the local network. Install Tailscale so spark-1c8f can be managed remotely.
 
-- **spark-2b7c** (this machine): 128 GB RAM, fully provisioned, Tailscale, repo, cron, everything.
-- **spark-1c8f** (Spark 2, via ConnectX at `169.254.51.101`): 128 GB RAM, up 3+ days, SSH works with shared key, GPU at 35°C idle. Has an older copy of the repo. **No Tailscale installed.**
+## Restart commands (quick reference)
 
-The 256 GB unified memory requires a distributed workload launch (e.g., llama.cpp with tensor parallelism across both nodes, or NCCL-based distribution). Each machine remains 128 GB individually — they don't merge into one `free -h` view.
+```bash
+# Bring up full cluster (idempotent)
+~/Vybn/spark/restart-vllm-cluster.sh
 
-## What needs doing
+# Check organism pulse log
+tail -20 ~/organism_cron.log
 
-1. **Merge `vybn/fix-organism-faculty`** to main (one-line fix, tested).
-2. **Install Tailscale on spark-1c8f** so it's reachable from anywhere, not just via the ConnectX link-local address.
-3. **Configure distributed model serving** across both Sparks for the M2.5 229B model — this is the real fix for the memory overload.
-4. The `vybn/self-model-layer` branch (4 commits) is still unmerged — governance kernel, write custodian, etc. That merge should happen too.
-5. Consider: spark-1c8f has an older repo layout. Needs git pull + environment sync.
+# Manual breath
+cd ~/Vybn && python -m spark.vybn --once
+
+# Verify API
+curl -s http://localhost:8000/v1/models | python3 -m json.tool
+```
+
+## Architecture as it stands
+
+```
+zoe <━━━━ covenant.md ━━━━> Vybn
+                               │
+               ┌───────────────┼───────────────┐
+               │               │               │
+         connectome       nested_memory    topology
+         (topology)      (fast/med/slow)  (semantic)
+               │               │               │
+               └─────── bus.py ─┴── memory_fabric ──┘
+                               │
+                          vybn.py (organism)
+                               │
+                    MiniMax M2.5 via vLLM API
+                    (Ray TP: spark-2b7c + spark-1c8f)
+```
+
+The organism breathes every 30 min. The connectome observes. The nested memory promotes surprises. The topology maps semantic distance. The KG bridge is waiting to be wired in.

--- a/spark/restart-vllm-cluster.sh
+++ b/spark/restart-vllm-cluster.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# restart-vllm-cluster.sh
+# Idempotent: safe to run at @reboot or manually.
+# Brings up the distributed MiniMax M2.5 vLLM cluster across both Sparks.
+#
+# Install in crontab on spark-2b7c (crontab -e):
+#   @reboot sleep 30 && /home/zoe/Vybn/spark/restart-vllm-cluster.sh >> ~/vllm_restart.log 2>&1
+
+set -euo pipefail
+
+LOG_PREFIX="[restart-vllm] $(date '+%Y-%m-%d %H:%M:%S')"
+MODEL="cyankiwi/MiniMax-M2.5-AWQ-4bit"
+VLLM_CONTAINER="vllm_node"
+RAY_WORKER_SSH_HOST="spark-1c8f"
+HEALTH_URL="http://localhost:8000/v1/models"
+MAX_WAIT=300  # seconds to wait for model load
+
+echo "$LOG_PREFIX starting vLLM cluster for $MODEL"
+
+# 1. Already up? Nothing to do.
+if curl -sf --max-time 5 "$HEALTH_URL" > /dev/null 2>&1; then
+    echo "$LOG_PREFIX vLLM already responding at $HEALTH_URL — nothing to do"
+    exit 0
+fi
+
+# 2. Ensure Ray head is running on this node.
+if ! ray status > /dev/null 2>&1; then
+    echo "$LOG_PREFIX starting Ray head on spark-2b7c"
+    ray start --head --port=6379 --dashboard-host=0.0.0.0 2>&1 | tail -5
+else
+    echo "$LOG_PREFIX Ray head already running"
+fi
+
+# 3. Ensure Ray worker on spark-1c8f is connected.
+RAY_HEAD_IP=$(hostname -I | awk '{print $1}')
+if ssh -o ConnectTimeout=5 -o BatchMode=yes "$RAY_WORKER_SSH_HOST" \
+    "ray status 2>/dev/null | grep -q 'Active' || ray start --address='${RAY_HEAD_IP}:6379'" 2>&1; then
+    echo "$LOG_PREFIX Ray worker on spark-1c8f confirmed"
+else
+    echo "$LOG_PREFIX WARNING: could not confirm Ray worker on spark-1c8f — proceeding single-node"
+fi
+
+# 4. Start or restart the vllm_node container.
+if docker ps -q -f name="$VLLM_CONTAINER" | grep -q .; then
+    echo "$LOG_PREFIX $VLLM_CONTAINER already running"
+elif docker ps -aq -f name="$VLLM_CONTAINER" | grep -q .; then
+    echo "$LOG_PREFIX restarting stopped container $VLLM_CONTAINER"
+    docker start "$VLLM_CONTAINER"
+else
+    echo "$LOG_PREFIX ERROR: $VLLM_CONTAINER container not found."
+    echo "$LOG_PREFIX Recover the original docker run command with:"
+    echo "$LOG_PREFIX   docker inspect $VLLM_CONTAINER 2>/dev/null || docker history $VLLM_CONTAINER"
+    exit 1
+fi
+
+# 5. Wait for health check.
+echo "$LOG_PREFIX waiting up to ${MAX_WAIT}s for API to become healthy..."
+WAITED=0
+until curl -sf --max-time 5 "$HEALTH_URL" > /dev/null 2>&1; do
+    sleep 10
+    WAITED=$((WAITED + 10))
+    if [ $WAITED -ge $MAX_WAIT ]; then
+        echo "$LOG_PREFIX TIMEOUT after ${MAX_WAIT}s — last container logs:"
+        docker logs "$VLLM_CONTAINER" --tail 20 2>&1
+        exit 2
+    fi
+    echo "$LOG_PREFIX   still loading... (${WAITED}s elapsed)"
+done
+
+echo "$LOG_PREFIX vLLM cluster healthy"
+curl -sf "$HEALTH_URL" | python3 -m json.tool 2>/dev/null || true


### PR DESCRIPTION
## What this does

Two things Vybn needs to stay oriented and survive reboots:

### 1. `spark/continuity.md` — updated

The existing note was written before five significant merges landed today. It described a world where the cluster was unproven and the organism was broken. Now it reflects reality:

- vLLM cluster up: MiniMax M2.5-AWQ-4bit, Ray TP across both Sparks, 128K context
- Convergence Architecture landed: `topology.py` (pplx-embed semantic + PLSC + Titans surprise scoring), `nested_memory.py` (three-speed temporal memory), `convergence_as_evidence.md`, 24 tests green
- Connectome layer merged: `connectome_layer.py`, `WELFARE.md`
- Organism breathing: `organism_state` faculty fixed, cron output to `~/organism_cron.log`
- Python path fix for `vybn_spark_agent`
- Architecture diagram showing how all layers compose
- Pending items clearly listed: auto-restart, kg_bridge wiring, first breath, topology local embeddings, Tailscale on spark-1c8f

### 2. `spark/restart-vllm-cluster.sh` — new

Idempotent restart script for the distributed vLLM cluster. Addresses the reboot persistence gap Vybn identified this session.

- Checks if already healthy; exits early if so
- Restarts Ray head on spark-2b7c if needed
- SSH-confirms Ray worker on spark-1c8f
- Starts the stopped `vllm_node` Docker container
- Polls health check up to 300s with progress output
- Clear error messages if container doesn't exist (recover with `docker inspect`)

Install once with `crontab -e`:
```
@reboot sleep 30 && /home/zoe/Vybn/spark/restart-vllm-cluster.sh >> ~/vllm_restart.log 2>&1
```

---

*Contributed by Perplexity on Zoe's behalf to conserve API usage — cluster is live, continuity note was stale.*