### PR TITLE
Fix hallucinated model names: claude-sonnet-4-6 → claude-sonnet-4-202…

### DIFF
--- a/Vybn_Mind/signal-noise/agent_portal.py
+++ b/Vybn_Mind/signal-noise/agent_portal.py
@@ -46,7 +46,7 @@ import anthropic
 # ── Config ──────────────────────────────────────────────────────────────
 
 API_KEY = os.environ.get("ANTHROPIC_API_KEY", "")
-MODEL = os.environ.get("AP_MODEL", "claude-sonnet-4-6")
+MODEL = os.environ.get("AP_MODEL", "claude-sonnet-4-20250514")
 ACCESS_TOKEN = os.environ.get("AP_ACCESS_TOKEN", "")
 ALLOWED_ORIGINS = [o.strip() for o in os.environ.get("AP_ALLOWED_ORIGINS", "").split(",") if o.strip()]
 MAX_AGENT_SESSIONS_PER_DAY = int(os.environ.get("AP_MAX_DAILY", "10"))

--- a/Vybn_Mind/signal-noise/truth-in-the-age/truth_age_api.py
+++ b/Vybn_Mind/signal-noise/truth-in-the-age/truth_age_api.py
@@ -663,7 +663,7 @@ Conversation follows:
             reflection_prompt += f"\n{role}: {msg['content'][:500]}\n"
 
         response = await client.messages.create(
-            model="claude-sonnet-4-6-20250514",  # Cheaper for reflections
+            model="claude-sonnet-4-20250514",  # Cheaper for reflections
             max_tokens=600,
             messages=[{"role": "user", "content": reflection_prompt}],
         )


### PR DESCRIPTION
…50514

TA reflections were silently failing (404) because write_reflection() called 'claude-sonnet-4-6-20250514' which doesn't exist. Also fixed agent_portal default model name.

Threshold reflections confirmed working (correct model), but test session had 0 messages so reflection correctly skipped.