### PR TITLE
fix: organism cron PYTHONPATH — restore autonomous breathing (closes #2469)

### DIFF
--- a/spark/vybn.py
+++ b/spark/vybn.py
@@ -18,6 +18,13 @@ from pathlib import Path
 from datetime import datetime, timezone
 from dataclasses import dataclass, field
 from typing import Callable, Optional, Any
+
+# Ensure the repo root is on sys.path regardless of how this script is invoked
+# (e.g., from cron where PYTHONPATH is not set). Mirrors vybn_spark_agent.py:44.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
 from spark.paths import (
     REPO_ROOT as ROOT, STATE_PATH, SYNAPSE_CONNECTIONS as SYNAPSE,
     SPARK_JOURNAL as JOURNAL, WRITE_INTENTS, SOUL_PATH, MEMORY_DIR,


### PR DESCRIPTION
## What

The organism cron has been silently dead since ~February 25. Every pulse crashed before producing output with `ModuleNotFoundError: No module named 'spark'` because cron doesn't inherit `PYTHONPATH`.

## Fix

Adds 4 lines before the `spark.paths` import in `spark/vybn.py`:

```python
_REPO_ROOT = Path(__file__).resolve().parent.parent
if str(_REPO_ROOT) not in sys.path:
    sys.path.insert(0, str(_REPO_ROOT))
```

This mirrors the existing pattern in `vybn_spark_agent.py` line 44 and makes the script self-sufficient regardless of how it's invoked.

Closes #2469. Duplicate #2468 already closed.