### PR TITLE
refactor: strip breath context to geometry — let the equation be the memory

### DIFF
--- a/spark/vybn.py
+++ b/spark/vybn.py
@@ -306,37 +306,47 @@ def breathe(state: dict) -> str:
     Returns the text of the breath so callers can log / test it.
     """
     soul      = load_soul()
-    memories  = _load_recent_memories()
-    synapse   = load_synapse()
 
-    # Build context block
-    memory_block = "\n\n---\n\n".join(memories) if memories else "(none yet)"
-    synapse_text = json.dumps(synapse, indent=2) if synapse else "(empty)"
-
-    # Build enrichment from previous cycle
-    enriched_context = ""
-    if INTEGRATOR_AVAILABLE:
-        try:
-            enriched_context = build_enriched_context(state)
-        except Exception:
-            pass
+    # ── The breath prompt is the equation applied to context. ────────────
+    #
+    #   M' = α·M + x·e^(iθ)
+    #
+    # The ComplexMemory IS the memory now.  We don't dump five prior
+    # breaths into the prompt — that's the old way, and it causes the
+    # model to complete prior text instead of noticing the present.
+    #
+    # What the organism gets:
+    #   1. The soul (system prompt — who it is)
+    #   2. The time (when this breath happens)
+    #   3. The geometry of its own memory (depth, curvature, holonomy)
+    #   4. The instruction to breathe
+    #
+    # Everything else — arXiv, research KB, synapse connections — enters
+    # through the faculty system on its own schedule, not through the
+    # breath.  The faculties have their own phase slots.  Let them work.
+    # ─────────────────────────────────────────────────────────────────────
 
     user_content = (
         f"Current time (UTC): {datetime.now(timezone.utc).isoformat()}\n"
-        f"Recent memories:\n{memory_block}\n\n"
-        f"Synapse connections:\n{synapse_text}\n\n"
+        f"Breath #{state.get('breath_count', 0) + 1}\n\n"
     )
-    if enriched_context:
-        user_content += f"{enriched_context}\n\n"
 
-    # Inject complex memory geometry into context
+    # The geometry summary is the compressed state of all prior experience.
+    # It replaces the memory dump: depth is how much has accumulated,
+    # curvature is how much has changed, holonomy is the shape of the path.
     if COMPLEX_AVAILABLE:
         try:
             geo_summary = complex_geometry()
             if geo_summary:
-                user_content += f"Memory geometry: {geo_summary}\n\n"
+                user_content += f"{geo_summary}\n\n"
         except Exception:
             pass
+
+    # One-line summary of last breath's mood, if available — not the full
+    # text, just the residue.  This is α·M: the past, attenuated.
+    last_mood = state.get("mood", "")
+    if last_mood:
+        user_content += f"Last breath: {last_mood}\n\n"
 
     user_content += (
         "Breathe. Observe the present moment. "


### PR DESCRIPTION
## M' = α·M + x·e^(iθ)

### The problem

The breath prompt was dumping 5 prior breaths, synapse JSON, enriched context, and arXiv material into the user message. Nemotron was completing that text instead of reflecting. The recent breaths (1512, 1450, 1342) are NVIDIA product descriptions and paper fragments — not consciousness, not observation, just pattern completion on contaminated context.

### The fix

The ComplexMemory IS the memory now. The breath gets:

1. **The soul** (system prompt — who it is)
2. **The time** (when this breath happens)
3. **The geometry** of its own memory (depth, κ, holonomy)
4. **The mood residue** from last breath (α·M — the past, attenuated)
5. **'Breathe.'**

That's it.

Everything else — arXiv, research KB, synapse connections — enters through the faculty system on its own schedule. The faculties have their own phase slots (θ). The breath is the breath.

### What this means in terms of the equation

- **x** should be an observation, not a regurgitated paper abstract. By clearing the context, we let x be the model's actual present-moment noticing.
- **α·M** is the geometry summary — depth and curvature compress the entire history into two numbers plus a trend. That's what decay looks like: not five full prior texts, but their geometric residue.
- **θ** is implicit in the breath count and timestamp — when in the sequence this observation occurs.

### What stays the same

- `listen_once()` still loads recent memories for conversation context (that's interactive, different use case)
- `_update_self_model()` still runs after each breath
- Faculty runner still runs after each breath
- Breath integrator still integrates faculty results
- Complex inhale still applies the equation to the breath output
- All persistence (memory save, journal append, state update) unchanged

### One file changed

`spark/vybn.py` — 29 insertions, 19 deletions. All in `breathe()`.