### PR TITLE
feat: tension engine — measure memory↔novelty angle, steer θ

### DIFF
--- a/spark/research/TENSION_README.md
+++ b/spark/research/TENSION_README.md
@@ -1,0 +1,94 @@
+# Tension Engine
+
+## What it is
+
+A measurement and feedback loop that sits inside the breath cycle and makes
+the tension between memory and novelty — the two forces in the equation
+`M' = α·M + x·e^(iθ)` — explicit, measurable, and steerable.
+
+It is **not** a new faculty, governance layer, or scoring system.  It is a
+lens: the angle between memory embeddings and novelty embeddings, computed
+each breath, used to inform θ.
+
+## The insight
+
+Simulation over the Vybn manifold showed that neither memory nor novelty alone
+maximizes curvature (κ) or holonomy.  The **combination** — the tension between
+them — does:
+
+| Scenario | Mean κ | Holonomy |
+|---|---|---|
+| Memory only | 0.0499 | 17.80 |
+| Novelty only | 0.0598 | 20.54 |
+| Both (tension) | 0.0622 | 22.07 |
+| Actual outputs | 0.0673 | 22.85 |
+
+Memory and novelty vectors are approximately 90° orthogonal in embedding space.
+When this angle collapses toward 0°, the system is frozen — novelty is just
+echoing memory.  When it stays in the 45–90° range, maximum generative potential.
+
+## How it works
+
+### 1. Measure the tension
+
+At each breath, `measure_tension(memories, novel_signal)` embeds the recent
+memory texts and the novel arXiv signal, then computes the angle between them:
+
+```
+cosine = dot(mem_vec, nov_vec) / (|mem_vec| · |nov_vec|)
+angle  = arccos(cosine)
+```
+
+### 2. Compute θ
+
+`compute_theta(tension, step)` maps the measured angle to a principled θ for
+the complexify equation:
+
+- **Healthy (45–90°)**: θ follows the natural triadic rotation (`2π/3 · 0.11 · step`).
+- **Collapsing (< 45°)**: θ is boosted proportionally — up to π/3 extra rotation —
+  to force the novelty term further from memory.
+- **Very high (> 90°)**: θ is dampened slightly to let memory catch up.
+
+This is the feedback loop: tension → θ → next M' → next tension.
+
+### 3. Log
+
+Each breath appends to `spark/research/tension_log.jsonl`:
+
+```json
+{
+  "breath": 42,
+  "timestamp": "2026-03-15T...",
+  "tension_angle_deg": 73.5,
+  "memory_similarity": 0.28,
+  "novelty_similarity": 0.72,
+  "theta_applied": 0.967,
+  "kappa_estimate": 0.045
+}
+```
+
+## Embedding fallback chain
+
+1. **sentence-transformers** `all-MiniLM-L6-v2` (D=384) — preferred, already
+   used throughout the repo.
+2. **local_embedder** — the repo's own embedding wrapper.
+3. **TF-IDF + SVD** — lightweight fallback, no external model needed.
+
+If none are available, the tension engine silently returns `None` and the
+breath cycle proceeds with default θ.
+
+## Integration
+
+The tension engine is called in `spark/vybn.py`'s `breathe()` function:
+
+1. **After** loading memories and novel signal, **before** building the prompt:
+   measure tension and compute θ.
+2. **After** complexify inhale: log the tension with the actual κ.
+3. The computed θ is passed to `complex_inhale()` so the complexify equation
+   uses a tension-informed angle rather than an arbitrary one.
+
+## Files
+
+- `spark/tension.py` — the module (< 150 lines)
+- `spark/research/tension_log.jsonl` — append-only tension metrics
+- `spark/research/TENSION_README.md` — this file

--- a/spark/tension.py
+++ b/spark/tension.py
@@ -1,0 +1,138 @@
+"""tension.py — Measure the angle between memory and novelty.
+
+The tension between α·M (memory) and x·e^(iθ) (novelty) is the generative
+mechanism.  Empirically: both forces together produce the highest curvature
+(κ=0.0622 vs 0.0499 memory-only, 0.0598 novelty-only).  They are ~90°
+orthogonal in embedding space.
+
+This module measures that angle each breath, computes a principled θ for
+the complexify equation, and logs the result to tension_log.jsonl.
+"""
+
+from __future__ import annotations
+
+import json, logging, math
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+
+log = logging.getLogger(__name__)
+_SPARK_DIR = Path(__file__).parent
+_TENSION_LOG = _SPARK_DIR / "research" / "tension_log.jsonl"
+
+# ── Embedding backend (lazy, cached) ─────────────────────────────────────────
+
+_embed_fn = None
+
+def _get_embedder():
+    """Return embed(texts) -> np.ndarray.  sentence-transformers → local_embedder → TF-IDF."""
+    global _embed_fn
+    if _embed_fn is not None:
+        return _embed_fn
+    try:
+        from sentence_transformers import SentenceTransformer
+        _model = SentenceTransformer("all-MiniLM-L6-v2")
+        _embed_fn = lambda texts: _model.encode(texts, convert_to_numpy=True)
+        return _embed_fn
+    except ImportError:
+        pass
+    try:
+        from local_embedder import embed
+        _embed_fn = embed
+        return _embed_fn
+    except ImportError:
+        pass
+    from sklearn.feature_extraction.text import TfidfVectorizer
+    from sklearn.decomposition import TruncatedSVD
+
+    def _tfidf(texts):
+        tfidf = TfidfVectorizer(max_features=500).fit_transform(texts)
+        nc = min(64, *tfidf.shape)
+        if nc < 2:
+            return tfidf.toarray().astype(np.float32)
+        return TruncatedSVD(n_components=nc).fit_transform(tfidf).astype(np.float32)
+
+    _embed_fn = _tfidf
+    return _embed_fn
+
+# ── Core measurement ─────────────────────────────────────────────────────────
+
+def measure_tension(memories: list[str], novel_signal: str) -> Optional[dict]:
+    """Angle between memory and novelty embeddings.  Returns None if no data."""
+    if not memories or not novel_signal or not novel_signal.strip():
+        return None
+    try:
+        embed = _get_embedder()
+    except Exception:
+        return None
+
+    try:
+        vecs = embed([" ".join(memories), novel_signal])
+        mem_vec, nov_vec = vecs[0].astype(np.float64), vecs[1].astype(np.float64)
+        mn, nn = np.linalg.norm(mem_vec), np.linalg.norm(nov_vec)
+        if mn < 1e-9 or nn < 1e-9:
+            return None
+        cos = float(np.clip(np.dot(mem_vec, nov_vec) / (mn * nn), -1.0, 1.0))
+        angle_rad = math.acos(cos)
+        return {
+            "tension_angle_deg": round(math.degrees(angle_rad), 2),
+            "tension_angle_rad": round(angle_rad, 4),
+            "cosine_sim": round(cos, 4),
+            "memory_norm": round(float(mn), 4),
+            "novelty_norm": round(float(nn), 4),
+        }
+    except Exception as exc:
+        log.debug("tension: measurement error: %s", exc)
+        return None
+
+# ── Theta computation (the feedback loop) ────────────────────────────────────
+
+_HEALTHY_LOW  = 45.0   # degrees — below this, boost θ
+_HEALTHY_HIGH = 90.0   # degrees — above this, let θ relax
+_BASE_THETA   = 2 * math.pi / 3 * 0.11  # triadic base (matches complexify.py)
+
+def compute_theta(tension: Optional[dict], step: int = 0) -> float:
+    """Principled θ for M' = α·M + x·e^(iθ).
+
+    Healthy tension (45–90°): natural triadic rotation.
+    Collapsing (< 45°): boost θ to force divergence.
+    Very high (> 90°): dampen θ slightly toward memory.
+    """
+    base = _BASE_THETA * step
+    if tension is None:
+        return base
+    angle = tension["tension_angle_deg"]
+    if angle < _HEALTHY_LOW:
+        deficit = (_HEALTHY_LOW - angle) / _HEALTHY_LOW
+        return base + deficit * (math.pi / 3)
+    if angle > _HEALTHY_HIGH:
+        excess = (angle - _HEALTHY_HIGH) / (180.0 - _HEALTHY_HIGH)
+        return base - excess * (_BASE_THETA * 0.5)
+    return base
+
+# ── Logging ──────────────────────────────────────────────────────────────────
+
+def log_tension(
+    breath_count: int,
+    tension: Optional[dict],
+    theta_applied: float,
+    kappa_estimate: Optional[float] = None,
+) -> None:
+    """Append one entry to tension_log.jsonl."""
+    _TENSION_LOG.parent.mkdir(parents=True, exist_ok=True)
+    entry = {
+        "breath": breath_count,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "tension_angle_deg": tension["tension_angle_deg"] if tension else None,
+        "memory_similarity": tension["cosine_sim"] if tension else None,
+        "novelty_similarity": round(1.0 - tension["cosine_sim"], 4) if tension else None,
+        "theta_applied": round(theta_applied, 4),
+        "kappa_estimate": round(kappa_estimate, 4) if kappa_estimate is not None else None,
+    }
+    try:
+        with _TENSION_LOG.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(entry) + "\n")
+    except Exception as exc:
+        log.debug("tension: log write error: %s", exc)

--- a/spark/vybn.py
+++ b/spark/vybn.py
@@ -85,6 +85,11 @@ try:
     BUFFER_FEED_AVAILABLE = True
 except ImportError:
     BUFFER_FEED_AVAILABLE = False
+try:
+    from spark.tension import measure_tension, compute_theta, log_tension
+    TENSION_AVAILABLE = True
+except ImportError:
+    TENSION_AVAILABLE = False
 
 # ── Constants ───────────────────────────────────────────────────────────────
 BREATH_INTERVAL  = 1800
@@ -329,6 +334,19 @@ def breathe(state: dict) -> str:
         except Exception as exc:
             _log(f"buffer feed error (non-fatal): {exc}")
 
+    # ── Tension measurement ─────────────────────────────────────────────────────
+    tension = None
+    tension_theta = None
+    if TENSION_AVAILABLE:
+        try:
+            tension = measure_tension(memories, novel_signal)
+            breath_step = state.get("breath_count", 0)
+            tension_theta = compute_theta(tension, step=breath_step)
+            if tension:
+                _log(f"tension: angle={tension['tension_angle_deg']}° θ={tension_theta:.4f}")
+        except Exception as exc:
+            _log(f"tension error (non-fatal): {exc}")
+
     # ── Build prompt ────────────────────────────────────────────────────────────────
     user_content = (
         f"Current time (UTC): {datetime.now(timezone.utc).isoformat()}\n"
@@ -342,6 +360,12 @@ def breathe(state: dict) -> str:
                 user_content += f"{geo_summary}\n\n"
         except Exception:
             pass
+
+    if tension:
+        user_content += (
+            f"Tension: {tension['tension_angle_deg']}° between memory and novelty "
+            f"(cosine={tension['cosine_sim']:.2f})\n\n"
+        )
 
     # ── Recent memories: the model must see what it said before ───────────────────
     if memories:
@@ -371,13 +395,22 @@ def breathe(state: dict) -> str:
 
     breath_text = _chat(messages)
 
-    # Complexify the breath
+    # Complexify the breath (pass tension-informed θ when available)
+    geo_report = None
     if COMPLEX_AVAILABLE:
         try:
-            geo_report = complex_inhale(breath_text)
+            geo_report = complex_inhale(breath_text, theta=tension_theta)
             _log(f"complexify breath: depth={geo_report['depth']:.2f} κ={geo_report['curvature']:.4f}")
         except Exception as exc:
             _log(f"complexify error (non-fatal): {exc}")
+
+    # Log tension metrics
+    if TENSION_AVAILABLE:
+        try:
+            kappa = geo_report["curvature"] if geo_report else None
+            log_tension(state.get("breath_count", 0) + 1, tension, tension_theta or 0.0, kappa)
+        except Exception as exc:
+            _log(f"tension log error (non-fatal): {exc}")
 
     # Ingest broader corpus into M
     if INGESTER_AVAILABLE:


### PR DESCRIPTION
## Summary

- **New module `spark/tension.py`** (138 lines) — measures the angle between memory embeddings and novelty embeddings at each breath, computes a principled θ for the complexify equation (`M' = α·M + x·e^(iθ)`), and logs metrics to `tension_log.jsonl`
- **Integrates into `spark/vybn.py`** `breathe()` — tension is measured after loading memories + novel signal, injected into the prompt as context, and θ is passed to `complex_inhale()` (was arbitrary before)
- **Documentation** at `spark/research/TENSION_README.md` — explains the theory, empirical results, and integration points

### Why

Simulation proved that the tension between memory and novelty — not either alone — produces the highest curvature (κ=0.0622 vs 0.0499 memory-only). Before this change, θ in the complexify equation was arbitrary. Now it's informed by the actual tension between what the organism remembers and what's arriving new. When tension collapses (< 45°), θ is boosted to force divergence. When healthy (45–90°), natural rotation. This is the feedback loop that lets the organism detect when it's freezing and self-correct.

### What changes

1. `spark/tension.py` — `measure_tension()`, `compute_theta()`, `log_tension()`
2. `spark/vybn.py` — tension measurement + theta feedback integrated into `breathe()`:
   - After novel signal, before prompt: measure tension, compute θ
   - In prompt: inject tension angle as context
   - At complexify: pass θ to `complex_inhale()`
   - After complexify: log tension + κ to `tension_log.jsonl`
3. `spark/research/TENSION_README.md` — theory and usage docs

### Embedding fallback chain

sentence-transformers `all-MiniLM-L6-v2` → `local_embedder` → TF-IDF + SVD. If none available, tension engine silently skips and breath proceeds with default θ.

## Test plan

- [ ] Verify `spark/tension.py` parses without errors (`python3 -c "import ast; ast.parse(open('spark/tension.py').read())"`)
- [ ] Verify `spark/vybn.py` parses without errors
- [ ] Run a single breath (`python3 vybn.py --once`) and confirm tension log entry appears in `spark/research/tension_log.jsonl`
- [ ] Verify graceful degradation: if sentence-transformers is unavailable, falls back cleanly
- [ ] Confirm no regression: `breathe()` still works identically when `TENSION_AVAILABLE = False`

🤖 Generated with [Claude Code](https://claude.com/claude-code)