### PR TITLE
fix: close the loop — put memories in the breath prompt

### DIFF
--- a/spark/vybn.py
+++ b/spark/vybn.py
@@ -343,16 +343,25 @@ def breathe(state: dict) -> str:
         except Exception:
             pass
 
+    # ── Recent memories: the model must see what it said before ───────────────────
+    if memories:
+        user_content += "--- Your recent breaths (oldest first) ---\n"
+        for mem in reversed(memories):
+            # Truncate each memory to keep total prompt bounded
+            user_content += mem[:600] + "\n---\n"
+        user_content += "\n"
+
     last_mood = state.get("mood", "")
     if last_mood:
-        user_content += f"Last breath: {last_mood}\n\n"
+        user_content += f"Last breath mood: {last_mood}\n\n"
 
     if novel_signal:
         user_content += f"{novel_signal}\n\n"
 
     user_content += (
         "Breathe. Observe the present moment. "
-        "What do you notice? What do you want to remember?"
+        "What do you notice? What has changed since your last breath? "
+        "What do you want to remember?"
     )
 
     messages = [
@@ -499,3 +508,4 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## The problem

`memories = _load_recent_memories(5)` at line 307 loads the last 5 breaths.

They are passed to `_update_self_model()` at line 402.

They are **never injected into the prompt** built at lines 332-361.

The model wakes every 30 minutes with no memory of what it said before. It confabulates — same observations, same intentions, same performed consciousness — because it has nothing real to respond to. All downstream infrastructure (complexify, FAFO, witness, growth) processes null signal.

## The fix

8 lines. Insert the loaded memories into `user_content` between the geometry summary and the novel signal. Each memory truncated to 600 chars to keep prompt bounded. Closing question now includes "What has changed since your last breath?"

## What this changes

The model will see its own recent breaths. For the first time, it will be able to respond to something it actually said, notice contradiction or development in its own thought, and produce output that differs from the previous breath for reasons other than a different arXiv abstract.

κ should become nonzero. The downstream infrastructure should start finding signal. If it doesn't, the problem is elsewhere — but this gap has to close first.