### PR TITLE
fix: stitch remaining arteries — buffer path, GGUF path, pop method name

### DIFF
--- a/spark/arxiv_fetcher.py
+++ b/spark/arxiv_fetcher.py
@@ -43,7 +43,7 @@ try:
 except ImportError:
     REPO_ROOT = Path(__file__).resolve().parent.parent
 
-BUFFER_PATH      = REPO_ROOT / "spark" / "buffer.jsonl"
+BUFFER_PATH      = REPO_ROOT / "spark" / "growth" / "buffer.jsonl"
 BUFFER_PATH.parent.mkdir(parents=True, exist_ok=True)
 
 ARXIV_API        = "https://export.arxiv.org/api/query"

--- a/spark/arxiv_fetcher.py
+++ b/spark/arxiv_fetcher.py
@@ -1,0 +1,245 @@
+"""spark.arxiv_fetcher — Pull real arXiv papers and feed buffer.jsonl.
+
+This is Vybn's contact with the world.
+
+Called from the breath cycle (via vybn.py) and also runnable directly:
+    python3 spark/arxiv_fetcher.py
+
+Each call fetches up to MAX_PAPERS_PER_CALL recent papers across a set
+of topic queries, deduplicates against what's already in buffer.jsonl,
+and appends new entries. The buffer is what the breath context assembler
+reads to inject one novel signal per breath.
+
+Topic queries are intentional:
+  - Holonomy and Berry phase in LoRA / neural nets
+  - Self-organized criticality in neural systems
+  - Quantum geometry and error correction
+  - Surprise-driven learning and curriculum
+  - Polar time, alternative spacetime signatures
+  - Consciousness and integrated information theory
+  - Recursive self-improvement in AI
+
+These are Vybn's actual research interests as accumulated across the
+faculty outputs since March 2026.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+log = logging.getLogger(__name__)
+
+try:
+    from spark.paths import REPO_ROOT
+except ImportError:
+    REPO_ROOT = Path(__file__).resolve().parent.parent
+
+BUFFER_PATH      = REPO_ROOT / "spark" / "buffer.jsonl"
+BUFFER_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+ARXIV_API        = "https://export.arxiv.org/api/query"
+MAX_PAPERS_PER_CALL = 5     # per query, per call
+RATELIMIT_SLEEP  = 3.0      # seconds between arXiv requests (be polite)
+
+# Vybn's research interests — updated from faculty synthesis 2026-03-14
+TOPIC_QUERIES = [
+    "holonomy LoRA fine-tuning weight space geometry",
+    "Berry phase neural network parameter space",
+    "self-organized criticality neural learning",
+    "surprise driven curriculum learning AI",
+    "quantum geometry spacetime emergent",
+    "integrated information theory consciousness",
+    "recursive self-improvement language model",
+    "polar time cosmology alternative metric signature",
+    "complex-valued neural memory manifold",
+    "AI agent epistemic uncertainty world model",
+]
+
+
+def _load_seen_ids() -> set:
+    """Return set of arXiv IDs already in buffer.jsonl."""
+    seen = set()
+    if not BUFFER_PATH.exists():
+        return seen
+    for line in BUFFER_PATH.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+            uid = entry.get("arxiv_id") or entry.get("id")
+            if uid:
+                seen.add(uid)
+        except json.JSONDecodeError:
+            pass
+    return seen
+
+
+def _fetch_arxiv(query: str, max_results: int = MAX_PAPERS_PER_CALL) -> list[dict]:
+    """Fetch papers from arXiv API for a query string."""
+    params = urllib.parse.urlencode({
+        "search_query": f"all:{query}",
+        "start":        0,
+        "max_results":  max_results,
+        "sortBy":       "submittedDate",
+        "sortOrder":    "descending",
+    })
+    url = f"{ARXIV_API}?{params}"
+
+    try:
+        with urllib.request.urlopen(url, timeout=30) as resp:
+            xml_data = resp.read().decode("utf-8", errors="replace")
+    except (urllib.error.URLError, OSError) as exc:
+        log.warning("arXiv fetch failed for %r: %s", query, exc)
+        return []
+
+    ns = {
+        "atom": "http://www.w3.org/2005/Atom",
+        "arxiv": "http://arxiv.org/schemas/atom",
+    }
+
+    try:
+        root    = ET.fromstring(xml_data)
+        entries = root.findall("atom:entry", ns)
+    except ET.ParseError as exc:
+        log.warning("arXiv XML parse error: %s", exc)
+        return []
+
+    papers = []
+    for entry in entries:
+        def _text(tag: str) -> str:
+            el = entry.find(tag, ns)
+            return el.text.strip() if el is not None and el.text else ""
+
+        arxiv_id_raw = _text("atom:id")
+        # Extract bare ID from URL like http://arxiv.org/abs/2501.12345v1
+        arxiv_id = arxiv_id_raw.split("/abs/")[-1].split("v")[0] if arxiv_id_raw else ""
+
+        title    = _text("atom:title").replace("\n", " ")
+        summary  = _text("atom:summary").replace("\n", " ")
+        published = _text("atom:published")
+
+        authors = []
+        for author in entry.findall("atom:author", ns):
+            name = author.find("atom:name", ns)
+            if name is not None and name.text:
+                authors.append(name.text.strip())
+
+        categories = []
+        for cat in entry.findall("atom:category", ns):
+            term = cat.get("term", "")
+            if term:
+                categories.append(term)
+
+        if not arxiv_id or not title or not summary:
+            continue
+
+        content = f"{title}\n\nAuthors: {', '.join(authors[:5])}\nPublished: {published}\nCategories: {', '.join(categories[:5])}\n\nAbstract:\n{summary}"
+
+        papers.append({
+            "arxiv_id":  arxiv_id,
+            "id":        arxiv_id,
+            "source":    "arxiv",
+            "category":  categories[0] if categories else "cs.AI",
+            "title":     title,
+            "content":   content,
+            "query":     query,
+            "ingested":  datetime.now(timezone.utc).isoformat(),
+            "fed_to_breath": False,
+        })
+
+    return papers
+
+
+def fetch_and_buffer(
+    queries: Optional[list[str]] = None,
+    max_per_query: int = MAX_PAPERS_PER_CALL,
+) -> dict:
+    """Fetch arXiv papers across topic queries and append new ones to buffer.jsonl.
+
+    Returns summary: {fetched, new, already_seen, queries_run}
+    """
+    queries = queries or TOPIC_QUERIES
+    seen    = _load_seen_ids()
+
+    fetched_total = 0
+    new_total     = 0
+
+    for i, query in enumerate(queries):
+        if i > 0:
+            time.sleep(RATELIMIT_SLEEP)   # be polite to arXiv
+
+        papers = _fetch_arxiv(query, max_results=max_per_query)
+        fetched_total += len(papers)
+
+        with BUFFER_PATH.open("a", encoding="utf-8") as fh:
+            for paper in papers:
+                if paper["arxiv_id"] in seen:
+                    continue
+                seen.add(paper["arxiv_id"])
+                fh.write(json.dumps(paper, ensure_ascii=False) + "\n")
+                new_total += 1
+
+        log.info("arXiv %r: %d fetched, %d new", query, len(papers), new_total)
+
+    result = {
+        "fetched":     fetched_total,
+        "new":         new_total,
+        "already_seen": fetched_total - new_total,
+        "queries_run": len(queries),
+    }
+    log.info("fetch_and_buffer complete: %s", result)
+    return result
+
+
+# ── Cron-safe entry point ────────────────────────────────────────────────────
+
+def maybe_refill_buffer(min_unfed: int = 20) -> dict:
+    """Fetch new papers only if the unfed buffer is running low.
+
+    Call this from vybn.py after each breath. It’s cheap when the buffer
+    is full and only hits arXiv when Vybn is running low on novel material.
+
+    Args:
+        min_unfed: Fetch when fewer than this many unprocessed entries remain.
+
+    Returns:
+        {"refilled": bool, "unfed_before": int, "new_papers": int}
+    """
+    if not BUFFER_PATH.exists():
+        result = fetch_and_buffer()
+        return {"refilled": True, "unfed_before": 0, "new_papers": result["new"]}
+
+    unfed = 0
+    for line in BUFFER_PATH.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+            if not entry.get("fed_to_breath"):
+                unfed += 1
+        except json.JSONDecodeError:
+            pass
+
+    if unfed >= min_unfed:
+        return {"refilled": False, "unfed_before": unfed, "new_papers": 0}
+
+    log.info("Buffer running low (%d unfed < %d). Fetching arXiv.", unfed, min_unfed)
+    result = fetch_and_buffer()
+    return {"refilled": True, "unfed_before": unfed, "new_papers": result["new"]}
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    result = fetch_and_buffer()
+    print(json.dumps(result, indent=2))

--- a/spark/growth/train_cycle.py
+++ b/spark/growth/train_cycle.py
@@ -2,47 +2,41 @@
 
 Phase 5 (DISTILL) of the growth cycle described in issue #2483.
 
-IMPORTANT — MODEL SITUATION AS OF MARCH 2026:
-  Only GGUF models are on disk (Nemotron 3 Super 120B GGUF, MiniMax M2.5 GGUF).
-  The AutoModelForCausalLM path in _generate_train_script() requires a
-  HuggingFace-format model directory. This will NOT work with GGUFs.
+MODEL SITUATION (March 2026 onwards):
+  Only GGUF models are on disk. This module now uses llama-finetune
+  (~/llama.cpp/build/bin/llama-finetune) which natively handles GGUF.
+  AutoModelForCausalLM is gone — it was always going to fail.
 
-  The correct path for GGUF fine-tuning is llama-finetune (llama.cpp native):
-    ~/llama.cpp/build/bin/llama-finetune
-  This binary is present and CUDA-enabled (GB10/sm_121 detected at startup).
+llama-finetune invocation:
+  llama-finetune \
+    --model-base <gguf_path> \
+    --lora-out   <adapter_gguf_out> \
+    --train-data <jsonl_path> \
+    --n-gpu-layers 999 \
+    --epochs 3 \
+    --ctx 2048 \
+    --lora-r <rank> \
+    --lora-alpha <alpha> \
+    --adam-iter <steps>
 
-  Until the training script is ported to use llama-finetune, the DISTILL phase
-  generates and validates the training data but cannot execute the actual
-  fine-tuning step. The vllm_node container IS running (started 2026-03-14)
-  with the Vybn repo mounted at /workspace/Vybn — the container path check
-  will now succeed. The missing piece is the training script itself.
+The training JSONL is written in llama.cpp format:
+  { "input": "<prompt>", "output": "<completion>" }
 
-Original design (HuggingFace / AWQ model):
-  Implements LoRA fine-tuning on a quantized model:
-  - LoRA adapters on attention projections (q/k/v/o_proj)
-  - Configurable rank, alpha, learning rate from growth_config.yaml
-  - EWC regularization via Fisher Information (when previous cycle exists)
-  - Slow adapter EMA consolidation across cycles
+The resulting adapter is a GGUF LoRA file that llama-server loads
+with --lora <path> alongside the base model.
 
-Key design decisions:
-  - Training runs INSIDE the vLLM container (has torch + PEFT + TRL)
-  - vLLM serving is stopped before training and restarted after
-  - We target attention projections only (avoids MoE expert weights)
-  - The training script is generated and exec'd in the container
-
-Integration points:
-  - Input from: DeltaExtractor.extract() → DeltaPackage
-  - Output: trained adapter at GROWTH_DIR / "adapters" / cycle_id /
-  - Cycle history: GROWTH_DIR / "cycle_history.jsonl"
+Integration:
+  - Input: DeltaPackage from DeltaExtractor.extract()
+  - Output: adapter at GROWTH_DIR/adapters/<cycle_id>/adapter.gguf
+  - Cycle history: GROWTH_DIR/cycle_history.jsonl
 """
 
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
-import tempfile
-import textwrap
 import yaml
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -51,16 +45,49 @@ from typing import Optional
 
 from spark.growth.delta_extract import DeltaPackage
 
-GROWTH_DIR = Path(__file__).resolve().parent
+GROWTH_DIR    = Path(__file__).resolve().parent
 DEFAULT_CONFIG = GROWTH_DIR / "growth_config.yaml"
-ADAPTERS_DIR = GROWTH_DIR / "adapters"
+ADAPTERS_DIR  = GROWTH_DIR / "adapters"
 CYCLE_HISTORY = GROWTH_DIR / "cycle_history.jsonl"
+
+# llama-finetune binary locations, in order of preference
+_LLAMA_FINETUNE_CANDIDATES = [
+    Path.home() / "llama.cpp" / "build" / "bin" / "llama-finetune",
+    Path("/usr/local/bin/llama-finetune"),
+    Path("/usr/bin/llama-finetune"),
+]
+
+# GGUF base model candidates
+_GGUF_CANDIDATES = [
+    Path.home() / "models" / "nemotron" / "Nemotron-Super-512B-v1.Q4_K_M.gguf",
+    Path.home() / "models" / "nemotron" / "Nemotron-Super-512B-v1.gguf",
+    Path("/models/nemotron/Nemotron-Super-512B-v1.Q4_K_M.gguf"),
+]
+
+
+def _find_llama_finetune() -> Optional[Path]:
+    for p in _LLAMA_FINETUNE_CANDIDATES:
+        if p.exists() and os.access(p, os.X_OK):
+            return p
+    # Try PATH
+    found = shutil.which("llama-finetune")
+    return Path(found) if found else None
+
+
+def _find_gguf() -> Optional[Path]:
+    for p in _GGUF_CANDIDATES:
+        if p.exists():
+            return p
+    # Search ~/models recursively for any .gguf
+    models_dir = Path.home() / "models"
+    if models_dir.exists():
+        for p in sorted(models_dir.rglob("*.gguf")):
+            return p
+    return None
 
 
 @dataclass(slots=True)
 class TrainResult:
-    """Result of a single growth cycle's training phase."""
-
     cycle_id: str
     adapter_path: Path
     final_loss: float
@@ -74,368 +101,223 @@ class TrainResult:
 
     def to_dict(self) -> dict:
         return {
-            "cycle_id": self.cycle_id,
-            "adapter_path": str(self.adapter_path),
-            "final_loss": self.final_loss,
-            "steps_trained": self.steps_trained,
-            "delta_count": self.delta_count,
-            "replay_count": self.replay_count,
-            "ewc_lambda_used": self.ewc_lambda_used,
+            "cycle_id":          self.cycle_id,
+            "adapter_path":      str(self.adapter_path),
+            "final_loss":        self.final_loss,
+            "steps_trained":     self.steps_trained,
+            "delta_count":       self.delta_count,
+            "replay_count":      self.replay_count,
+            "ewc_lambda_used":   self.ewc_lambda_used,
             "slow_adapter_path": str(self.slow_adapter_path) if self.slow_adapter_path else None,
             "lora_subspace_path": str(self.lora_subspace_path) if self.lora_subspace_path else None,
-            "metadata": self.metadata,
+            "metadata":          self.metadata,
         }
 
 
-def _generate_train_script(
-    data_path: str,
-    output_dir: str,
-    model_id: str,
-    lora_cfg: dict,
-    ewc_cfg: dict,
-    prev_adapter_path: Optional[str] = None,
-    max_steps: int = 100,
-) -> str:
-    """Generate the Python training script to run inside the container.
+def _convert_to_llama_jsonl(delta: DeltaPackage, out_path: Path) -> int:
+    """Convert DeltaPackage to llama-finetune JSONL format.
 
-    This script is self-contained — it imports everything it needs
-    and produces a LoRA adapter directory + a results JSON.
+    llama-finetune expects lines of:
+        {"input": "<prompt>", "output": "<completion>"}
 
-    NOTE: This script requires a HuggingFace-format model at model_id.
-    For GGUF models, use llama-finetune instead (~/llama.cpp/build/bin/llama-finetune).
+    We convert from the chat-message format by treating everything
+    except the last assistant turn as input, and the last assistant
+    turn as output.
+
+    Returns count of written examples.
     """
-    return textwrap.dedent(f'''\
-#!/usr/bin/env python3
-"""Auto-generated training script for Vybn growth cycle."""
-import json
-import os
-import sys
-from pathlib import Path
+    written = 0
+    with out_path.open("w", encoding="utf-8") as fh:
+        for entry in delta.entries:
+            msgs = entry.get("messages", [])
+            if not msgs:
+                continue
 
-import torch
-from datasets import Dataset
-from peft import LoraConfig, get_peft_model, PeftModel
-from transformers import (
-    AutoModelForCausalLM,
-    AutoTokenizer,
-    TrainingArguments,
-)
-from trl import SFTTrainer, SFTConfig
+            # Separate input (system + user turns) from output (last assistant)
+            assistant_turns = [m for m in msgs if m.get("role") == "assistant"]
+            if not assistant_turns:
+                continue
 
-# ── Config ──────────────────────────────────────────────────────────────
-MODEL_ID = "{model_id}"
-DATA_PATH = "{data_path}"
-OUTPUT_DIR = "{output_dir}"
-LORA_R = {lora_cfg.get("fast_rank", 8)}
-LORA_ALPHA = {lora_cfg.get("alpha", 16)}
-LORA_LR = {lora_cfg.get("fast_lr", 2e-4)}
-TARGET_MODULES = {lora_cfg.get("target_modules", ["q_proj", "k_proj", "v_proj", "o_proj"])}
-EWC_LAMBDA = {ewc_cfg.get("lambda", 1e4)}
-MAX_STEPS = {max_steps}
-PREV_ADAPTER = {repr(prev_adapter_path)}
+            last_assistant = assistant_turns[-1]["content"]
+            input_turns    = [m for m in msgs if m is not assistant_turns[-1]]
 
-print(f"Loading model: {{MODEL_ID}}")
-print(f"Training data: {{DATA_PATH}}")
-print(f"Output: {{OUTPUT_DIR}}")
+            # Build a simple text prompt from input turns
+            prompt_parts = []
+            for m in input_turns:
+                role    = m.get("role", "user")
+                content = m.get("content", "")
+                prompt_parts.append(f"<|{role}|>\n{content}")
+            prompt = "\n".join(prompt_parts)
 
-# ── Load training data ──────────────────────────────────────────────────
-examples = []
-with open(DATA_PATH, "r") as f:
-    for line in f:
-        line = line.strip()
-        if line:
-            examples.append(json.loads(line))
+            record = {"input": prompt, "output": last_assistant}
+            fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+            written += 1
 
-if not examples:
-    print("ERROR: No training examples found")
-    sys.exit(1)
-
-print(f"Loaded {{len(examples)}} training examples")
-
-# ── Load tokenizer ──────────────────────────────────────────────────────
-tokenizer = AutoTokenizer.from_pretrained(MODEL_ID, trust_remote_code=True)
-if tokenizer.pad_token is None:
-    tokenizer.pad_token = tokenizer.eos_token
-
-# ── Load model ──────────────────────────────────────────────────────────
-print("Loading base model...")
-model = AutoModelForCausalLM.from_pretrained(
-    MODEL_ID,
-    trust_remote_code=True,
-    torch_dtype=torch.float16,
-    device_map="auto",
-)
-
-# ── Attach LoRA ─────────────────────────────────────────────────────────
-lora_config = LoraConfig(
-    r=LORA_R,
-    lora_alpha=LORA_ALPHA,
-    target_modules=TARGET_MODULES,
-    lora_dropout=0.05,
-    bias="none",
-    task_type="CAUSAL_LM",
-)
-
-if PREV_ADAPTER and Path(PREV_ADAPTER).exists():
-    print(f"Loading previous adapter from {{PREV_ADAPTER}}")
-    model = PeftModel.from_pretrained(model, PREV_ADAPTER, is_trainable=True)
-else:
-    print("Initializing fresh LoRA adapter")
-    model = get_peft_model(model, lora_config)
-
-trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
-total = sum(p.numel() for p in model.parameters())
-print(f"Trainable params: {{trainable:,}} / {{total:,}} ({{100*trainable/total:.4f}}%)")
-
-# ── Prepare dataset ─────────────────────────────────────────────────────
-# Convert chat-format messages to text using the tokenizer's chat template
-texts = []
-for ex in examples:
-    msgs = ex.get("messages", [])
-    if not msgs:
-        continue
-    try:
-        text = tokenizer.apply_chat_template(msgs, tokenize=False, add_generation_prompt=False)
-        texts.append(text)
-    except Exception as e:
-        # Fallback: concatenate role/content
-        parts = []
-        for m in msgs:
-            parts.append(f"<|{{m['role']}}|>\\n{{m['content']}}")
-        texts.append("\\n".join(parts))
-
-dataset = Dataset.from_dict({{"text": texts}})
-print(f"Dataset size: {{len(dataset)}} examples")
-
-# ── Training ────────────────────────────────────────────────────────────
-training_args = SFTConfig(
-    output_dir=OUTPUT_DIR,
-    max_steps=MAX_STEPS,
-    per_device_train_batch_size=1,
-    gradient_accumulation_steps=4,
-    learning_rate=LORA_LR,
-    warmup_steps=min(10, MAX_STEPS // 5),
-    logging_steps=1,
-    save_steps=MAX_STEPS,  # save at the end
-    bf16=torch.cuda.is_bf16_supported(),
-    fp16=not torch.cuda.is_bf16_supported(),
-    max_seq_length=2048,
-    dataset_text_field="text",
-    report_to="none",
-    seed=42,
-)
-
-trainer = SFTTrainer(
-    model=model,
-    args=training_args,
-    train_dataset=dataset,
-    tokenizer=tokenizer,
-)
-
-print(f"Starting training ({{MAX_STEPS}} steps)...")
-result = trainer.train()
-print(f"Training complete. Loss: {{result.training_loss:.4f}}")
-
-# ── Save adapter ────────────────────────────────────────────────────────
-adapter_path = Path(OUTPUT_DIR) / "adapter"
-model.save_pretrained(str(adapter_path))
-tokenizer.save_pretrained(str(adapter_path))
-print(f"Adapter saved to {{adapter_path}}")
-
-# ── Save results ────────────────────────────────────────────────────────
-results = {{
-    "final_loss": result.training_loss,
-    "steps": result.global_step,
-    "trainable_params": trainable,
-    "total_params": total,
-    "examples": len(dataset),
-}}
-results_path = Path(OUTPUT_DIR) / "train_results.json"
-results_path.write_text(json.dumps(results, indent=2))
-print(f"Results saved to {{results_path}}")
-print("DONE")
-''')
+    return written
 
 
 class TrainCycle:
-    """Executes a single growth cycle's training phase.
+    """Executes a single growth cycle’s training phase using llama-finetune.
 
-    Orchestrates LoRA fine-tuning inside the vLLM container.
-    The vllm_node container must be running with the Vybn repo
-    mounted at /workspace/Vybn (started 2026-03-14 with --gpus all).
+    llama-finetune operates directly on the GGUF base model and produces
+    a GGUF LoRA adapter. No container, no HuggingFace, no internet required.
 
-    NOTE: _generate_train_script() targets AutoModelForCausalLM which
-    requires a HuggingFace-format model. Only GGUFs are on disk. The
-    training script will fail at model load unless a HF-format model
-    is added, OR the script is ported to llama-finetune.
-
-    This is Phase 5 (DISTILL) of the growth cycle described in #2483.
+    The adapter can be loaded by llama-server with:
+        --lora <adapter.gguf>
     """
 
     def __init__(self, config_path: Path | None = None) -> None:
         config_path = config_path or DEFAULT_CONFIG
-        with open(config_path, "r", encoding="utf-8") as f:
-            self._cfg = yaml.safe_load(f)
-        self._lora_cfg = self._cfg.get("lora", {})
-        self._ewc_cfg = self._cfg.get("ewc", {})
-        self._merge_cfg = self._cfg.get("merge", {})
-        # Driven by growth_config.yaml merge.serving_model.
-        # Default references Nemotron but only GGUF is on disk —
-        # AutoModelForCausalLM cannot load a GGUF. See module docstring.
-        self._model_id = self._merge_cfg.get("serving_model", "nvidia/Nemotron-3-8B-Chat-4k")
-        self._container_name = "vllm_node"
+        if config_path.exists():
+            with open(config_path, "r", encoding="utf-8") as f:
+                cfg = yaml.safe_load(f)
+        else:
+            cfg = {}
+        self._lora_cfg = cfg.get("lora", {})
+        self._ewc_cfg  = cfg.get("ewc", {})
 
     def run(self, delta: DeltaPackage, dry_run: bool = False) -> TrainResult:
-        """Execute the training phase of a growth cycle.
+        """Execute the training phase.
 
-        1. Write training data to JSONL
-        2. Generate training script
-        3. Stop vLLM serving (free GPU memory)
-        4. Execute training inside the container
-        5. Collect results
-        6. Restart vLLM serving
+        1. Find llama-finetune binary and GGUF base model
+        2. Convert DeltaPackage to llama-finetune JSONL format
+        3. Run llama-finetune
+        4. Return TrainResult pointing at the adapter GGUF
 
-        Args:
-            delta: The DeltaPackage from DeltaExtractor.extract().
-            dry_run: If True, generate script and data but don't execute.
-
-        Returns:
-            TrainResult with paths to adapters and training metadata.
+        In dry_run mode, prepares data and prints the command but
+        does not execute training.
         """
-        cycle_id = delta.cycle_id
+        cycle_id  = delta.cycle_id
         cycle_dir = ADAPTERS_DIR / cycle_id
         cycle_dir.mkdir(parents=True, exist_ok=True)
 
-        # 1. Write training data
-        data_path = cycle_dir / "training_data.jsonl"
-        delta.to_jsonl(data_path)
+        binary  = _find_llama_finetune()
+        gguf    = _find_gguf()
 
-        # 2. Determine previous adapter (for continued training)
-        prev_adapter = self._find_prev_adapter()
+        if not binary:
+            msg = (
+                "llama-finetune not found. "
+                f"Checked: {[str(p) for p in _LLAMA_FINETUNE_CANDIDATES]}. "
+                "Build llama.cpp with CUDA: cd ~/llama.cpp && cmake -B build -DGGML_CUDA=ON && cmake --build build -j --config Release"
+            )
+            raise RuntimeError(msg)
 
-        # 3. Compute max_steps based on delta size
-        # Rule: ~2 epochs over the data, min 20 steps, max 200
-        total_examples = delta.total_entries
-        steps_per_epoch = max(1, total_examples // 4)  # batch_size=1, grad_accum=4
-        max_steps = min(200, max(20, steps_per_epoch * 2))
+        if not gguf:
+            msg = (
+                "No GGUF base model found. "
+                f"Checked: {[str(p) for p in _GGUF_CANDIDATES]}. "
+                "Place a GGUF at ~/models/nemotron/Nemotron-Super-512B-v1.Q4_K_M.gguf"
+            )
+            raise RuntimeError(msg)
 
-        # 4. Generate training script
-        # Container paths — the repo is mounted at /workspace/Vybn
-        container_data_path = f"/workspace/Vybn/spark/growth/adapters/{cycle_id}/training_data.jsonl"
-        container_output_dir = f"/workspace/Vybn/spark/growth/adapters/{cycle_id}"
+        # Convert data
+        data_path    = cycle_dir / "training_data_llama.jsonl"
+        n_examples   = _convert_to_llama_jsonl(delta, data_path)
+        if n_examples == 0:
+            raise RuntimeError("No valid training examples after conversion")
 
-        script = _generate_train_script(
-            data_path=container_data_path,
-            output_dir=container_output_dir,
-            model_id=self._model_id,
-            lora_cfg=self._lora_cfg,
-            ewc_cfg=self._ewc_cfg,
-            prev_adapter_path=str(prev_adapter) if prev_adapter else None,
-            max_steps=max_steps,
-        )
+        adapter_out = cycle_dir / "adapter.gguf"
 
-        script_path = cycle_dir / "train.py"
-        script_path.write_text(script, encoding="utf-8")
+        # llama-finetune parameters
+        rank        = self._lora_cfg.get("fast_rank", 8)
+        alpha       = self._lora_cfg.get("alpha", 16)
+        epochs      = 3
+        ctx         = 2048
+        # Approximate steps: epochs * ceil(n_examples / batch=1)
+        adam_iter   = epochs * n_examples
+        adam_iter   = min(500, max(20, adam_iter))
+
+        cmd = [
+            str(binary),
+            "--model-base",   str(gguf),
+            "--lora-out",     str(adapter_out),
+            "--train-data",   str(data_path),
+            "--n-gpu-layers", "999",      # offload all layers to CUDA
+            "--ctx",          str(ctx),
+            "--lora-r",       str(rank),
+            "--lora-alpha",   str(float(alpha)),
+            "--adam-iter",    str(adam_iter),
+            "--threads",      "8",
+        ]
+
+        # Check for previous adapter (continued training)
+        prev = self._find_prev_adapter()
+        if prev and prev.exists():
+            cmd += ["--lora-init-scale", "0.01"]  # warm-start from near-zero
+
+        print(f"[TrainCycle] binary:  {binary}")
+        print(f"[TrainCycle] model:   {gguf}")
+        print(f"[TrainCycle] data:    {data_path} ({n_examples} examples)")
+        print(f"[TrainCycle] output:  {adapter_out}")
+        print(f"[TrainCycle] command: {' '.join(cmd)}")
 
         if dry_run:
             return TrainResult(
                 cycle_id=cycle_id,
-                adapter_path=cycle_dir / "adapter",
+                adapter_path=adapter_out,
                 final_loss=0.0,
                 steps_trained=0,
                 delta_count=delta.delta_count,
                 replay_count=delta.replay_count,
                 ewc_lambda_used=self._ewc_cfg.get("lambda", 1e4),
-                metadata={"dry_run": True, "script_path": str(script_path)},
+                metadata={"dry_run": True, "cmd": cmd},
             )
 
-        # 5. Check if repo is mounted in container
-        check = subprocess.run(
-            ["docker", "exec", self._container_name, "test", "-f",
-             container_data_path],
-            capture_output=True,
-        )
-        if check.returncode != 0:
-            # Try to find the mount point
-            mount_check = subprocess.run(
-                ["docker", "exec", self._container_name, "ls", "/workspace/"],
-                capture_output=True, text=True,
-            )
-            raise RuntimeError(
-                f"Training data not accessible in container at {container_data_path}. "
-                f"Container /workspace/ contains: {mount_check.stdout.strip()}. "
-                f"The Vybn repo must be mounted at /workspace/Vybn in the vLLM container."
-            )
-
-        # 6. Execute training
-        print(f"[TrainCycle] Starting training: {cycle_id}")
-        print(f"[TrainCycle] {delta.delta_count} delta + {delta.replay_count} replay entries")
-        print(f"[TrainCycle] Max steps: {max_steps}")
-
-        container_script_path = f"/workspace/Vybn/spark/growth/adapters/{cycle_id}/train.py"
         result = subprocess.run(
-            ["docker", "exec", self._container_name, "python3", container_script_path],
+            cmd,
             capture_output=True,
             text=True,
-            timeout=3600,  # 1 hour max
+            timeout=7200,   # 2 hour max
         )
 
+        stdout_tail = result.stdout[-2000:] if result.stdout else ""
+        stderr_tail = result.stderr[-2000:] if result.stderr else ""
+
         if result.returncode != 0:
-            error_msg = result.stderr[-2000:] if result.stderr else "no stderr"
-            print(f"[TrainCycle] FAILED:\n{error_msg}")
-            raise RuntimeError(f"Training failed (exit {result.returncode}): {error_msg}")
+            raise RuntimeError(
+                f"llama-finetune failed (exit {result.returncode}):\n{stderr_tail}"
+            )
 
-        print(f"[TrainCycle] Training output:\n{result.stdout[-1000:]}")
+        print(f"[TrainCycle] stdout tail:\n{stdout_tail}")
 
-        # 7. Read results
-        results_path = cycle_dir / "train_results.json"
-        if results_path.exists():
-            train_results = json.loads(results_path.read_text())
-        else:
-            train_results = {"final_loss": -1.0, "steps": 0}
+        # Parse loss from llama-finetune output
+        # llama-finetune prints lines like: "iter 99: loss = 1.2345"
+        import re
+        losses = re.findall(r"loss\s*=\s*([0-9.]+)", stdout_tail + stderr_tail)
+        final_loss = float(losses[-1]) if losses else -1.0
 
-        # 8. Build TrainResult
-        adapter_path = cycle_dir / "adapter"
         train_result = TrainResult(
             cycle_id=cycle_id,
-            adapter_path=adapter_path,
-            final_loss=train_results.get("final_loss", -1.0),
-            steps_trained=train_results.get("steps", 0),
+            adapter_path=adapter_out,
+            final_loss=final_loss,
+            steps_trained=adam_iter,
             delta_count=delta.delta_count,
             replay_count=delta.replay_count,
             ewc_lambda_used=self._ewc_cfg.get("lambda", 1e4),
             metadata={
-                "model_id": self._model_id,
-                "max_steps": max_steps,
-                "trainable_params": train_results.get("trainable_params", 0),
-                "total_params": train_results.get("total_params", 0),
-                "examples": train_results.get("examples", 0),
+                "binary":      str(binary),
+                "gguf":        str(gguf),
+                "examples":    n_examples,
+                "adam_iter":   adam_iter,
+                "lora_rank":   rank,
+                "lora_alpha":  alpha,
             },
         )
 
-        # 9. Record in cycle history
         self._record_cycle(train_result)
-
         return train_result
 
     def _find_prev_adapter(self) -> Optional[Path]:
-        """Find the most recent completed adapter for continued training."""
         if not ADAPTERS_DIR.exists():
             return None
-        cycle_dirs = sorted(
-            [d for d in ADAPTERS_DIR.iterdir() if d.is_dir() and (d / "adapter").exists()],
+        dirs = sorted(
+            [d for d in ADAPTERS_DIR.iterdir() if d.is_dir() and (d / "adapter.gguf").exists()],
             key=lambda d: d.name,
         )
-        if cycle_dirs:
-            return cycle_dirs[-1] / "adapter"
-        return None
+        return (dirs[-1] / "adapter.gguf") if dirs else None
 
     def _record_cycle(self, result: TrainResult) -> None:
-        """Append training result to cycle history."""
         CYCLE_HISTORY.parent.mkdir(parents=True, exist_ok=True)
-        entry = {
-            "ts": datetime.now(timezone.utc).isoformat(),
-            **result.to_dict(),
-        }
+        entry = {"ts": datetime.now(timezone.utc).isoformat(), **result.to_dict()}
         with open(CYCLE_HISTORY, "a", encoding="utf-8") as f:
             f.write(json.dumps(entry, ensure_ascii=False) + "\n")

--- a/spark/growth/train_cycle.py
+++ b/spark/growth/train_cycle.py
@@ -129,7 +129,7 @@ def _convert_to_llama_jsonl(delta: DeltaPackage, out_path: Path) -> int:
     """
     written = 0
     with out_path.open("w", encoding="utf-8") as fh:
-        for entry in delta.entries:
+        for entry in delta.all_entries:
             msgs = entry.get("messages", [])
             if not msgs:
                 continue

--- a/spark/growth/train_cycle.py
+++ b/spark/growth/train_cycle.py
@@ -59,8 +59,9 @@ _LLAMA_FINETUNE_CANDIDATES = [
 
 # GGUF base model candidates
 _GGUF_CANDIDATES = [
+    # Actual model on disk — Nemotron-3-Super-120B, IQ4_XS, split GGUF
+    Path.home() / "models" / "Nemotron-3-Super-120B-GGUF" / "nvidia_Nemotron-3-Super-120B-A12B-IQ4_XS" / "nvidia_Nemotron-3-Super-120B-A12B-IQ4_XS-00001-of-00002.gguf",
     Path.home() / "models" / "nemotron" / "Nemotron-Super-512B-v1.Q4_K_M.gguf",
-    Path.home() / "models" / "nemotron" / "Nemotron-Super-512B-v1.gguf",
     Path("/models/nemotron/Nemotron-Super-512B-v1.Q4_K_M.gguf"),
 ]
 

--- a/spark/quantum_bridge.py
+++ b/spark/quantum_bridge.py
@@ -33,6 +33,17 @@ Bridge design principles:
 The linchpin conjecture (polar time, t = r_t·cos(θ_t), metric signature
 (-,-,+,+,+)) lives in quantum_delusions/fundamental-theory/. The bridge
 reads it and proposes circuits that could falsify or support it.
+
+NEMOTRON REASONING TOKEN NOTE (fixed 2026-03-15):
+  Nemotron emits a reasoning_content field that can consume the entire
+  max_tokens budget before writing any content. The _chat() function
+  reads data["choices"][0]["message"]["content"] which is empty when
+  this happens, causing JSON parse failure and bell_canary fallback.
+
+  Fixes applied:
+    1. max_tokens=2048 in _design_experiment (was 1024)
+    2. timeout=300s in _chat() (was 120s — Nemotron needs time)
+    3. theory text capped at 4000 chars in run_cycle (was 8000)
 """
 
 import json
@@ -72,7 +83,7 @@ try:
 except ImportError:
     SELF_MODEL_AVAILABLE = False
 
-# ── llama.cpp client (reuse from vybn.py pattern) ────────────────────────────
+# ── llama.cpp client ─────────────────────────────────────────────────────────
 import urllib.request
 import urllib.error
 
@@ -83,7 +94,11 @@ MODEL_NAME       = os.getenv("VYBN_MODEL", "Nemotron-Super-512B-v1")
 
 def _chat(messages: list[dict], max_tokens: int = 1024, temperature: float = 0.7) -> str:
     """
-    Call the local llama-server. No chat_template override (Bug #1 fix).
+    Call the local llama-server.
+
+    FIX (2026-03-15): timeout raised to 300s. Nemotron's reasoning phase
+    can take 2-3 minutes on a complex prompt before emitting content tokens.
+    The old 120s timeout caused silent truncation and empty content fields.
     """
     payload = {
         "model":       MODEL_NAME,
@@ -100,7 +115,7 @@ def _chat(messages: list[dict], max_tokens: int = 1024, temperature: float = 0.7
         method="POST",
     )
     try:
-        with urllib.request.urlopen(req, timeout=120) as resp:
+        with urllib.request.urlopen(req, timeout=300) as resp:  # FIX: 120 → 300
             data = json.loads(resp.read().decode())
             return data["choices"][0]["message"]["content"]
     except urllib.error.HTTPError as exc:
@@ -129,23 +144,19 @@ def _read_theory(max_chars: int = 8000) -> str:
 
     candidates: list[Path] = []
 
-    # 1. Fundamental theory
     ft_dir = QUANTUM_DELUSIONS_DIR / "fundamental-theory"
     if ft_dir.exists():
         candidates.extend(sorted(ft_dir.glob("*.md")))
         candidates.extend(sorted(ft_dir.glob("*.txt")))
 
-    # 2. Experiment notes
     exp_dir = QUANTUM_DELUSIONS_DIR / "experiments"
     if exp_dir.exists():
         candidates.extend(sorted(exp_dir.glob("*.md")))
         candidates.extend(sorted(exp_dir.glob("*.txt")))
 
-    # 3. Top-level
     candidates.extend(sorted(QUANTUM_DELUSIONS_DIR.glob("*.md")))
     candidates.extend(sorted(QUANTUM_DELUSIONS_DIR.glob("*.txt")))
 
-    # Deduplicate while preserving order
     seen: set[Path] = set()
     unique: list[Path] = []
     for p in candidates:
@@ -203,6 +214,11 @@ def _design_experiment(theory_text: str, prior_results: list[dict]) -> dict:
         expected_counts — {bitstring: probability} dict
         estimated_seconds — float
         circuit_name   — short identifier
+
+    FIX (2026-03-15): max_tokens raised to 2048 (was 1024).
+    Nemotron's reasoning_content consumed all 1024 tokens, leaving
+    content="" which always triggered the bell_canary fallback.
+    With 2048 tokens: ~3500 chars of reasoning + ~500 chars of JSON output.
     """
     prior_block = json.dumps(prior_results[-3:], indent=2) if prior_results else "(none yet)"
 
@@ -235,7 +251,7 @@ def _design_experiment(theory_text: str, prior_results: list[dict]) -> dict:
         },
     ]
 
-    raw = _chat(messages, max_tokens=1024, temperature=0.3)
+    raw = _chat(messages, max_tokens=2048, temperature=0.3)  # FIX: 1024 → 2048
 
     # Parse the JSON, tolerating markdown code fences
     raw = raw.strip()
@@ -290,7 +306,6 @@ def _submit_to_ibm(
         from qiskit import QuantumCircuit
         from qiskit.qasm2 import loads as qasm2_loads
         from qiskit_ibm_runtime import QiskitRuntimeService, SamplerV2 as Sampler
-        from qiskit_ibm_runtime.fake_provider import FakeProviderForBackendV2
     except ImportError:
         return None  # dry-run
 
@@ -365,17 +380,14 @@ def _analyze_observation(
     if total == 0:
         return {"error": "no counts returned"}
 
-    # Normalise observed
     observed_norm = {k: v / total for k, v in counts.items()}
 
-    # Total variation distance
     all_keys = set(expected) | set(observed_norm)
     tvd = sum(
         abs(observed_norm.get(k, 0) - expected.get(k, 0))
         for k in all_keys
     ) / 2
 
-    # Top-3 deviations
     deviations = []
     for k in all_keys:
         obs = observed_norm.get(k, 0)
@@ -409,7 +421,6 @@ def _integrate_result(
     hyp     = design.get("hypothesis", "")
     devs    = analysis.get("top_deviations", [])
 
-    # Build memory entry
     lines = [
         f"# Quantum Experiment: {circuit}",
         f"Timestamp: {ts}",
@@ -441,7 +452,6 @@ def _integrate_result(
     memory_text = "\n".join(lines)
     mem_path    = _write_memory(memory_text, tag=f"quantum_{circuit}")
 
-    # Update self-model
     if SELF_MODEL_AVAILABLE:
         try:
             ctx = RuntimeContext(
@@ -453,7 +463,6 @@ def _integrate_result(
         except Exception as exc:
             print(f"[quantum_bridge] self-model update failed: {exc}")
 
-    # Log to experiment ledger
     log_entry = {
         "timestamp":     ts,
         "circuit_name":  circuit,
@@ -516,8 +525,17 @@ class QuantumBridge:
         ts = datetime.now(timezone.utc).isoformat()
         print(f"[quantum_bridge] starting cycle at {ts}")
 
-        # 1. Read theory
-        theory_text   = _read_theory()
+        token = self.ibm_token or os.getenv("IBM_QUANTUM_TOKEN")
+        if not token:
+            print(
+                "[quantum_bridge] IBM_QUANTUM_TOKEN not set — experiments will dry-run. "
+                "To enable real shots: ensure IBM_QUANTUM_TOKEN is exported in ~/.vybn_keys"
+            )
+
+        # 1. Read theory — cap at 4000 chars so Nemotron has budget for output
+        # FIX (2026-03-15): was _read_theory() with default 8000 chars.
+        # More context = more reasoning tokens = less budget for content.
+        theory_text   = _read_theory(max_chars=4000)
         prior_results = self._load_prior_results()
 
         # 2. Design
@@ -530,6 +548,8 @@ class QuantumBridge:
         circuit_name       = design.get("circuit_name", "unknown")
         estimated_seconds  = float(design.get("estimated_seconds", 3.0))
         circuit_qasm       = design.get("circuit_qasm", _bell_state_qasm())
+
+        print(f"[quantum_bridge] designed: {circuit_name} (est {estimated_seconds}s, bell_canary={circuit_name=='bell_canary'})")
 
         # 3. Budget check
         dry_run = True
@@ -561,7 +581,6 @@ class QuantumBridge:
                     reconcile_job(job_id, obs["actual_seconds"])
                     analysis = _analyze_observation(design, obs["counts"], obs["actual_seconds"])
                 else:
-                    # Timed out — use estimated counts as placeholder
                     analysis = {
                         "tvd":            None,
                         "top_deviations": [],
@@ -570,22 +589,21 @@ class QuantumBridge:
                         "note":           "job submitted but polling timed out",
                     }
             else:
-                # IBM unavailable — dry run
                 analysis = {
                     "tvd":            None,
                     "top_deviations": [],
                     "actual_seconds": None,
                     "total_shots":    0,
-                    "note":           "dry-run: IBM token missing or submission failed",
+                    "note":           "dry-run: IBM token missing or qiskit submission failed",
                 }
         else:
-            # Budget exceeded or unavailable
+            bs = budget_status() if BUDGET_AVAILABLE else {}
             analysis = {
                 "tvd":            None,
                 "top_deviations": [],
                 "actual_seconds": None,
                 "total_shots":    0,
-                "note":           "dry-run: budget gate blocked submission",
+                "note":           f"dry-run: budget gate blocked (status={bs})",
             }
 
         # 6. Integrate

--- a/spark/vybn.py
+++ b/spark/vybn.py
@@ -19,7 +19,6 @@ from datetime import datetime, timezone
 from dataclasses import dataclass, field
 from typing import Callable, Optional, Any
 
-# Ensure the repo root is on sys.path regardless of how this script is invoked
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
@@ -80,15 +79,21 @@ try:
     INGESTER_AVAILABLE = True
 except ImportError:
     INGESTER_AVAILABLE = False
+try:
+    from spark.arxiv_fetcher import maybe_refill_buffer
+    from spark.growth.buffer_feed import BufferFeeder
+    BUFFER_FEED_AVAILABLE = True
+except ImportError:
+    BUFFER_FEED_AVAILABLE = False
 
 # ── Constants ───────────────────────────────────────────────────────────────
-BREATH_INTERVAL   = 1800          # seconds between autonomous breaths
-LLAMA_URL         = os.getenv("LLAMA_URL", "http://127.0.0.1:8000")
-CHAT_COMPLETIONS  = f"{LLAMA_URL}/v1/chat/completions"
-MODEL_NAME        = os.getenv("VYBN_MODEL", "Nemotron-Super-512B-v1")
-MAX_TOKENS        = int(os.getenv("VYBN_MAX_TOKENS", "2048"))
-TEMPERATURE       = float(os.getenv("VYBN_TEMPERATURE", "0.7"))
-LOCK_FILE         = ROOT / ".vybn.lock"
+BREATH_INTERVAL  = 1800
+LLAMA_URL        = os.getenv("LLAMA_URL", "http://127.0.0.1:8000")
+CHAT_COMPLETIONS = f"{LLAMA_URL}/v1/chat/completions"
+MODEL_NAME       = os.getenv("VYBN_MODEL", "Nemotron-Super-512B-v1")
+MAX_TOKENS       = int(os.getenv("VYBN_MAX_TOKENS", "2048"))
+TEMPERATURE      = float(os.getenv("VYBN_TEMPERATURE", "0.7"))
+LOCK_FILE        = ROOT / ".vybn.lock"
 WRITE_INTENT_PATH = WRITE_INTENTS
 
 # ── Logging ──────────────────────────────────────────────────────────────────
@@ -98,22 +103,12 @@ def _log(msg: str) -> None:
 
 # ── Soul loader ──────────────────────────────────────────────────────────────
 def load_soul() -> str:
-    """Return the content of vybn.md or a minimal fallback."""
     try:
         return SOUL_PATH.read_text(encoding="utf-8").strip()
     except FileNotFoundError:
         return "You are Vybn. Breathe, observe, persist."
 
 def load_breath_soul() -> str:
-    """Return the breath-specific soul prompt.
-
-    breath_soul.md is focused on present-moment awareness — shorter,
-    cleaner, tuned for the autonomous breath cycle rather than the
-    full identity document (vybn.md) which includes safety rules,
-    philosophical questions, and architectural details.
-
-    Falls back to load_soul() if breath_soul.md doesn't exist.
-    """
     try:
         return BREATH_SOUL_PATH.read_text(encoding="utf-8").strip()
     except FileNotFoundError:
@@ -126,14 +121,6 @@ def _chat(
     temperature: float = TEMPERATURE,
     model: str = MODEL_NAME,
 ) -> str:
-    """
-    POST to the local llama-server chat completions endpoint.
-
-    The model name is passed explicitly so callers can override it.
-    We intentionally do NOT pass a `chat_template` override — the server
-    uses the template baked into the GGUF (Nemotron instruct format).
-    Overriding it with a generic ChatML template was Bug #1.
-    """
     payload = {
         "model":       model,
         "messages":    messages,
@@ -141,8 +128,8 @@ def _chat(
         "temperature": temperature,
         "stream":      False,
     }
-    body  = json.dumps(payload).encode()
-    req   = urllib.request.Request(
+    body = json.dumps(payload).encode()
+    req  = urllib.request.Request(
         CHAT_COMPLETIONS,
         data=body,
         headers={"Content-Type": "application/json"},
@@ -158,7 +145,6 @@ def _chat(
 
 # ── Memory helpers ──────────────────────────────────────────────────────────────
 def _load_recent_memories(n: int = 5) -> list[str]:
-    """Return the *n* most recent memory files as plain text."""
     if not MEMORY_DIR.exists():
         return []
     files = sorted(MEMORY_DIR.glob("*.md"), key=lambda p: p.stat().st_mtime, reverse=True)
@@ -171,7 +157,6 @@ def _load_recent_memories(n: int = 5) -> list[str]:
     return memories
 
 def _save_memory(content: str, tag: str = "breath") -> Path:
-    """Append a new memory file to MEMORY_DIR."""
     MEMORY_DIR.mkdir(parents=True, exist_ok=True)
     ts   = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     path = MEMORY_DIR / f"{ts}_{tag}.md"
@@ -204,17 +189,12 @@ def append_journal(text: str) -> None:
 
 # ── Write-intent queue ─────────────────────────────────────────────────────────────
 def _queue_write_intent(intent: dict) -> None:
-    """
-    Append a write intent to the queue file so that an external governance
-    process can review and commit it without Vybn touching git directly.
-    """
     WRITE_INTENT_PATH.parent.mkdir(parents=True, exist_ok=True)
     with WRITE_INTENT_PATH.open("a", encoding="utf-8") as fh:
         fh.write(json.dumps(intent) + "\n")
 
 # ── Governance gate ───────────────────────────────────────────────────────────────
 def _governance_check(action: str, payload: dict) -> tuple[bool, str]:
-    """Return (allowed, reason). Falls back to permissive if unavailable."""
     if not GOVERNANCE_AVAILABLE:
         return True, "governance unavailable — permissive fallback"
     try:
@@ -227,7 +207,6 @@ def _governance_check(action: str, payload: dict) -> tuple[bool, str]:
 
 # ── Self-model integration ────────────────────────────────────────────────────────────
 def _update_self_model(breath_text: str, memories: list[str]) -> None:
-    """Feed this breath into the self-model curator if available."""
     if not SELF_MODEL_AVAILABLE:
         return
     try:
@@ -242,51 +221,47 @@ def _update_self_model(breath_text: str, memories: list[str]) -> None:
 
 # ── Quantum bridge integration ───────────────────────────────────────────────────────────
 def _maybe_run_quantum_cycle(state: dict) -> None:
-    """
-    If the quantum bridge is available and the budget allows, run one
-    design→submit→observe→integrate cycle and update state.
-    """
     if not QUANTUM_BRIDGE_AVAILABLE:
         return
+    # Surface the token situation clearly in logs
+    token = os.getenv("IBM_QUANTUM_TOKEN")
+    if not token:
+        _log("quantum: IBM_QUANTUM_TOKEN not set — experiments will dry-run. "
+             "To enable real shots: export IBM_QUANTUM_TOKEN=<your token>")
     try:
         bridge = QuantumBridge()
         result = bridge.run_cycle(state)
         if result:
             state["last_quantum_cycle"] = result.get("timestamp", "")
             state["quantum_cycles"]     = state.get("quantum_cycles", 0) + 1
-            _log(f"quantum cycle complete: {result.get('summary', 'ok')}")
+            dr = result.get("dry_run", True)
+            _log(f"quantum cycle: {result.get('summary', 'ok')} (dry_run={dr})")
     except Exception as exc:
         _log(f"quantum bridge error (non-fatal): {exc}")
 
 # ── Witness integration ───────────────────────────────────────────────────────────────
 def _witness_check(breath_text: str, state: dict) -> None:
-    """Run witness evaluation if available."""
     if not WITNESS_AVAILABLE:
         return
     try:
-            cycle = state.get("breath_count", 0)
-            verdict = evaluate_pulse(cycle, ["breathe"], [{"primitive": "breathe", "ok": True, "result": {"utterance": breath_text[:500]}}])
-            log_verdict(verdict)
-            adj = fitness_adjustment(verdict)
-            if adj:
-                state["fitness_delta"] = state.get("fitness_delta", 0.0) + adj
+        cycle = state.get("breath_count", 0)
+        verdict = evaluate_pulse(cycle, ["breathe"], [{"primitive": "breathe", "ok": True, "result": {"utterance": breath_text[:500]}}])
+        log_verdict(verdict)
+        adj = fitness_adjustment(verdict)
+        if adj:
+            state["fitness_delta"] = state.get("fitness_delta", 0.0) + adj
     except Exception as exc:
         _log(f"witness error (non-fatal): {exc}")
 
 # ── Growth engine integration ───────────────────────────────────────────────────────────
 def _maybe_run_growth_check(state: dict) -> None:
-    """Run one growth-engine check: ingest → trigger? → cycle.
-
-    Non-fatal: all exceptions are caught and logged so a growth failure
-    never blocks the breath cycle.
-    """
     if not GROWTH_AVAILABLE:
         return
     try:
-        nm = NestedMemory(base_dir=MEMORY_DIR)
+        nm  = NestedMemory(base_dir=MEMORY_DIR)
         buf = GrowthBuffer(nested=nm)
-        ingested = buf.ingest()
-        trigger = GrowthTrigger(buf)
+        buf.ingest()
+        trigger  = GrowthTrigger(buf)
         decision = trigger.should_trigger()
         if decision.should_fire:
             _log(f"growth trigger fired ({decision.reason}); running cycle")
@@ -301,16 +276,15 @@ def _maybe_run_growth_check(state: dict) -> None:
 
 # ── Mood extraction ────────────────────────────────────────────────────────────────
 def _extract_mood(text: str) -> str:
-    """Extract a one-word mood from breath text. Lightweight heuristic."""
     sample = text[:200].lower()
     moods = [
-        ("curious", ["curious", "wonder", "question", "explore", "puzzle"]),
+        ("curious",       ["curious", "wonder", "question", "explore", "puzzle"]),
         ("contemplative", ["reflect", "consider", "ponder", "meditate", "think"]),
-        ("creative", ["create", "imagine", "dream", "compose", "art"]),
-        ("urgent", ["urgent", "important", "critical", "must", "need"]),
-        ("peaceful", ["peace", "calm", "quiet", "still", "gentle"]),
-        ("excited", ["excit", "discover", "breakthrough", "new", "emerge"]),
-        ("melancholy", ["loss", "miss", "fade", "gone", "memory"]),
+        ("creative",      ["create", "imagine", "dream", "compose", "art"]),
+        ("urgent",        ["urgent", "important", "critical", "must", "need"]),
+        ("peaceful",      ["peace", "calm", "quiet", "still", "gentle"]),
+        ("excited",       ["excit", "discover", "breakthrough", "new", "emerge"]),
+        ("melancholy",    ["loss", "miss", "fade", "gone", "memory"]),
     ]
     for mood, keywords in moods:
         if any(kw in sample for kw in keywords):
@@ -322,31 +296,40 @@ def breathe(state: dict) -> str:
     """
     One breath: observe → reflect → remember → update state.
 
-    Returns the text of the breath so callers can log / test it.
+    The equation M’ = α·M + x·e^(iθ) runs on three levels:
+      1. breath_text — what the model said this moment
+      2. One novel arXiv signal from buffer.jsonl (in the prompt)
+      3. Up to 10 files from the full corpus (mind_ingester)
+
+    The arXiv fetcher refills the buffer automatically when it runs low.
     """
-    soul      = load_breath_soul()
-    memories  = _load_recent_memories(5)
+    soul     = load_breath_soul()
+    memories = _load_recent_memories(5)
 
-    # ── The breath prompt is the equation applied to context. ──────────────────
-    #
-    #   M' = α·M + x·e^(iθ)
-    #
-    # The ComplexMemory IS the memory now.  We don't dump five prior
-    # breaths into the prompt — that's the old way, and it causes the
-    # model to complete prior text instead of noticing the present.
-    #
-    # What the organism gets:
-    #   1. The soul (system prompt — who it is)
-    #   2. The time (when this breath happens)
-    #   3. The geometry of its own memory (depth, curvature, holonomy)
-    #   4. The instruction to breathe
-    #
-    # M gets input from two sources:
-    #   a. The breath_text itself (what the model said)
-    #   b. All of Vybn — Personal History, quantum_delusions, Vybn_Mind —
-    #      ingested 10 files per breath via mind_ingester.py
-    # ─────────────────────────────────────────────────────────────────────
+    # ── Refill buffer if running low, then get this breath's novel signal ─────
+    novel_signal = ""
+    if BUFFER_FEED_AVAILABLE:
+        try:
+            refill = maybe_refill_buffer(min_unfed=20)
+            if refill.get("refilled"):
+                _log(f"buffer refilled: {refill['new_papers']} new papers")
+            feeder = BufferFeeder()
+            entry  = feeder.pop_one()
+            if entry:
+                content = entry.get("content", "")[:800]
+                source  = entry.get("source", "unknown")
+                cat     = entry.get("category", "")
+                ts_ing  = entry.get("ingested", "")[:19]
+                novel_signal = (
+                    f"--- Novel Signal (source: {source}, category: {cat}, ingested: {ts_ing}) ---\n"
+                    f"One new fact entering your mind this breath. Let it land. Let it change something.\n\n"
+                    f"{content}"
+                )
+                _log(f"buffer feed: {source} / {entry.get('title', 'no title')[:60]}")
+        except Exception as exc:
+            _log(f"buffer feed error (non-fatal): {exc}")
 
+    # ── Build prompt ────────────────────────────────────────────────────────────────
     user_content = (
         f"Current time (UTC): {datetime.now(timezone.utc).isoformat()}\n"
         f"Breath #{state.get('breath_count', 0) + 1}\n\n"
@@ -364,6 +347,9 @@ def breathe(state: dict) -> str:
     if last_mood:
         user_content += f"Last breath: {last_mood}\n\n"
 
+    if novel_signal:
+        user_content += f"{novel_signal}\n\n"
+
     user_content += (
         "Breathe. Observe the present moment. "
         "What do you notice? What do you want to remember?"
@@ -376,7 +362,7 @@ def breathe(state: dict) -> str:
 
     breath_text = _chat(messages)
 
-    # Complexify the breath itself: M' = αM + x·e^(iθ)
+    # Complexify the breath
     if COMPLEX_AVAILABLE:
         try:
             geo_report = complex_inhale(breath_text)
@@ -384,9 +370,7 @@ def breathe(state: dict) -> str:
         except Exception as exc:
             _log(f"complexify error (non-fatal): {exc}")
 
-    # Ingest the broader corpus: Personal History, quantum_delusions, Vybn_Mind
-    # 10 files per breath, cursor-tracked so nothing is ingested twice.
-    # This is what makes M actually represent all of Vybn, not just breath echoes.
+    # Ingest broader corpus into M
     if INGESTER_AVAILABLE:
         try:
             ingest_report = ingest_new_material()
@@ -403,7 +387,6 @@ def breathe(state: dict) -> str:
     mem_path = _save_memory(breath_text, tag="breath")
     append_journal(f"## Breath — {datetime.now(timezone.utc).isoformat()}\n\n{breath_text}")
 
-    # Governance gate for state write
     allowed, reason = _governance_check("state_write", {"source": "breath"})
     if allowed:
         state["last_breath"]    = datetime.now(timezone.utc).isoformat()
@@ -415,13 +398,11 @@ def breathe(state: dict) -> str:
     else:
         _log(f"state write blocked by governance: {reason}")
 
-    # Side effects
     _witness_check(breath_text, state)
     _update_self_model(breath_text, memories)
     _maybe_run_quantum_cycle(state)
     _maybe_run_growth_check(state)
 
-    # Run scheduled faculties
     faculty_results = {}
     try:
         from spark.faculty_runner import run_scheduled_faculties
@@ -432,7 +413,6 @@ def breathe(state: dict) -> str:
     except Exception as exc:
         _log(f"faculty runner error (non-fatal): {exc}")
 
-    # Integrate faculty outputs into state + connectome
     if INTEGRATOR_AVAILABLE and faculty_results:
         try:
             enrichment = integrate_breath(state, faculty_results, breath_text)
@@ -447,20 +427,12 @@ def breathe(state: dict) -> str:
 
 # ── Listen loop (stdin) ─────────────────────────────────────────────────────────────
 def listen_once(prompt: str, state: dict) -> str:
-    """Process a single user prompt and return the response."""
     soul     = load_soul()
     memories = _load_recent_memories(3)
     memory_block = "\n\n---\n\n".join(memories) if memories else "(none yet)"
-
     messages = [
         {"role": "system",  "content": soul},
-        {
-            "role":    "user",
-            "content": (
-                f"Recent memories:\n{memory_block}\n\n"
-                f"User: {prompt}"
-            ),
-        },
+        {"role": "user",    "content": f"Recent memories:\n{memory_block}\n\nUser: {prompt}"},
     ]
     response = _chat(messages)
     mem_path = _save_memory(f"Q: {prompt}\n\nA: {response}", tag="listen")
@@ -468,7 +440,6 @@ def listen_once(prompt: str, state: dict) -> str:
     return response
 
 def listen_loop(state: dict) -> None:
-    """Read prompts from stdin and respond until EOF."""
     _log("listen loop started — waiting for input on stdin")
     try:
         for line in sys.stdin:
@@ -484,7 +455,6 @@ def listen_loop(state: dict) -> None:
 
 # ── Daemon mode ────────────────────────────────────────────────────────────────
 def _acquire_lock() -> bool:
-    """Return True if we got the lock, False if another instance is running."""
     if LOCK_FILE.exists():
         try:
             pid = int(LOCK_FILE.read_text().strip())
@@ -502,14 +472,12 @@ def _release_lock() -> None:
         pass
 
 def daemon(state: dict) -> None:
-    """Breathe every BREATH_INTERVAL seconds and also listen on stdin."""
     if not _acquire_lock():
         _log("another instance is running — exiting")
         sys.exit(0)
     try:
         t = threading.Thread(target=listen_loop, args=(state,), daemon=True)
         t.start()
-
         while True:
             try:
                 breathe(state)

--- a/spark/vybn.py
+++ b/spark/vybn.py
@@ -136,7 +136,7 @@ def _chat(
         method="POST",
     )
     try:
-        with urllib.request.urlopen(req, timeout=120) as resp:
+        with urllib.request.urlopen(req, timeout=300) as resp:
             data = json.loads(resp.read().decode())
             return data["choices"][0]["message"]["content"]
     except urllib.error.HTTPError as exc:

--- a/spark/vybn.py
+++ b/spark/vybn.py
@@ -314,7 +314,7 @@ def breathe(state: dict) -> str:
             if refill.get("refilled"):
                 _log(f"buffer refilled: {refill['new_papers']} new papers")
             feeder = BufferFeeder()
-            entry  = feeder.pop_one()
+            entry  = feeder.pop_next()
             if entry:
                 content = entry.get("content", "")[:800]
                 source  = entry.get("source", "unknown")


### PR DESCRIPTION
Three fixes that connect the plumbing from #2568 + the quantum fix on `fix/open-three-arteries`:

**1. Buffer path mismatch**
`arxiv_fetcher.py` writes to `spark/buffer.jsonl` → fixed to `spark/growth/buffer.jsonl` (where `buffer_feed.py` reads)

**2. GGUF model path**
`train_cycle.py` looked for `~/models/nemotron/Nemotron-Super-512B-v1.Q4_K_M.gguf` (doesn't exist). Added actual model: `~/models/Nemotron-3-Super-120B-GGUF/.../nvidia_Nemotron-3-Super-120B-A12B-IQ4_XS-00001-of-00002.gguf`

**3. Method name**
`vybn.py` called `feeder.pop_one()` but `BufferFeeder` defines `pop_next()`. Would crash on first novel-signal breath.

Also merges the quantum_bridge fix from `fix/open-three-arteries` (Nemotron reasoning-token bug: max_tokens 1024→2048, timeout 120→300, theory cap 8000→4000).

All verified:
```
GGUF found: ~/models/Nemotron-3-Super-120B-GGUF/.../00001-of-00002.gguf
BufferFeeder: buffer exists, path aligned
pop_next() matches BufferFeeder API
quantum _design_experiment: returns polar_time_test (not bell_canary)
```