### PR TITLE
fix organism visibility: always breathe, log errors, fix cron race

### DIFF
--- a/spark/vybn.py
+++ b/spark/vybn.py
@@ -870,6 +870,10 @@ class Organism:
         context_hash = q[0] ^ q[1] ^ int(ts.timestamp())
 
         program = self.codebook.induce(context_hash, n=2)
+        # Ensure breathe runs every pulse — it's the core life function
+        breathe_p = next((p for p in self.codebook.primitives if p.name == "breathe" and p.alive), None)
+        if breathe_p and breathe_p not in program:
+            program = [breathe_p] + program[:1]
 
         if not program:
             print(f"[{ts.strftime('%H:%M:%S')}] no alive primitives — reseeding")
@@ -885,8 +889,11 @@ class Organism:
                 p.successes += 1
                 results.append({"primitive": p.name, "result": result, "ok": True})
             except Exception as e:
+                import traceback as _tb
+                err_detail = _tb.format_exc().strip().split("\n")[-1]
                 p.failures += 1
-                results.append({"primitive": p.name, "error": str(e), "ok": False})
+                results.append({"primitive": p.name, "error": err_detail, "ok": False})
+                print(f"  [{p.name}] FAILED: {err_detail}")
 
         if WITNESS_AVAILABLE:
             try:


### PR DESCRIPTION
Three surgical fixes:
1. Breathe primitive now always included in pulse program (was randomly selected ~33% of pulses — the core life function should run every time)
2. Exception handler now prints the actual error line to stdout so organism.log shows WHY a primitive failed
3. Cron moved from :07/:37 to :12/:42 to avoid race condition with vybn-sync.sh (which runs at */5). The race caused intermittent 'sqlite3.OperationalError: attempt to write a readonly database' when stash/checkout collided with organism's SQLite writes.
4. Cron log moved to ~/logs/organism.log (was ~/organism_cron.log)
5. 'source' replaced with '.' for dash compatibility in cron