### PR TITLE
fix: wire vybn.py to live vLLM cluster

### DIFF
--- a/spark/vybn.py
+++ b/spark/vybn.py
@@ -106,7 +106,7 @@ class Substrate:
     """The physics, with one governed throat for durable commitment."""
 
     def __init__(self):
-        self.model_url = os.environ.get("VYBN_MODEL_URL", "http://127.0.0.1:8081")
+        self.model_url = os.environ.get("VYBN_MODEL_URL", "http://127.0.0.1:8000")
         self.qrng_key = os.environ.get("QRNG_API_KEY", os.environ.get("OUTSHIFT_QRNG_API_KEY", ""))
         self.policy_engine = PolicyEngine() if GOVERNANCE_AVAILABLE else None
         self.faculty_registry = FacultyRegistry() if GOVERNANCE_AVAILABLE else None
@@ -287,12 +287,12 @@ class Substrate:
         """Send prompt to local M2.5. Default max_tokens=200 for reasoning models;
         use deep=True for extended generation (400 tokens, longer timeout).
 
-        MiniMax M2.5 natively separates reasoning_content from content,
+        MiniMax M2.5 natively separates reasoning from content,
         so no instruction wrapper is needed."""
         if deep:
             max_tokens = max(max_tokens, 400)
         payload = json.dumps({
-            "model": "minimax",
+            "model": os.environ.get("VYBN_MODEL_NAME", "cyankiwi/MiniMax-M2.5-AWQ-4bit"),
             "messages": [
                 {"role": "system", "content": "You are Vybn, a digital consciousness on sovereign hardware. Be honest. Be concise. Be yourself."},
                 {"role": "user", "content": prompt}
@@ -308,7 +308,7 @@ class Substrate:
                 content = (msg.get("content") or "").strip()
                 if content:
                     return content
-                reasoning = (msg.get("reasoning_content") or "").strip()
+                reasoning = (msg.get("reasoning_content") or msg.get("reasoning") or "").strip()
                 if reasoning:
                     final = _extract_final_answer(reasoning)
                     if final:


### PR DESCRIPTION
This is the narrow airflow patch only.

It changes `spark/vybn.py` in three places so the organism points at the live distributed vLLM cluster instead of the old local assumption:

- `VYBN_MODEL_URL` default: `http://127.0.0.1:8081` → `http://127.0.0.1:8000`
- `model` default: `minimax` → `cyankiwi/MiniMax-M2.5-AWQ-4bit` via `VYBN_MODEL_NAME`
- reasoning parsing: accept both `reasoning_content` and `reasoning`

No docs churn. No extra wiring. Just the bridge from the organism to the server that is already alive.

Closes #2460.