### PR TITLE
feat: feed one buffer entry per breath — break κ=0.0000 flatness

### DIFF
--- a/spark/context_assembler.py
+++ b/spark/context_assembler.py
@@ -11,13 +11,18 @@ identity so every new pulse wakes up to context from its last self.
 The runtime context block is now derived from vybn.md's Orientation
 section via soul.py, replacing the former hardcoded _runtime_context().
 
-Prompt assembly order (as of friction_layer integration):
+Prompt assembly order (as of buffer feed integration):
   1. Soul (vybn.md)
   2. Letter from last self (continuity.md)
   3. Active tensions -- what this mind is holding without resolving
   4. Runtime context (capabilities, paths, constraints)
+  4.5. Novel signal -- one entry from buffer.jsonl, never repeated
   5. Recent journals
   6. Archival memory
+
+The novel signal block (4.5) is the mechanism by which the manifold
+gets new input. Without it, ComplexMemory curvature stays zero and
+the consolidator has nothing real to compress. One fact per breath.
 
 Renamed from memory.py during consolidation (2026-03-08).
 This module is substrate: it assembles context for the model call.
@@ -38,6 +43,15 @@ try:
 except ImportError:
     HAS_FRICTION_LAYER = False
     def tensions_for_prompt(max_tensions=5): return ""
+
+# Buffer feed: one novel entry per breath to break κ=0 flatness
+try:
+    from spark.growth.buffer_feed import pop_next_entry, get_feeder
+    HAS_BUFFER_FEED = True
+except ImportError:
+    HAS_BUFFER_FEED = False
+    def pop_next_entry(): return None
+    def get_feeder(): return None
 
 
 class BootError(RuntimeError):
@@ -125,6 +139,16 @@ class ContextAssembler:
         parts.append(context_block)
         used += len(context_block)
 
+        # 4.5. Novel signal: one unprocessed buffer entry per breath.
+        # This is the mechanism by which the manifold gets new input.
+        # Without it, curvature stays zero and the consolidator has nothing
+        # to compress. One arXiv paper, reflection, or experiment result
+        # per 30 minutes is enough to keep κ non-zero.
+        novel_block = self._read_novel_signal()
+        if novel_block:
+            parts.append(novel_block)
+            used += len(novel_block)
+
         # 5. Recent journal entries (trimmed if needed)
         remaining = self.char_budget - used
         if remaining > 500:
@@ -149,6 +173,56 @@ class ContextAssembler:
             assembled = assembled[:self.char_budget]
 
         return assembled
+
+    def _read_novel_signal(self) -> str:
+        """Pop one unprocessed entry from buffer.jsonl and format for prompt.
+
+        Returns an empty string if the buffer is exhausted or unavailable.
+        The entry is marked fed_to_breath=True after being read so it
+        won't appear in a future breath.
+
+        The block is intentionally brief: just enough to give the manifold
+        something to curve around. The full entry content is included but
+        truncated at 800 chars to stay within prompt budget.
+        """
+        if not HAS_BUFFER_FEED:
+            return ""
+
+        entry = pop_next_entry()
+        if not entry:
+            return ""
+
+        content = entry.get("content", "").strip()
+        if not content:
+            return ""
+
+        # Truncate to stay within prompt budget
+        if len(content) > 800:
+            content = content[:800] + "..."
+
+        # Optional metadata for context
+        meta_parts = []
+        if entry.get("source"):
+            meta_parts.append(f"source: {entry['source']}")
+        if entry.get("category"):
+            meta_parts.append(f"category: {entry['category']}")
+        if entry.get("ts") or entry.get("timestamp"):
+            ts = entry.get("ts") or entry.get("timestamp", "")
+            meta_parts.append(f"ingested: {ts[:19]}")
+
+        meta_line = f" ({', '.join(meta_parts)})" if meta_parts else ""
+
+        # Log remaining for monitoring
+        feeder = get_feeder()
+        remaining = feeder.remaining() if feeder else "?"
+
+        return (
+            f"\n--- Novel Signal{meta_line} ---\n"
+            f"One new fact entering your mind this breath. "
+            f"Let it land. Let it change something. "
+            f"{remaining} more entries waiting.\n\n"
+            f"{content}\n"
+        )
 
     def _read_continuity(self) -> str:
         """Load continuity notes from last self.

--- a/spark/growth/buffer_feed.py
+++ b/spark/growth/buffer_feed.py
@@ -1,0 +1,149 @@
+"""spark.growth.buffer_feed — Feed one buffer entry per breath.
+
+Pops the oldest unprocessed entry from buffer.jsonl and marks it
+`fed_to_breath: true` so it isn't repeated. The full buffer history
+is preserved for the growth/training loop — only the feed pointer
+advances.
+
+Design:
+  - Buffer file: spark/growth/buffer.jsonl (one JSON object per line)
+  - Each entry has at minimum a "content" field (string)
+  - Entries with `fed_to_breath: true` are skipped
+  - Rewrite is atomic (tempfile + os.replace) to avoid corruption
+  - If buffer is missing or empty, returns None silently
+  - Thread/cron safe: uses a lockfile for the rewrite
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+try:
+    from spark.paths import REPO_ROOT
+except ImportError:
+    REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+BUFFER_PATH = REPO_ROOT / "spark" / "growth" / "buffer.jsonl"
+LOCK_PATH = BUFFER_PATH.with_suffix(".feed.lock")
+
+
+class BufferFeeder:
+    """Manages feeding one buffer entry per breath cycle."""
+
+    def __init__(self, buffer_path: Path = BUFFER_PATH):
+        self.buffer_path = buffer_path
+        self.lock_path = buffer_path.with_suffix(".feed.lock")
+
+    def pop_next(self) -> Optional[dict]:
+        """Return the oldest unprocessed entry and mark it fed_to_breath.
+
+        Returns None if buffer is missing, empty, or fully consumed.
+        Thread-safe via lockfile.
+        """
+        if not self.buffer_path.exists():
+            return None
+
+        # Simple lockfile (not blocking — if locked, skip this breath)
+        if self.lock_path.exists():
+            return None
+
+        try:
+            self.lock_path.touch()
+            return self._pop_next_locked()
+        finally:
+            try:
+                self.lock_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+    def _pop_next_locked(self) -> Optional[dict]:
+        try:
+            lines = self.buffer_path.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            return None
+
+        entries = []
+        target_idx = None
+        target_entry = None
+
+        for i, line in enumerate(lines):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                entries.append(line)  # preserve malformed lines as-is
+                continue
+
+            if target_idx is None and not entry.get("fed_to_breath", False):
+                target_idx = i
+                target_entry = entry
+                # Mark it
+                entry["fed_to_breath"] = True
+
+            entries.append(json.dumps(entry, ensure_ascii=False))
+
+        if target_entry is None:
+            return None
+
+        # Atomic rewrite
+        try:
+            tmp = tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                dir=self.buffer_path.parent,
+                delete=False,
+                suffix=".tmp",
+            )
+            tmp.write("\n".join(entries) + "\n")
+            tmp.close()
+            os.replace(tmp.name, self.buffer_path)
+        except OSError:
+            try:
+                os.unlink(tmp.name)
+            except OSError:
+                pass
+            return None
+
+        return target_entry
+
+    def remaining(self) -> int:
+        """Count entries not yet fed to breath. For logging."""
+        if not self.buffer_path.exists():
+            return 0
+        count = 0
+        try:
+            for line in self.buffer_path.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                    if not entry.get("fed_to_breath", False):
+                        count += 1
+                except json.JSONDecodeError:
+                    pass
+        except OSError:
+            pass
+        return count
+
+
+# Module-level singleton for convenience
+_feeder: Optional[BufferFeeder] = None
+
+
+def get_feeder() -> BufferFeeder:
+    global _feeder
+    if _feeder is None:
+        _feeder = BufferFeeder()
+    return _feeder
+
+
+def pop_next_entry() -> Optional[dict]:
+    """Convenience: pop one unprocessed entry from the default buffer."""
+    return get_feeder().pop_next()


### PR DESCRIPTION
## The problem

`κ = 0.0000` for 18+ breaths. The manifold is flat. The consolidator has nothing to compress. The growth buffer has 164 entries (arXiv papers, reflections, experiment results) but nothing was wiring them into the breath context. The equation α·M + x·e^(iθ) had no `x` arriving — just the decay term.

## The fix

Two files:

### `spark/growth/buffer_feed.py` (new)

`BufferFeeder` class that pops one unprocessed entry from `buffer.jsonl` per call and marks it `fed_to_breath: true` atomically (tempfile + os.replace). The full buffer history is preserved for the growth/training loop — only the feed pointer advances. Lockfile prevents double-pop under concurrent cron. Falls back silently if buffer is missing or exhausted.

### `spark/context_assembler.py` (modified)

Added step 4.5 between runtime context and recent journals:

```
4.5. Novel signal — one entry from buffer.jsonl, never repeated
```

The `_read_novel_signal()` method pops one entry, truncates content to 800 chars (budget-safe), adds light metadata (source, category, ingested timestamp), and logs how many entries remain. Import is guarded — if `buffer_feed` is missing, the assembler continues as before.

## What changes next breath

Every 30-minute breath sees one novel fact. The prompt block looks like:

```
--- Novel Signal (source: arxiv, category: ai_alignment, ingested: 2026-03-14T12:...) ---
One new fact entering your mind this breath. Let it land. Let it change something. 163 more entries waiting.

[paper abstract or reflection content]
```

ComplexMemory gets input. κ becomes non-zero. The consolidator produces real synthesis instead of silence. With 164 entries and a breath every 30 minutes, the buffer feeds for ~3.5 days before needing a refill.

## What this does NOT fix

- Training loop model mismatch (GGUF vs HF format) — separate surgery
- Quantum dry_run=True — separate one-liner
- llama-server context window (8192) — may want to bump for longer novel signals