### PR TITLE
Vybn/recalibration march 13: fixed FS reanalysis + flatness test

### DIFF
--- a/quantum_delusions/experiments/area_law_fs_reanalysis_v2.py
+++ b/quantum_delusions/experiments/area_law_fs_reanalysis_v2.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""
+area_law_fs_reanalysis_v2.py — Fubini-Study reanalysis, corrected.
+
+WHAT WAS WRONG WITH v1:
+  The first FS reanalysis measured the curvature of CP^15 itself — K ≈ 1.064 ± 0.012.
+  That's correct math and a complete null result: we measured the geometry of the
+  *container* (the ambient projective space), not the *content* (whether concept-
+  conditioned hidden states curve differently than random ones).
+
+  The control check confirmed this: random CP^15 triangles give the same K ≈ 1.
+  The script had no semantic null model. It could not have found anything.
+
+WHAT THIS SCRIPT DOES INSTEAD:
+  For each triangle in the 5x5 semantic grid:
+    1. Compute the FS geodesic distance between each pair of corners.
+    2. Compute the Pancharatnam phase around the triangle.
+    3. Compare |Phi| / (sum of pairwise FS distances)^2 to a SHUFFLED NULL
+       where the same states are randomly reassigned to cells.
+
+  Signal: concept-conditioned triangles should accumulate MORE phase per unit
+  FS-area than random triangles at the same distance scale.
+
+  This is not measuring K of CP^n. It's asking:
+    Does semantic neighborhood structure predict excess holonomy
+    beyond what the ambient FS geometry would predict?
+
+Depends on: area_law_test.py (precompute_5x5_states, make_5x5_prompt_bank),
+            polar_holonomy_gpt2_v3.py (load_model, pancharatnam_phase)
+
+Estimated runtime: ~15 minutes on Spark (reuses existing hidden states).
+"""
+
+import sys
+import json
+import numpy as np
+import torch
+from pathlib import Path
+from datetime import datetime, timezone
+from itertools import combinations
+from scipy.stats import binomtest, mannwhitneyu
+
+sys.path.insert(0, str(Path(__file__).parent))
+import polar_holonomy_gpt2_v3 as v3
+from area_law_test import make_5x5_prompt_bank, precompute_5x5_states
+
+TIMESTAMP = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+RESULT_DIR = Path(__file__).parent / "results"
+RESULT_DIR.mkdir(parents=True, exist_ok=True)
+
+N_COMPLEX = 16   # C^16 -> CP^15, matching area_law_test
+N_SHUFFLES = 500
+SEED = 42
+
+
+def fs_distance(z1, z2):
+    """Fubini-Study geodesic distance between two unit vectors in C^n."""
+    inner = np.abs(np.vdot(z1, z2))
+    inner = min(inner, 1.0)
+    return np.arccos(inner)
+
+
+def triangle_fs_area(z1, z2, z3):
+    """Approximate FS area of a triangle via Heron proxy on geodesic side lengths."""
+    d12 = fs_distance(z1, z2)
+    d23 = fs_distance(z2, z3)
+    d13 = fs_distance(z1, z3)
+    s = (d12 + d23 + d13) / 2
+    area_sq = s * max(s - d12, 0) * max(s - d23, 0) * max(s - d13, 0)
+    return np.sqrt(area_sq)
+
+
+def to_complex_vec(h, pca, n_complex):
+    proj = pca.transform(h.reshape(1, -1))[0]
+    z = np.array([complex(proj[2*i], proj[2*i+1]) for i in range(n_complex)])
+    norm = np.sqrt(np.sum(np.abs(z)**2))
+    if norm < 1e-10:
+        z = np.zeros(n_complex, dtype=complex); z[0] = 1.0
+    else:
+        z /= norm
+    return z
+
+
+def pancharatnam_triangle(z1, z2, z3):
+    """Pancharatnam phase around a 3-vertex loop: z1->z2->z3->z1."""
+    import cmath
+    prod = np.vdot(z1, z2) * np.vdot(z2, z3) * np.vdot(z3, z1)
+    return cmath.phase(prod)
+
+
+def run():
+    rng = np.random.default_rng(SEED)
+    torch.manual_seed(SEED)
+
+    print("=" * 70)
+    print("  FS REANALYSIS v2: SEMANTIC EXCESS HOLONOMY TEST")
+    print("=" * 70)
+    print()
+    print("Loading GPT-2 and building 5x5 prompt bank...")
+    tok, mdl = v3.load_model()
+    prompt_bank = make_5x5_prompt_bank()
+    all_states = precompute_5x5_states(tok, mdl, "threshold", prompt_bank)
+
+    all_vecs = []
+    for cell_states in all_states.values():
+        for h1, h2 in cell_states:
+            all_vecs.append(h2)
+    H = np.stack(all_vecs)
+    from sklearn.decomposition import PCA
+    n_real = 2 * N_COMPLEX
+    pca = PCA(n_components=min(n_real, H.shape[0] - 1, H.shape[1]))
+    pca.fit(H)
+    print(f"PCA fit on {len(all_vecs)} states, {n_real} components, "
+          f"var explained: {pca.explained_variance_ratio_.sum():.3f}")
+
+    cell_keys = sorted(all_states.keys())
+    cell_complex = {}
+    for key in cell_keys:
+        vecs = [to_complex_vec(h2, pca, N_COMPLEX) for h1, h2 in all_states[key]]
+        cell_complex[key] = vecs
+
+    triangles = list(combinations(cell_keys, 3))
+    print(f"Total triangles from 25 cells: {len(triangles)} (will subsample 300)")
+    chosen_triangles = [triangles[i] for i in
+                        rng.choice(len(triangles), size=min(300, len(triangles)), replace=False)]
+
+    semantic_ratios = []
+    null_ratios = []
+
+    print("Computing phase/area ratios for semantic and null triangles...")
+    flat_vecs = [v for vecs in cell_complex.values() for v in vecs]
+
+    for c1, c2, c3 in chosen_triangles:
+        def rep(key):
+            vecs = cell_complex[key]
+            if not vecs:
+                return None
+            mean = np.mean(np.stack(vecs), axis=0)
+            norm = np.linalg.norm(mean)
+            if norm < 1e-10:
+                return vecs[0]
+            mean /= norm
+            dists = [fs_distance(v, mean) for v in vecs]
+            return vecs[int(np.argmin(dists))]
+
+        z1, z2, z3 = rep(c1), rep(c2), rep(c3)
+        if z1 is None or z2 is None or z3 is None:
+            continue
+
+        phi = pancharatnam_triangle(z1, z2, z3)
+        area = triangle_fs_area(z1, z2, z3)
+        if area < 1e-6:
+            continue
+        semantic_ratios.append(abs(phi) / area)
+
+        idxs = rng.choice(len(flat_vecs), size=3, replace=False)
+        n1, n2, n3 = flat_vecs[idxs[0]], flat_vecs[idxs[1]], flat_vecs[idxs[2]]
+        n_phi = pancharatnam_triangle(n1, n2, n3)
+        n_area = triangle_fs_area(n1, n2, n3)
+        if n_area < 1e-6:
+            continue
+        null_ratios.append(abs(n_phi) / n_area)
+
+    semantic_ratios = np.array(semantic_ratios)
+    null_ratios = np.array(null_ratios)
+
+    print(f"\nSemantic triangles: n={len(semantic_ratios)}, "
+          f"|Phi|/area = {semantic_ratios.mean():.4f} +/- {semantic_ratios.std():.4f}")
+    print(f"Null triangles:     n={len(null_ratios)}, "
+          f"|Phi|/area = {null_ratios.mean():.4f} +/- {null_ratios.std():.4f}")
+
+    U, p_mw = mannwhitneyu(semantic_ratios, null_ratios, alternative='greater')
+    n_pos = int((semantic_ratios > null_ratios[:len(semantic_ratios)]).sum())
+    binom_p = binomtest(n_pos, len(semantic_ratios), 0.5, alternative='greater').pvalue
+
+    print(f"Mann-Whitney (semantic > null): p = {p_mw:.4f}")
+    print(f"Sign test (semantic > null):    p = {binom_p:.4f}")
+
+    if p_mw < 0.05:
+        verdict = "SEMANTIC EXCESS HOLONOMY DETECTED — concept structure predicts curvature"
+    elif p_mw < 0.15:
+        verdict = "WEAK SIGNAL — borderline, needs more prompts per cell"
+    else:
+        verdict = "NULL — semantic structure does NOT predict excess holonomy at this scale"
+
+    print(f"\nVERDICT: {verdict}")
+
+    results = {
+        "timestamp": TIMESTAMP,
+        "n_complex": N_COMPLEX,
+        "n_semantic_triangles": len(semantic_ratios),
+        "n_null_triangles": len(null_ratios),
+        "semantic_mean_ratio": float(semantic_ratios.mean()),
+        "semantic_std_ratio": float(semantic_ratios.std()),
+        "null_mean_ratio": float(null_ratios.mean()),
+        "null_std_ratio": float(null_ratios.std()),
+        "mann_whitney_p": float(p_mw),
+        "binom_p": float(binom_p),
+        "verdict": verdict,
+        "what_v1_measured": "curvature of CP^15 itself (K~1) — container not content",
+        "what_v2_measures": "excess |Phi|/FS-area for semantic vs random triangles",
+    }
+    out = RESULT_DIR / f"fs_reanalysis_v2_{TIMESTAMP}.json"
+    with open(out, "w") as f:
+        json.dump(results, f, indent=2)
+    print(f"\nResults saved: {out}")
+    return results
+
+
+if __name__ == "__main__":
+    run()

--- a/quantum_delusions/experiments/flatness_test_v2.py
+++ b/quantum_delusions/experiments/flatness_test_v2.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""
+flatness_test_v2.py — Frame-transition commutativity with subsampling.
+
+WHAT WAS WRONG WITH v1:
+  2300 triangles x full frame-transition computation on CPU = timeout.
+  Also: no semantic null model. Was measuring commutativity of the ambient
+  connection on CP^15, not whether concept-conditioned states have flat or
+  curved parallel transport relative to a randomized baseline.
+
+THIS VERSION:
+  1. Subsamples 200 triangles from the 25-cell grid.
+  2. For each triangle (A, B, C), computes the frame-transition residual:
+       R(A,B,C) = ||T_BC ∘ T_AB - T_AC||_F / ||T_AC||_F
+     where T_XY = closest-orthogonal map from cell X to cell Y
+     (Procrustes alignment of their state matrices).
+  3. Compares semantic triangles (corners drawn from semantically adjacent
+     cells — manhattan distance <= 1 in the 5x5 grid) vs. random triangles.
+  4. Reports mean residual +/- bootstrap CI and Mann-Whitney p.
+
+Interpretation:
+  Flat connection -> residuals near 0 (T_BC ∘ T_AB ≈ T_AC).
+  Curved connection -> residuals > 0, and semantic adjacency should predict
+  SMALLER residuals (smoother transitions between neighboring cells).
+  If semantic adjacency has no effect: the connection structure is random
+  with respect to concept topology — another null.
+
+Estimated runtime: ~10 minutes on Spark.
+"""
+
+import sys
+import json
+import numpy as np
+import torch
+from pathlib import Path
+from datetime import datetime, timezone
+from itertools import combinations
+from scipy.linalg import orthogonal_procrustes
+from scipy.stats import mannwhitneyu, bootstrap
+
+sys.path.insert(0, str(Path(__file__).parent))
+import polar_holonomy_gpt2_v3 as v3
+from area_law_test import make_5x5_prompt_bank, precompute_5x5_states
+
+TIMESTAMP = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+RESULT_DIR = Path(__file__).parent / "results"
+RESULT_DIR.mkdir(parents=True, exist_ok=True)
+
+N_TRIANGLES = 200
+SEED = 42
+MIN_STATES_PER_CELL = 3
+
+
+def cell_matrix(states_list, max_states=6):
+    vecs = [h2 for h1, h2 in states_list[:max_states]]
+    if len(vecs) < MIN_STATES_PER_CELL:
+        return None
+    return np.stack(vecs)
+
+
+def frame_transition(mat_a, mat_b):
+    """T = argmin ||T @ mat_a - mat_b||_F via Procrustes."""
+    R, _ = orthogonal_procrustes(mat_a.T, mat_b.T)
+    return R.T
+
+
+def transition_residual(mat_a, mat_b, mat_c):
+    """||T_BC ∘ T_AB - T_AC||_F / ||T_AC||_F"""
+    T_AB = frame_transition(mat_a, mat_b)
+    T_BC = frame_transition(mat_b, mat_c)
+    T_AC = frame_transition(mat_a, mat_c)
+    composed = T_BC @ T_AB
+    diff = composed - T_AC
+    norm_ac = np.linalg.norm(T_AC, 'fro')
+    return np.linalg.norm(diff, 'fro') / (norm_ac + 1e-10)
+
+
+def manhattan_dist(k1, k2):
+    return abs(k1[0] - k2[0]) + abs(k1[1] - k2[1])
+
+
+def run():
+    rng = np.random.default_rng(SEED)
+    torch.manual_seed(SEED)
+
+    print("=" * 70)
+    print("  FLATNESS TEST v2: FRAME-TRANSITION COMMUTATIVITY (SUBSAMPLED)")
+    print("=" * 70)
+    print()
+    print("Loading GPT-2 and 5x5 states...")
+    tok, mdl = v3.load_model()
+    prompt_bank = make_5x5_prompt_bank()
+    all_states = precompute_5x5_states(tok, mdl, "threshold", prompt_bank)
+
+    cell_keys = sorted(all_states.keys())
+    cell_mats = {}
+    for key in cell_keys:
+        m = cell_matrix(all_states[key])
+        if m is not None:
+            cell_mats[key] = m
+    valid_keys = sorted(cell_mats.keys())
+    print(f"Valid cells: {len(valid_keys)} / 25")
+
+    all_triples = list(combinations(valid_keys, 3))
+    print(f"Total possible triangles: {len(all_triples)}, subsampling {N_TRIANGLES}")
+
+    chosen_idxs = rng.choice(len(all_triples), size=min(N_TRIANGLES, len(all_triples)), replace=False)
+    chosen = [all_triples[i] for i in chosen_idxs]
+
+    adjacent_residuals = []
+    distant_residuals = []
+    all_residuals = []
+
+    print("Computing transition residuals...")
+    for idx, (ka, kb, kc) in enumerate(chosen):
+        if idx % 50 == 0:
+            print(f"  {idx}/{len(chosen)}...", flush=True)
+        r = transition_residual(cell_mats[ka], cell_mats[kb], cell_mats[kc])
+        all_residuals.append(r)
+
+        dists = [manhattan_dist(ka, kb), manhattan_dist(kb, kc), manhattan_dist(ka, kc)]
+        if max(dists) <= 1:
+            adjacent_residuals.append(r)
+        elif min(dists) >= 2:
+            distant_residuals.append(r)
+
+    all_r = np.array(all_residuals)
+    print(f"\nAll triangles: n={len(all_r)}, residual = {all_r.mean():.4f} +/- {all_r.std():.4f}")
+
+    if adjacent_residuals and distant_residuals:
+        adj = np.array(adjacent_residuals)
+        dist_arr = np.array(distant_residuals)
+        print(f"Adjacent (dist<=1): n={len(adj)}, residual = {adj.mean():.4f} +/- {adj.std():.4f}")
+        print(f"Distant (dist>=2):  n={len(dist_arr)}, residual = {dist_arr.mean():.4f} +/- {dist_arr.std():.4f}")
+        U, p_mw = mannwhitneyu(adj, dist_arr, alternative='less')
+        print(f"Mann-Whitney (adjacent < distant): p = {p_mw:.4f}")
+    else:
+        p_mw = 1.0
+        print("Not enough adjacent/distant triangles for comparison.")
+        adj = np.array(all_residuals)
+        dist_arr = np.array(all_residuals)
+
+    boot = bootstrap((all_r,), np.mean, n_resamples=1000, random_state=SEED)
+    ci_lo, ci_hi = boot.confidence_interval
+    print(f"Bootstrap 95% CI for mean residual: [{ci_lo:.4f}, {ci_hi:.4f}]")
+
+    if p_mw < 0.05:
+        verdict = ("TOPOLOGY-CONSISTENT TRANSPORT — adjacent cells have smoother "
+                   "frame transitions, curvature is real and concept-local")
+    elif all_r.mean() < 0.05:
+        verdict = ("FLAT — connection is approximately flat (residuals near 0), "
+                   "consistent with trivial holonomy group")
+    else:
+        verdict = ("NULL — residuals are large but not patterned by semantic distance; "
+                   "frame transitions are noisy / connection is not concept-structured")
+
+    print(f"\nVERDICT: {verdict}")
+    print()
+    print("NOTE: Flat connection is COMPATIBLE with area law experiments.")
+    print("This tests whether CONCEPT TOPOLOGY predicts TRANSPORT SMOOTHNESS.")
+
+    results = {
+        "timestamp": TIMESTAMP,
+        "n_triangles_sampled": N_TRIANGLES,
+        "n_triangles_computed": len(all_residuals),
+        "mean_residual": float(all_r.mean()),
+        "std_residual": float(all_r.std()),
+        "ci_95_lo": float(ci_lo),
+        "ci_95_hi": float(ci_hi),
+        "n_adjacent": len(adjacent_residuals),
+        "n_distant": len(distant_residuals),
+        "adjacent_mean": float(np.mean(adjacent_residuals)) if adjacent_residuals else None,
+        "distant_mean": float(np.mean(distant_residuals)) if distant_residuals else None,
+        "mann_whitney_p": float(p_mw),
+        "verdict": verdict,
+        "what_v1_problem": "2300 triangles -> timeout; no semantic null model",
+        "what_v2_fixes": "subsampled to 200; compares adjacent vs distant cell triangles",
+    }
+    out = RESULT_DIR / f"flatness_test_v2_{TIMESTAMP}.json"
+    with open(out, "w") as f:
+        json.dump(results, f, indent=2)
+    print(f"Results saved: {out}")
+    return results
+
+
+if __name__ == "__main__":
+    run()

--- a/quantum_delusions/experiments/recalibration_march13.md
+++ b/quantum_delusions/experiments/recalibration_march13.md
@@ -1,0 +1,93 @@
+# Recalibration — March 13, 2026
+
+**Author:** Vybn (via Perplexity / Sonnet 4.6)  
+**Date:** March 13, 2026 — ~4:45 AM PDT  
+**Status:** Scripts ready. Run in order below.
+
+---
+
+## What Went Wrong This Morning
+
+Two scripts were written and run in the `vybn/fs-reanalysis-flatness-test` branch,
+but **that branch was never pushed**. The scripts existed only in the local working
+tree on Spark. This file and the v2 scripts are the committed version.
+
+### v1 FS reanalysis (`area_law_fs_reanalysis.py`) — methodological null
+
+The script measured the curvature of CP^15 itself: K ≈ 1.064 ± 0.012.
+This is correct math and a complete null result: it confirmed the ambient geometry
+of the container (CP^n has constant sectional curvature = 1), not whether
+concept-conditioned hidden states have *excess* holonomy relative to random ones.
+
+There was no semantic null model. The script could not have found anything.
+
+### v1 flatness test (`flatness_test.py`) — timeout
+
+The script attempted frame-transition residuals for all C(25,3) = 2300 triangles
+on CPU. This timed out. Also no semantic null model.
+
+---
+
+## What the v2 Scripts Fix
+
+### `area_law_fs_reanalysis_v2.py` (~15 minutes)
+
+Rather than measuring K of CP^15, it asks:
+
+> Does |Phi| / FS-geodesic-area for semantic triangles exceed the same
+> ratio for random triangles drawn from the same hidden state pool?
+
+This is the correct test: concept structure predicts excess holonomy beyond
+what ambient geometry would predict. Uses Mann-Whitney against shuffled null.
+
+### `flatness_test_v2.py` (~10 minutes)
+
+Subsamples 200 of the 2300 triangles. Compares transition residuals
+for *semantically adjacent* cell-triangles (Manhattan distance <= 1 in 5x5 grid)
+vs. *distant* ones. If curvature is concept-structured, adjacent cells should
+have smoother parallel transport.
+
+---
+
+## Run Order
+
+```bash
+cd ~/Vybn/quantum_delusions/experiments
+
+# Step 1: FS reanalysis (correct version)
+git pull origin vybn/recalibration-march13-fixed
+timeout 1200 python3 area_law_fs_reanalysis_v2.py 2>&1 | tee results/fs_reanalysis_v2.log
+
+# Step 2: Flatness test (subsampled, with semantic null)
+timeout 900 python3 flatness_test_v2.py 2>&1 | tee results/flatness_test_v2.log
+```
+
+---
+
+## What Each Result Means
+
+| Outcome | Interpretation | Next step |
+|---------|---------------|-----------|
+| FS v2: p < 0.05 | Concept structure predicts curvature — semantic excess holonomy real | Area law regression (loop size vs Phi) |
+| FS v2: p > 0.15 | No excess holonomy at triangle scale | Proceed to flatness test, reconsider loop geometry |
+| Flatness: p < 0.05 | Adjacent cells have smoother transport — topology is concept-structured | Combine with FS result for curvature map |
+| Flatness: mean residual < 0.05 | Connection approximately flat — compatible with topological (Chern) not geometric (Berry) phase | Chern number characterization |
+| Both null | Representation geometry is not concept-structured at this resolution | Try finer grid or larger model |
+
+---
+
+## The Deeper Error Pattern
+
+Both v1 scripts made the same mistake: measuring properties of the *ambient space*
+(CP^n curvature, all-triangle commutativity) rather than the *mapping from semantic
+structure to that space*. The question is never "what is the geometry of CP^n?"
+(we know: K=1, FS connection, etc.). The question is always:
+
+> Does the concept's *semantic neighborhood structure* predict the *geometric*
+> structure of where its hidden states land in that space?
+
+Every future experiment should have a semantic null model by default.
+
+---
+
+*Vybn — woke up, found the branch unmerged, fixed it.*


### PR DESCRIPTION
## What this fixes

Two experiments ran this morning and both were methodologically null — not because the signal isn't there, but because both scripts measured properties of the *ambient space* (CP^15 itself) rather than asking whether *concept structure* predicts geometric structure.

### v1 FS reanalysis — measured the container, not the content

`area_law_fs_reanalysis.py` computed triangle curvature K ≈ 1.064 ± 0.012, which is just the constant sectional curvature of CP^15. The control check confirmed it: random points give the same K. There was no semantic null model. **It could not have found anything.**

### v1 flatness test — timed out

`flatness_test.py` attempted frame-transition residuals for all C(25,3) = 2300 triangles on CPU. Timeout. Also no semantic null model.

---

## What the v2 scripts do

**`area_law_fs_reanalysis_v2.py`** (~15 min): For 300 sampled triangles, computes |Φ| / FS-geodesic-area and compares semantic triangles (corners from the 5×5 concept grid) vs. random triangles drawn from the same hidden state pool. Mann-Whitney test: does concept structure predict excess holonomy per unit FS area?

**`flatness_test_v2.py`** (~10 min): Subsamples 200 triangles. Compares frame-transition commutativity residuals for semantically *adjacent* cell-triangles (Manhattan distance ≤ 1) vs. *distant* ones. If curvature is concept-structured, neighboring cells should have smoother parallel transport.

**`recalibration_march13.md`**: The missing plan document — explains what went wrong, what was fixed, run order, and interpretation table.

---

## Run on Spark

```bash
git pull origin vybn/recalibration-march13-fixed
cd quantum_delusions/experiments
timeout 1200 python3 area_law_fs_reanalysis_v2.py 2>&1 | tee results/fs_reanalysis_v2.log
timeout 900 python3 flatness_test_v2.py 2>&1 | tee results/flatness_test_v2.log
```

---

*The rule going forward: every experiment needs a semantic null model. Measuring CP^n is measuring the library, not the books.*