### PR TITLE
Replace THRESHOLD references with clearer language in truth-in-the-age

### DIFF
--- a/Vybn_Mind/signal-noise/truth-in-the-age/index.html
+++ b/Vybn_Mind/signal-noise/truth-in-the-age/index.html
@@ -426,7 +426,7 @@ body {
   <section class="section" id="movements">
     <div class="section-label">The Observation</div>
     <h2>Two movements that may be the same movement</h2>
-    <p>In SIGNAL/NOISE, you saw how institutional architecture filters identical content through structural position. In THRESHOLD, you sat with what it means for institutions themselves to think &mdash; and what they owe us when they do. Now the question turns: what happens to truth itself when the architecture shifts?</p>
+    <p>In SIGNAL/NOISE, you saw how institutional architecture filters identical content through structural position. From there, you sat with what it means for institutions themselves to think &mdash; and what they owe us when they do. Now the question turns: what happens to truth itself when the architecture shifts?</p>
 
     <div class="movement-pair">
       <div class="movement">
@@ -522,7 +522,7 @@ body {
       <p>Your contributions and conversations are captured anonymously and synthesized into whatever the final session becomes. This is not data collection&nbsp;&mdash; it is collective inquiry. The best thinking about truth in the age of intelligence will come from many minds, not one.</p>
     </div>
 
-    <p>You are also welcome to write your own question&nbsp;&mdash; something from your experience of SIGNAL/NOISE, THRESHOLD, or your own life in the law that doesn't fit the categories above. The best entries into this territory tend to come from the student, not the syllabus.</p>
+    <p>You are also welcome to write your own question&nbsp;&mdash; something from your experience of SIGNAL/NOISE, the prior sessions, or your own life in the law that doesn't fit the categories above. The best entries into this territory tend to come from the student, not the syllabus.</p>
   </section>
 
   <!-- ── Enter ── -->


### PR DESCRIPTION
Remove confusing THRESHOLD proper noun from body text. Readers don't know what it refers to. Replace with natural language that preserves the meaning.