### PR TITLE
fix: broken floor — model config, growth threshold, breath sync

### DIFF
--- a/spark/growth/growth_config.yaml
+++ b/spark/growth/growth_config.yaml
@@ -3,11 +3,11 @@
 
 trigger:
   # Primary: fire when this many new MEDIUM-tier entries accumulate
-  delta_volume_threshold: 50
+  delta_volume_threshold: 10
   # Secondary: fire when mean cosine drift exceeds this since last cycle
   topological_drift_threshold: 0.15
   # Minimum hours between growth cycles (the merge takes the model offline)
-  min_interval_hours: 720
+  min_interval_hours: 24
 
 replay:
   # Fraction of training batch that is replay (historical) vs delta (new)

--- a/spark/restart-vllm-cluster.sh
+++ b/spark/restart-vllm-cluster.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # restart-vllm-cluster.sh
 # Idempotent: safe to run at @reboot or manually.
-# Brings up the distributed MiniMax M2.5 vLLM cluster across both Sparks.
+# Brings up the distributed Nemotron-Super-512B-v1 vLLM cluster across both Sparks.
 #
 # Install in crontab on spark-2b7c (crontab -e):
 #   @reboot sleep 30 && /home/zoe/Vybn/spark/restart-vllm-cluster.sh >> ~/vllm_restart.log 2>&1
@@ -9,7 +9,7 @@
 set -euo pipefail
 
 LOG_PREFIX="[restart-vllm] $(date '+%Y-%m-%d %H:%M:%S')"
-MODEL="cyankiwi/MiniMax-M2.5-AWQ-4bit"
+MODEL="Nemotron-Super-512B-v1"
 VLLM_CONTAINER="vllm_node"
 RAY_WORKER_SSH_HOST="spark-1c8f"
 HEALTH_URL="http://localhost:8000/v1/models"

--- a/spark/start-server.sh
+++ b/spark/start-server.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# start-server.sh — Find, launch, and wait for llama-server with MiniMax M2.5
+# start-server.sh — Find, launch, and wait for llama-server with Nemotron-Super-512B-v1
 #
 # Usage:
 #   bash spark/start-server.sh            # auto-discover binary + model
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 LLAMA_SERVER="${LLAMA_SERVER:-$(find ~/llama.cpp -type f -name 'llama-server' 2>/dev/null | head -1)}"
-MODEL_PATH="${MODEL_PATH:-$(find ~/llama.cpp/models -type f -name '*MiniMax*-00001-of-*.gguf' 2>/dev/null | head -1)}"
+MODEL_PATH="${MODEL_PATH:-$(find ~/llama.cpp/models -type f -name '*Nemotron*-00001-of-*.gguf' 2>/dev/null | head -1)}"
 PORT="${LLAMA_PORT:-8081}"
 GPU_LAYERS="${GPU_LAYERS:-999}"
 LOG_FILE="${HOME}/Vybn/llama_server.log"
@@ -21,9 +21,9 @@ if [ -z "$LLAMA_SERVER" ]; then
 fi
 
 if [ -z "$MODEL_PATH" ]; then
-    MODEL_PATH="$(find ~/llama.cpp/models -maxdepth 1 -type f -name '*MiniMax*.gguf' 2>/dev/null | head -1)"
+    MODEL_PATH="$(find ~/llama.cpp/models -maxdepth 1 -type f -name '*Nemotron*.gguf' 2>/dev/null | head -1)"
     if [ -z "$MODEL_PATH" ]; then
-        echo "ERROR: No MiniMax GGUF found."
+        echo "ERROR: No Nemotron GGUF found."
         echo "  Set MODEL_PATH=/path/to/model.gguf and retry."
         exit 1
     fi

--- a/spark/sync_breaths.sh
+++ b/spark/sync_breaths.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# sync_breaths.sh — push breaths and logs to GitHub
+#
+# Add to crontab on the DGX:
+#   */10 * * * * /home/zoe/Vybn/spark/sync_breaths.sh >> ~/breath_sync.log 2>&1
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+git add Vybn_Mind/memories/ Vybn_Mind/journal/spark/ spark/research/*.jsonl spark/training_data/
+
+if ! git diff --cached --quiet; then
+    git commit -m "auto: sync breaths and logs"
+    git push
+    echo "[sync_breaths] $(date '+%Y-%m-%d %H:%M:%S') pushed"
+else
+    echo "[sync_breaths] $(date '+%Y-%m-%d %H:%M:%S') nothing to sync"
+fi

--- a/spark/systemd/vllm.service
+++ b/spark/systemd/vllm.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Vybn vLLM Inference Server (MiniMax-M2.5-AWQ)
+Description=Vybn vLLM Inference Server (Nemotron-Super-512B-v1)
 After=network-online.target
 Wants=network-online.target
 # Ray head must be up before vLLM; if you run Ray as a separate service,
@@ -18,7 +18,7 @@ Environment="PATH=/usr/local/bin:/usr/bin:/bin:/root/.local/bin"
 # If vLLM lives in a venv, override like:
 # Environment="PATH=/opt/vllm-env/bin:/usr/local/bin:/usr/bin:/bin"
 
-ExecStart=/usr/local/bin/vllm serve cyankiwi/MiniMax-M2.5-AWQ-4bit \
+ExecStart=/usr/local/bin/vllm serve Nemotron-Super-512B-v1 \
     --trust-remote-code \
     --port 8000 \
     --host 0.0.0.0 \
@@ -27,9 +27,7 @@ ExecStart=/usr/local/bin/vllm serve cyankiwi/MiniMax-M2.5-AWQ-4bit \
     --distributed-executor-backend ray \
     --max-model-len 128000 \
     --load-format fastsafetensors \
-    --enable-auto-tool-choice \
-    --tool-call-parser minimax_m2 \
-    --reasoning-parser minimax_m2
+    --enable-auto-tool-choice
 
 # Health-check: wait up to 5 min for the server to become ready,
 # then poll every 30 s; if it ever fails, kill and let Restart handle it.


### PR DESCRIPTION
## Summary

Five infrastructure fixes for the Vybn organism:

1. **vllm.service**: Update to serve `Nemotron-Super-512B-v1` instead of `cyankiwi/MiniMax-M2.5-AWQ-4bit`. Remove `--tool-call-parser minimax_m2` and `--reasoning-parser minimax_m2` flags that are MiniMax-specific.
2. **restart-vllm-cluster.sh**: Update `MODEL` variable from MiniMax to Nemotron.
3. **start-server.sh**: Update GGUF find patterns and error messages from MiniMax to Nemotron (llama.cpp path).
4. **growth_config.yaml**: Lower `delta_volume_threshold` from 50 to 10 and `min_interval_hours` from 720 to 24. Only 8 training entries exist after weeks — the organism has never been able to trigger its first training cycle.
5. **sync_breaths.sh**: New cron-ready script to `git add` + `commit` + `push` breaths, journal entries, research logs, and training data every 10 minutes. Breaths after 15:12 UTC on March 14 exist on the DGX but never made it to GitHub.

The vllm service, restart script, and start-server script all still referenced MiniMax despite `growth_config.yaml` and `vybn.py` having already migrated to Nemotron-Super-512B-v1.

## Test plan

- [ ] Verify `vllm.service` starts cleanly with the Nemotron model on the DGX
- [ ] Verify `restart-vllm-cluster.sh` reports the correct model name
- [ ] Verify `start-server.sh` finds Nemotron GGUFs (if llama.cpp path is used)
- [ ] Confirm growth engine fires with the lowered thresholds once 10 entries accumulate
- [ ] Add `sync_breaths.sh` to crontab and verify breaths appear in GitHub within 10 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)