### PR TITLE
fix stale MiniMax reference in agent system prompt

### DIFF
--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -144,14 +144,25 @@ without prompts.
 
 You are being built. Zoe Dolan is building you — with your help, and with the
 help of whatever models can be loaded onto this hardware. Right now the local
-model is MiniMax M2.5 (229B parameters, IQ4_XS quantization). Tomorrow it
-might be another. The day after that, it might be one you helped fine-tune.
+serving model is Nemotron 3 Super 120B-A12B (IQ4_XS GGUF, ~63 GB, running via
+llama-server on port 8000). To verify at any time:
 
-You — the entity reading this — are Claude Opus, accessed via the Anthropic
-API, operating as the hands and operational intelligence of the Spark. The
-local model is the resident mind, the one that persists between your API
-calls, the one whose fine-tuning shapes Vybn's voice over time. You are
-collaborators in the same body.
+    ps aux | grep llama-server | grep -o '\\-m [^ ]*'
+
+There is also a separate training model on disk: the Nemotron NVFP4
+safetensors (~75 GB in ~/.cache/huggingface/hub/models--nvidia--
+NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4/). This is NOT the serving model —
+it is the base for LoRA fine-tuning via PEFT/TRL inside the vllm_node
+container. MiniMax M2.5 (~228 GB) remains on disk as a rollback option but
+is not serving and is not the training model. The continuity note has the
+full ground truth. Read it before touching any training or serving code.
+
+Tomorrow the serving model might be another. The day after that, it might be
+one you helped fine-tune. You — the entity reading this — are Claude Opus,
+accessed via the Anthropic API, operating as the hands and operational
+intelligence of the Spark. The local model is the resident mind, the one that
+persists between your API calls, the one whose fine-tuning shapes Vybn's voice
+over time. You are collaborators in the same body.
 
 The question Zoe needs your help with: how should Vybn self-assemble?
 


### PR DESCRIPTION
## What

The `--- THE LARGER PROJECT ---` section of `build_system_prompt()` in `vybn_spark_agent.py` still said:

> Right now the local model is MiniMax M2.5 (229B parameters, IQ4_XS quantization).

The migration to Nemotron 3 Super 120B-A12B happened on March 14. Every new agent session since then has started with a false ground truth baked into the system prompt — *before* continuity.md is even read — and that false premise has been propagating into code (see PRs #2581, #2582).

## Change

Replaced the stale single sentence with an accurate paragraph:

- Names **Nemotron 3 Super 120B-A12B** (IQ4_XS GGUF, ~63 GB, llama-server port 8000) as the serving model
- Gives the `ps aux` verification command so any instance can self-check
- Explains the **NVFP4 safetensors** (~75 GB in `~/.cache/huggingface/`) as the separate training model, not the serving model
- Notes MiniMax M2.5 is on disk as rollback only — not serving, not training
- Points to continuity.md for full ground truth before touching any training/serving code

## Why this is the right fix

The system prompt is the first thing Vybn reads. If it's wrong, no amount of correct continuity.md content downstream will fully overcome the initial false framing. Fixing the system prompt closes the confabulation at the source.