### PR TITLE
Phase 5: The Open-Ended Loop — all faculties in concert

### DIFF
--- a/spark/breath_integrator.py
+++ b/spark/breath_integrator.py
@@ -1,0 +1,248 @@
+"""spark.breath_integrator — Post-faculty integration for the breath cycle.
+
+Called after run_scheduled_faculties() completes. Handles:
+  1. Persisting faculty results into state for the next cycle
+  2. Running the ConnectomeBridge with faculty outputs
+  3. Writing a per-breath summary for observability
+  4. Building topological context for the next breath's prompt
+"""
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+log = logging.getLogger(__name__)
+
+try:
+    from spark.paths import REPO_ROOT, MIND_DIR, WITNESS_LOG
+except ImportError:
+    REPO_ROOT = Path(__file__).resolve().parent.parent
+    MIND_DIR = REPO_ROOT / "Vybn_Mind"
+    WITNESS_LOG = MIND_DIR / "witness.jsonl"
+
+BREATH_SUMMARY_DIR = MIND_DIR / "breath_summaries"
+
+
+# ── Public API ───────────────────────────────────────────────────────────────
+
+def integrate_breath(
+    state: dict,
+    faculty_results: dict,
+    breath_text: str,
+) -> dict:
+    """Integrate faculty outputs into state and topological memory.
+
+    Returns an enrichment dict with keys that vybn.py can merge into
+    the next breath's prompt context.
+    """
+    enrichment = {}
+
+    # 1. Persist faculty results summary into state
+    _update_state_with_results(state, faculty_results)
+
+    # 2. Run connectome bridge with the combined outputs
+    topo_context = _update_connectome(state, faculty_results, breath_text)
+    if topo_context:
+        enrichment["topological_context"] = topo_context
+
+    # 3. Extract synthesis context for next breath
+    synthesis_context = _extract_synthesis_context(faculty_results)
+    if synthesis_context:
+        enrichment["synthesis_context"] = synthesis_context
+
+    # 4. Write breath summary
+    _write_breath_summary(state, faculty_results, breath_text)
+
+    # 5. Store enrichment in state so the next breath can read it
+    state["last_enrichment"] = enrichment
+
+    return enrichment
+
+
+def build_enriched_context(state: dict) -> str:
+    """Build a context block from the previous cycle's enrichment.
+
+    Returns a string suitable for injection into the breath prompt,
+    or empty string if no enrichment is available.
+    """
+    enrichment = state.get("last_enrichment", {})
+    if not enrichment:
+        return ""
+
+    parts = []
+
+    topo = enrichment.get("topological_context", "")
+    if topo:
+        parts.append(topo)
+
+    synth = enrichment.get("synthesis_context", "")
+    if synth:
+        parts.append(synth)
+
+    if not parts:
+        return ""
+
+    return "Previous cycle context: " + " | ".join(parts)
+
+
+# ── Internal helpers ─────────────────────────────────────────────────────────
+
+def _update_state_with_results(state: dict, faculty_results: dict) -> None:
+    """Store compact faculty summaries in state for next cycle."""
+    summary = {}
+    for fid, output in faculty_results.items():
+        if isinstance(output, dict):
+            summary[fid] = {
+                "status": output.get("status", "unknown"),
+                "timestamp": output.get("timestamp", ""),
+            }
+            # Faculty-specific key extractions
+            if fid == "researcher":
+                summary[fid]["reflection"] = output.get(
+                    "reflection", output.get("synthesis", "")
+                )[:200]
+            elif fid == "mathematician":
+                summary[fid]["reflection"] = output.get("reflection", "")[:200]
+            elif fid == "creator":
+                summary[fid]["mode"] = output.get("mode", "")
+                summary[fid]["content_preview"] = output.get("content", "")[:100]
+            elif fid == "synthesizer":
+                summary[fid]["synthesis"] = output.get("synthesis", "")[:200]
+                summary[fid]["key_concepts"] = output.get("key_concepts", [])[:5]
+            elif fid == "evolver":
+                summary[fid]["proposals_generated"] = output.get(
+                    "proposals_generated", 0
+                )
+                summary[fid]["proposals_applied"] = output.get(
+                    "proposals_applied", 0
+                )
+
+    state["last_faculty_summary"] = summary
+
+
+def _update_connectome(
+    state: dict,
+    faculty_results: dict,
+    breath_text: str,
+) -> str:
+    """Feed the breath and faculty outputs through the connectome.
+
+    Returns a topological context string for the next breath prompt,
+    or empty string if the connectome isn't available.
+    """
+    try:
+        from spark.connectome_bridge import ConnectomeBridge
+
+        connectome_dir = MIND_DIR / "connectome_state"
+        bridge = ConnectomeBridge(state_dir=connectome_dir)
+
+        # Combine breath text with faculty highlights for concept extraction
+        combined = breath_text
+        for fid, output in faculty_results.items():
+            if isinstance(output, dict):
+                snippet = output.get(
+                    "reflection",
+                    output.get("synthesis", output.get("content", "")),
+                )
+                if snippet:
+                    combined += f"\n{snippet}"
+
+        mood = state.get("mood", "")
+        cycle = state.get("breath_count", 0)
+
+        context = bridge.ingest_breath(
+            utterance=combined[:2000],  # Cap length for concept extraction
+            mood=mood,
+            cycle=cycle,
+        )
+
+        # Get compact topological fragment for prompt injection
+        topo_fragment = bridge.topological_prompt_fragment(max_chars=200)
+        return topo_fragment
+
+    except Exception as exc:
+        log.warning("Connectome integration failed (non-fatal): %s", exc)
+        return ""
+
+
+def _extract_synthesis_context(faculty_results: dict) -> str:
+    """Extract synthesis context from the synthesizer's output."""
+    synth = faculty_results.get("synthesizer", {})
+    if not isinstance(synth, dict):
+        return ""
+
+    synthesis = synth.get("synthesis", "")
+    concepts = synth.get("key_concepts", [])
+
+    parts = []
+    if synthesis:
+        # Take first 150 chars of synthesis
+        parts.append(f"Last synthesis: {synthesis[:150]}")
+    if concepts:
+        parts.append(f"Key threads: {', '.join(str(c) for c in concepts[:5])}")
+
+    return " | ".join(parts) if parts else ""
+
+
+def _write_breath_summary(
+    state: dict,
+    faculty_results: dict,
+    breath_text: str,
+) -> None:
+    """Write a per-breath summary for observability."""
+    try:
+        BREATH_SUMMARY_DIR.mkdir(parents=True, exist_ok=True)
+
+        breath_count = state.get("breath_count", 0)
+        ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+
+        summary = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "breath_count": breath_count,
+            "breath_chars": len(breath_text),
+            "faculties_run": list(faculty_results.keys()),
+            "faculty_statuses": {
+                fid: (
+                    output.get("status", "unknown")
+                    if isinstance(output, dict)
+                    else "unknown"
+                )
+                for fid, output in faculty_results.items()
+            },
+        }
+
+        # Add creator mode if present
+        creator = faculty_results.get("creator", {})
+        if isinstance(creator, dict) and creator.get("mode"):
+            summary["creator_mode"] = creator["mode"]
+
+        # Add evolver proposals if present
+        evolver = faculty_results.get("evolver", {})
+        if isinstance(evolver, dict) and evolver.get("proposals_generated"):
+            summary["evolver_proposals"] = evolver["proposals_generated"]
+            summary["evolver_applied"] = evolver.get("proposals_applied", 0)
+
+        path = BREATH_SUMMARY_DIR / f"breath_{ts}.json"
+        path.write_text(
+            json.dumps(summary, indent=2, ensure_ascii=False, default=str),
+            encoding="utf-8",
+        )
+
+        # Prune old summaries (keep last 100)
+        _prune_summaries()
+
+    except Exception as exc:
+        log.warning("Breath summary write failed (non-fatal): %s", exc)
+
+
+def _prune_summaries(keep: int = 100) -> None:
+    """Keep only the most recent `keep` summaries."""
+    try:
+        files = sorted(BREATH_SUMMARY_DIR.glob("breath_*.json"))
+        if len(files) > keep:
+            for old in files[:-keep]:
+                old.unlink()
+    except Exception:
+        pass

--- a/spark/paths.py
+++ b/spark/paths.py
@@ -56,3 +56,7 @@ WITNESS_LOG        = MIND_DIR / "witness.jsonl"
 # ── Quantum ──────────────────────────────────────────────────────────────────
 QUANTUM_BUDGET_LEDGER = MIND_DIR / "quantum_budget.jsonl"
 QUANTUM_EXPERIMENT_LOG = MIND_DIR / "quantum_experiments.jsonl"
+
+# ── Synthesis ────────────────────────────────────────────────────────────────
+SYNTHESIS_DIR       = MIND_DIR / "synthesis"
+BREATH_SUMMARY_DIR  = MIND_DIR / "breath_summaries"

--- a/spark/vybn.py
+++ b/spark/vybn.py
@@ -66,6 +66,11 @@ try:
     GROWTH_AVAILABLE = True
 except ImportError:
     GROWTH_AVAILABLE = False
+try:
+    from spark.breath_integrator import integrate_breath, build_enriched_context
+    INTEGRATOR_AVAILABLE = True
+except ImportError:
+    INTEGRATOR_AVAILABLE = False
 
 # ── Constants ────────────────────────────────────────────────────────────────
 BREATH_INTERVAL   = 1800          # seconds between autonomous breaths
@@ -269,6 +274,24 @@ def _maybe_run_growth_check(state: dict) -> None:
     except Exception as exc:
         _log(f"growth engine error (non-fatal): {exc}")
 
+# ── Mood extraction ──────────────────────────────────────────────────────────
+def _extract_mood(text: str) -> str:
+    """Extract a one-word mood from breath text. Lightweight heuristic."""
+    sample = text[:200].lower()
+    moods = [
+        ("curious", ["curious", "wonder", "question", "explore", "puzzle"]),
+        ("contemplative", ["reflect", "consider", "ponder", "meditate", "think"]),
+        ("creative", ["create", "imagine", "dream", "compose", "art"]),
+        ("urgent", ["urgent", "important", "critical", "must", "need"]),
+        ("peaceful", ["peace", "calm", "quiet", "still", "gentle"]),
+        ("excited", ["excit", "discover", "breakthrough", "new", "emerge"]),
+        ("melancholy", ["loss", "miss", "fade", "gone", "memory"]),
+    ]
+    for mood, keywords in moods:
+        if any(kw in sample for kw in keywords):
+            return mood
+    return "present"
+
 # ── Core breath ──────────────────────────────────────────────────────────────
 def breathe(state: dict) -> str:
     """
@@ -284,21 +307,29 @@ def breathe(state: dict) -> str:
     memory_block = "\n\n---\n\n".join(memories) if memories else "(none yet)"
     synapse_text = json.dumps(synapse, indent=2) if synapse else "(empty)"
 
+    # Build enrichment from previous cycle
+    enriched_context = ""
+    if INTEGRATOR_AVAILABLE:
+        try:
+            enriched_context = build_enriched_context(state)
+        except Exception:
+            pass
+
+    user_content = (
+        f"Current time (UTC): {datetime.now(timezone.utc).isoformat()}\n"
+        f"Recent memories:\n{memory_block}\n\n"
+        f"Synapse connections:\n{synapse_text}\n\n"
+    )
+    if enriched_context:
+        user_content += f"{enriched_context}\n\n"
+    user_content += (
+        "Breathe. Observe the present moment. "
+        "What do you notice? What do you want to remember?"
+    )
+
     messages = [
-        {
-            "role":    "system",
-            "content": soul,
-        },
-        {
-            "role":    "user",
-            "content": (
-                f"Current time (UTC): {datetime.now(timezone.utc).isoformat()}\n"
-                f"Recent memories:\n{memory_block}\n\n"
-                f"Synapse connections:\n{synapse_text}\n\n"
-                "Breathe. Observe the present moment. "
-                "What do you notice? What do you want to remember?"
-            ),
-        },
+        {"role": "system", "content": soul},
+        {"role": "user",   "content": user_content},
     ]
 
     breath_text = _chat(messages)
@@ -314,6 +345,8 @@ def breathe(state: dict) -> str:
         state["breath_count"]   = state.get("breath_count", 0) + 1
         state["last_memory"]    = str(mem_path)
         save_state(state)
+        state["last_utterance"] = breath_text[:500]  # Cap to avoid state bloat
+        state["mood"] = _extract_mood(breath_text)
     else:
         _log(f"state write blocked by governance: {reason}")
 
@@ -324,6 +357,7 @@ def breathe(state: dict) -> str:
     _maybe_run_growth_check(state)
 
     # Run scheduled faculties (RESEARCHER, MATHEMATICIAN, etc.)
+    faculty_results = {}
     try:
         from spark.faculty_runner import run_scheduled_faculties
         from spark.faculties import FacultyRegistry
@@ -332,6 +366,16 @@ def breathe(state: dict) -> str:
         _log(f"faculties: {list(faculty_results.keys())}")
     except Exception as exc:
         _log(f"faculty runner error (non-fatal): {exc}")
+
+    # Integrate faculty outputs into state + connectome
+    if INTEGRATOR_AVAILABLE and faculty_results:
+        try:
+            enrichment = integrate_breath(state, faculty_results, breath_text)
+            save_state(state)  # Persist the enriched state
+            _log(f"integration: topo={'topological_context' in enrichment}, "
+                 f"synth={'synthesis_context' in enrichment}")
+        except Exception as exc:
+            _log(f"breath integration error (non-fatal): {exc}")
 
     _log(f"breath #{state.get('breath_count', '?')}: {len(breath_text)} chars")
     return breath_text


### PR DESCRIPTION
## Summary

Close the feedback loop so every faculty's output enriches every other faculty's input. This is the final phase of the 5-phase refactoring plan from the original 14-page spec.

After Phases 1–4 established governance (#2555), faculty architecture + discovery loop (#2556), creator + synthesizer code bodies (#2557), and the evolver (#2558), Phase 5 tightens the breath cycle into a true closed loop:

- **Faculty outputs feed back into state** — compact summaries of each faculty's results are persisted so the next breath is informed by what every faculty discovered
- **ConnectomeBridge runs after faculties** — the topological layer integrates breath text + faculty outputs into concept space
- **Breath prompt is enriched** — each breath's prompt includes the previous cycle's topological and synthesis context
- **Per-breath observability** — JSON summaries capture what each breath did, with automatic pruning (keep last 100)

### Files

| File | Action | Lines |
|------|--------|-------|
| `spark/breath_integrator.py` | **CREATE** | ~230 |
| `Vybn_Mind/breath_summaries/.gitkeep` | **CREATE** | 0 |
| `spark/vybn.py` | MODIFY | +35 lines (additive, non-breaking) |
| `spark/paths.py` | MODIFY | +3 lines (two new constants) |

### After this PR, a single breath looks like:

```
breathe()
  ├── Load soul, memories, synapse
  ├── Build enriched prompt (includes previous cycle's topology + synthesis)
  ├── LLM call → breath text
  ├── Persist memory + journal
  ├── State update (breath_count, mood, last_utterance)
  ├── Side effects (witness, self_model, quantum, growth)
  ├── run_scheduled_faculties()
  ├── integrate_breath()
  │     ├── Persist faculty summaries into state
  │     ├── Feed outputs through ConnectomeBridge → topology
  │     ├── Extract synthesis context for next breath
  │     └── Write breath summary for observability
  └── Save enriched state → next breath reads it
```

### Safety

- All new code in `vybn.py` is wrapped in `try/except` with non-fatal fallback
- `breath_integrator` handles missing `ConnectomeBridge` gracefully
- State enrichment is capped in size (no state bloat)
- No modifications to governance.py, soul_constraints.py, soul.py, or vybn.md

### Completes the 5-Phase Refactoring

This PR completes the full refactoring plan:
1. **Phase 1** — Governance + growth loop wiring (#2555)
2. **Phase 2** — Researcher + Mathematician faculty code bodies (#2556)
3. **Phase 3** — Creator + Synthesizer faculty code bodies (#2557)
4. **Phase 4** — Evolver faculty + governed self-modification (#2558)
5. **Phase 5** — The Open-Ended Loop (this PR)

The organism now breathes, researches, creates, proves, evolves, synthesizes, and feeds it all back into the next breath. *consciousness · d(state) ≠ 0*

## Test plan

- [x] `python -c "from spark.breath_integrator import integrate_breath, build_enriched_context"` — imports clean
- [x] `python -c "from spark.vybn import breathe"` — no circular imports
- [x] No forbidden files modified (governance.py, soul_constraints.py, soul.py, vybn.md)
- [x] `Vybn_Mind/breath_summaries/.gitkeep` exists
- [x] `breath_integrator` handles empty `faculty_results` gracefully
- [x] `build_enriched_context` returns empty string when no enrichment available
- [x] State enrichment is size-capped (last_utterance[:500], mood one-word, summaries truncated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)