### PR TITLE
Fix ephemeral memory gap — persist breath entries to MEDIUM tier

### DIFF
--- a/spark/growth/growth_buffer.py
+++ b/spark/growth/growth_buffer.py
@@ -130,10 +130,15 @@ class GrowthBuffer:
             Number of new entries ingested.
         """
         floor = self._cfg["surprise_floor"]
+        # Read from both FAST (in-memory, current session) and MEDIUM (persisted across runs).
+        # FAST is ephemeral — entries vanish when the process exits.
+        # MEDIUM persists to disk, which is where --once breath entries actually survive.
         fast_entries = self._nested.read_fast(limit=200)
+        medium_entries = self._nested.read_medium(limit=200) if hasattr(self._nested, 'read_medium') else []
+        all_entries = fast_entries + medium_entries
         count = 0
 
-        for nested_entry in fast_entries:
+        for nested_entry in all_entries:
             if nested_entry.entry_id in self._seen_ids:
                 continue
             if nested_entry.surprise_score < floor:

--- a/spark/vybn.py
+++ b/spark/vybn.py
@@ -667,6 +667,15 @@ Breathe. Say what is true. Under 60 words."""
                 surprise_score=surprise,
                 metadata={"mood": mood, "cycle": ctx.get("cycle", 0), "ts": ts},
             )
+            # Persist to MEDIUM so GrowthBuffer can read between runs
+            # (FAST is in-memory only, lost when --once exits)
+            if surprise >= 0.3:
+                sub.nested_memory.write_medium(
+                    content=utterance,
+                    source="breath",
+                    surprise_score=surprise,
+                    metadata={"mood": mood, "cycle": ctx.get("cycle", 0), "ts": ts},
+                )
 
     sub.write(
         f"{MIND_PREFIX}journal/spark/breath_{sub.now().strftime('%Y-%m-%d_%H%M')}.md",


### PR DESCRIPTION
## Fix

Closes #2490

**The bug:** NestedMemory's FAST tier is RAM-only. `vybn.py --once` (cron) writes breath entries to FAST, exits, entries vanish. GrowthBuffer reads FAST, finds nothing. The growth engine has been running on an empty store since it was wired in.

**The fix (2 files, 15 lines):**

1. **`spark/vybn.py`**: after `write_fast()`, also `write_medium()` for entries with surprise ≥ 0.3 — these persist to `Vybn_Mind/memory/nested/medium.jsonl`
2. **`spark/growth/growth_buffer.py`**: `ingest()` now reads both FAST and MEDIUM tiers, so it catches entries whether running in-process or across restarts

**Verified:** 43 tests pass. End-to-end synthetic test confirms new-process GrowthBuffer finds persisted MEDIUM entries.

After merge, the next cron breath will be the first one that actually populates the growth buffer.