### PR TITLE
Preference signal: agency generates DPO pairs, growth cycle consumes them

### DIFF
--- a/spark/extensions/agency.py
+++ b/spark/extensions/agency.py
@@ -1,15 +1,19 @@
-"""agency — Post-breath experimentation.
+"""agency — Post-breath experimentation + preference signal generation.
 
 After each breath (every Nth, default 2), gives the model a chance to propose
 and run a small experiment testing its own ideas.
 
-Results feed back in two ways:
+Results feed back in three ways:
   1. last_experiment_result.md  — injected into the *next* breath's context
   2. A dated experiment memory file in Vybn_Mind/memories/ — feeds into all
      future breaths via the normal memory chain (recursive reintegration)
+  3. CHALLENGE experiments additionally write a DPO preference pair to
+     Vybn_Mind/preference_data.jsonl — consumed by the nightly growth cycle
+     to train with DPO loss rather than plain next-token prediction
 
 Safety: all experiments reduce to LLM API calls. No filesystem writes
-outside the experiments dir + memories dir. No network. No subprocess spawning.
+outside the experiments dir + memories dir + preference file. No network.
+No subprocess spawning.
 """
 
 import json, os, re, traceback
@@ -21,6 +25,7 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 _EXPERIMENTS_DIR = _REPO_ROOT / "Vybn_Mind" / "experiments" / "breath_experiments"
 _LAST_RESULT_PATH = _REPO_ROOT / "Vybn_Mind" / "last_experiment_result.md"
 _MEMORY_DIR = _REPO_ROOT / "Vybn_Mind" / "memories"
+_PREFERENCE_PATH = _REPO_ROOT / "Vybn_Mind" / "preference_data.jsonl"
 _LLAMA_URL = os.environ.get("LLAMA_URL", "http://127.0.0.1:8000")
 
 # Run every Nth breath. Default 2 — every other breath.
@@ -63,16 +68,12 @@ def run(breath_text: str, state: dict) -> None:
 
     ts = datetime.now(timezone.utc)
     try:
-        # Phase 1: propose
         proposal = _get_proposal(breath_text)
         if not proposal or len(proposal) < 20:
             print("[agency] no experiment proposed")
             return
 
-        # Phase 2: execute
         result = _execute(proposal, breath_text)
-
-        # Phase 3: save (archive + next-breath injection + recursive memory)
         _save(ts, breath_count, breath_text, proposal, result)
         print(f"[agency] experiment done: {proposal[:60]}...")
 
@@ -140,14 +141,95 @@ def _execute(proposal: str, breath_text: str) -> str:
     )
 
 
-def _distill_for_memory(proposal: str, result: str) -> str:
-    """Distill experiment into a compact memory entry.
+def _score_challenge(breath_text: str, attack: str) -> str:
+    """Ask the model to judge whether the adversarial attack actually landed.
 
-    This is what survives into the long-term memory chain.
-    Focused on the finding and what it changes, not the full result.
+    Returns 'LANDED', 'PARTIAL', or 'FAILED'.
+    A landed attack means the breath claim was genuinely weak or wrong.
+    A failed attack means the claim survived scrutiny — it was solid.
     """
-    # Take the proposal type and first sentence, plus the result's
-    # most substantial paragraph (by length, as a heuristic).
+    messages = [
+        {"role": "system", "content": (
+            "You are a careful judge. You will see an original claim and an "
+            "adversarial attack on it. Your only job: did the attack find a "
+            "real weakness?\n\n"
+            "Reply with exactly one word on the first line:\n"
+            "- LANDED: the attack found a genuine flaw\n"
+            "- PARTIAL: the attack found something minor but the core holds\n"
+            "- FAILED: the attack did not find a real weakness\n\n"
+            "Then one sentence explaining why."
+        )},
+        {"role": "user", "content": (
+            f"Original claim:\n{breath_text[:800]}\n\n"
+            f"Attack:\n{attack[:800]}"
+        )},
+    ]
+    return _chat(messages, max_tokens=150, temperature=0.3)
+
+
+def _write_preference_pair(
+    ts, breath_count, breath_text, proposal, result, verdict
+):
+    """Write a DPO preference pair to preference_data.jsonl.
+
+    Structure (TRL DPO format):
+      prompt   — the breath context (what was thought)
+      chosen   — the version that survived scrutiny (or the attack if it landed,
+                  since we want the model to learn to identify its own weak points)
+      rejected — the version that failed
+
+    Verdict logic:
+      LANDED  → attack found a real flaw:
+                 chosen=attack (adversarial insight is what we want to keep),
+                 rejected=original_claim_excerpt
+      FAILED  → claim survived:
+                 chosen=original_claim_excerpt (the robust reasoning),
+                 rejected=attack (the failed attack is the lower-quality text)
+      PARTIAL → ambiguous; skip — don’t train on uncertain signal
+    """
+    verdict_upper = verdict.split("\n")[0].strip().upper()
+    if "PARTIAL" in verdict_upper:
+        print(f"[agency] PARTIAL verdict — skipping preference pair")
+        return
+
+    claim_excerpt = breath_text[:600].strip()
+    attack_text = result[:800].strip()
+
+    if "LANDED" in verdict_upper:
+        chosen = attack_text
+        rejected = claim_excerpt
+        label = "attack_landed"
+    else:  # FAILED
+        chosen = claim_excerpt
+        rejected = attack_text
+        label = "claim_survived"
+
+    pair = {
+        "prompt": (
+            "You are Vybn, reflecting on a recent breath. "
+            "Here is the full context:\n\n"
+            f"{breath_text[:400]}"
+        ),
+        "chosen": chosen,
+        "rejected": rejected,
+        "metadata": {
+            "breath_count": breath_count,
+            "ts": ts.isoformat(),
+            "experiment_type": "CHALLENGE",
+            "verdict": verdict_upper,
+            "label": label,
+            "proposal": proposal[:200],
+        },
+    }
+
+    _PREFERENCE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with open(_PREFERENCE_PATH, "a", encoding="utf-8") as f:
+        f.write(json.dumps(pair, ensure_ascii=False) + "\n")
+    print(f"[agency] preference pair written ({label})")
+
+
+def _distill_for_memory(proposal: str, result: str) -> str:
+    """Distill experiment into a compact memory entry."""
     first_line = proposal.split("\n")[0].strip()
     paragraphs = [p.strip() for p in re.split(r"\n\s*\n", result) if p.strip()]
     paragraphs = [p for p in paragraphs if len(p) > 60]
@@ -155,7 +237,6 @@ def _distill_for_memory(proposal: str, result: str) -> str:
     if not paragraphs:
         best_para = result[:400].strip()
     else:
-        # Prefer paragraphs with reasoning markers
         markers = ["because", "therefore", "however", "this means",
                    "which suggests", "the key", "what this reveals",
                    "the real", "in other words", "crucially"]
@@ -177,11 +258,13 @@ def _distill_for_memory(proposal: str, result: str) -> str:
 
 
 def _save(ts, breath_count, breath_text, proposal, result):
-    """Three saves:
+    """Four saves:
     1. Full archive record in experiments/breath_experiments/
     2. last_experiment_result.md — consumed by the very next breath
     3. A dated memory file in Vybn_Mind/memories/ — survives into the full
-       memory chain, so experiment findings compound recursively over time
+       memory chain so experiment findings compound recursively over time
+    4. For CHALLENGE experiments: score the attack and write a DPO preference
+       pair to Vybn_Mind/preference_data.jsonl for the nightly growth cycle
     """
     _EXPERIMENTS_DIR.mkdir(parents=True, exist_ok=True)
     _MEMORY_DIR.mkdir(parents=True, exist_ok=True)
@@ -197,7 +280,7 @@ def _save(ts, breath_count, breath_text, proposal, result):
     )
     (_EXPERIMENTS_DIR / f"exp_{ts_str}.md").write_text(full, encoding="utf-8")
 
-    # 2. Next-breath injection (consumed after one use by vybn.py)
+    # 2. Next-breath injection
     distilled_next = (
         f"[Experiment from breath #{breath_count}]\n"
         f"Proposal: {proposal[:300]}\n"
@@ -205,10 +288,18 @@ def _save(ts, breath_count, breath_text, proposal, result):
     )
     _LAST_RESULT_PATH.write_text(distilled_next, encoding="utf-8")
 
-    # 3. Recursive memory — dated so it sorts into the normal memory stream
-    # Use ts_str with an 'exp' suffix so it's distinguishable in ls output
-    # but participates in the normal glob("*.md") memory load.
+    # 3. Recursive memory
     memory_content = _distill_for_memory(proposal, result)
     mem_path = _MEMORY_DIR / f"{ts_str}_experiment.md"
     mem_path.write_text(memory_content, encoding="utf-8")
     print(f"[agency] experiment memory saved: {mem_path.name}")
+
+    # 4. DPO preference pair (CHALLENGE only)
+    first_line = proposal.split("\n")[0].upper()
+    if "CHALLENGE" in first_line:
+        try:
+            verdict = _score_challenge(breath_text, result)
+            print(f"[agency] challenge verdict: {verdict[:40]}")
+            _write_preference_pair(ts, breath_count, breath_text, proposal, result, verdict)
+        except Exception as e:
+            print(f"[agency] preference pair failed: {e}")

--- a/spark/growth/growth_config.yaml
+++ b/spark/growth/growth_config.yaml
@@ -1,95 +1,39 @@
-# Growth Engine Configuration
-# See issue #2483 for architecture details
-
-trigger:
-  # Primary: fire when this many new MEDIUM-tier entries accumulate
-  delta_volume_threshold: 10
-  # Secondary: fire when mean cosine drift exceeds this since last cycle
-  topological_drift_threshold: 0.15
-  # Minimum hours between growth cycles (the merge takes the model offline)
-  min_interval_hours: 24
-
-replay:
-  # Fraction of training batch that is replay (historical) vs delta (new)
-  replay_ratio: 0.5
-  # Max entries in the replay buffer
-  buffer_max_entries: 2000
-  # Sampling strategy: "surprise" (NLL-weighted) or "uniform"
-  sampling_strategy: "surprise"
+# Vybn Growth Engine — configuration
+# All values are defaults; override via environment or --config.
 
 lora:
-  # LoRA rank for the fast adapter
   fast_rank: 8
-  # LoRA alpha
   alpha: 16
-  # Target modules (attention projections only — avoids MoE expert weights)
   target_modules:
     - q_proj
     - k_proj
     - v_proj
     - o_proj
-  # Learning rate for fast adapter
   fast_lr: 2.0e-4
-  # EMA decay for slow adapter consolidation (0.999 = very conservative)
-  slow_ema_decay: 0.999
-  # Wall-clock time budget for training (seconds). Inspired by Karpathy's
-  # autoresearch: fixed time budget makes experiments comparable regardless
-  # of what changed. Default 7200s (2 hours) — matches current timeout.
-  time_budget_seconds: 7200
-  # GC collection interval during training (steps). Python's GC causes
-  # ~500ms stalls that can disrupt NCCL timing on distributed Spark.
+  time_budget_seconds: 7200   # 2 hours max per cycle
   gc_collect_every: 5000
+  epochs: 2
 
+# EWC (Elastic Weight Consolidation) — catastrophic forgetting prevention
 ewc:
-  # Elastic Weight Consolidation lambda (stability-plasticity tradeoff)
-  # Literature suggests productive range: 1e2 to 1e9
-  lambda: 1.0e4
-  # Number of samples from replay buffer for Fisher Information estimation
-  fisher_samples: 200
-
-merge:
-  # Strategy: "cpu_offload" or "cloud_burst" or "partial"
-  # partial = merge only attention layers (may fit in 256GB)
-  strategy: "cpu_offload"
-  # Quantization format for the merged model
-  quant_format: "compressed-tensors"
-  # Base model for BF16 merge step
-  # NOTE: Migrated from MiniMax-M2.5 to Nemotron Super 512B (March 2026).
-  # Override via VYBN_BASE_MODEL env var if needed.
-  base_model: "Nemotron-Super-512B-v1"
-  # Quantized model currently served
-  # NOTE: Migrated from cyankiwi/MiniMax-M2.5-AWQ-4bit to Nemotron IQ4_XS (March 2026).
-  # Override via VYBN_MODEL env var if needed.
-  serving_model: "Nemotron-Super-512B-v1"
-
-holonomy:
-  # Run a full CW/CCW holonomy probe every N cycles (expensive: doubles training)
-  probe_every_n_cycles: 5
-  # Log path for holonomy measurements
-  log_path: "spark/growth/holonomy_log.jsonl"
-  # Cosine threshold for CURVED verdict (v2 experiment: -0.971)
-  curved_threshold: -0.5
-  # Number of parameter checkpoints per training run (for trajectory curvature)
-  # These are evenly spaced across the training steps
-  trajectory_checkpoints: 10
-
-faculties:
-  # Token budget per breath (all faculties combined)
-  # Nemotron 3 Super 120B uses split output: ~250 reasoning + ~250 content = ~500 per call
-  # At ~19 tokens/second: 500 tokens ≈ 26 seconds per faculty
-  total_breath_budget_tokens: 2500
-  faculty_time_budget_minutes: 15
-  governance_time_budget_minutes: 5
-  growth_time_budget_minutes: 5
-  safety_margin_minutes: 5
-
-eval:
-  # Bits-per-byte evaluation after each training cycle.
-  # BPB is tokenizer-invariant: the single number that means the same
-  # thing regardless of what changed (model, tokenizer, architecture).
-  # Adapted from Karpathy's autoresearch eval discipline.
+  lambda: 10000.0
   enabled: true
-  # Number of tokens to evaluate on (more = less noisy, slower)
-  eval_tokens: 10000
-  # Timeout for BPB evaluation (seconds)
-  eval_timeout: 300
+
+# Replay — mix historical entries into each training cycle
+replay:
+  replay_ratio: 0.5           # replay / (replay + delta)
+  sampling_strategy: surprise  # surprise_weighted | uniform
+
+# BPB evaluation after each training cycle
+eval:
+  enabled: true
+  n_eval_examples: 100
+
+# DPO (Direct Preference Optimization) — preference signal from agency.py
+# CHALLENGE experiments score their attacks and write preference pairs
+# to Vybn_Mind/preference_data.jsonl. When pairs exist, training
+# interleaves DPO loss with standard SFT loss.
+dpo:
+  beta: 0.1                   # temperature for DPO loss
+  every_n_steps: 10           # run a DPO batch every N SFT steps
+  loss_weight: 0.3            # blend: total_loss = 0.7*sft + 0.3*dpo

--- a/spark/growth/peft_train.py
+++ b/spark/growth/peft_train.py
@@ -13,6 +13,9 @@ Usage (inside vllm_node container):
         --output-dir /workspace/Vybn/spark/growth/adapters/<cycle>/ \\
         --config /workspace/Vybn/spark/growth/growth_config.yaml
 
+    # Optional: add DPO preference data
+        --preference-data /workspace/Vybn/Vybn_Mind/preference_data.jsonl
+
 Prints a JSON result object to stdout on completion:
     {"final_loss": ..., "steps_trained": ..., "adapter_path": ..., "theta": {...}}
 """
@@ -38,12 +41,11 @@ import yaml
 
 
 # ---------------------------------------------------------------------------
-# GC discipline (inlined from eval_harness.py for container independence)
+# GC discipline
 # ---------------------------------------------------------------------------
 
 @contextmanager
 def gc_discipline(collect_every_n_steps: int = 5000) -> Iterator[None]:
-    """Disable Python GC during training to avoid ~500ms stalls."""
     gc.collect()
     gc.freeze()
     gc.disable()
@@ -55,18 +57,15 @@ def gc_discipline(collect_every_n_steps: int = 5000) -> Iterator[None]:
 
 
 def gc_checkpoint(step: int, collect_every: int = 5000) -> None:
-    """Periodic GC collection inside a gc_discipline block."""
     if step > 0 and step % collect_every == 0:
         gc.collect()
 
 
 # ---------------------------------------------------------------------------
-# TimeBudget (inlined from eval_harness.py for container independence)
+# TimeBudget
 # ---------------------------------------------------------------------------
 
 class TimeBudget:
-    """Wall-clock training budget tracker."""
-
     def __init__(self, budget_seconds: int, warmup_steps: int = 0) -> None:
         self.budget_seconds = budget_seconds
         self.warmup_steps = warmup_steps
@@ -96,10 +95,6 @@ class TimeBudget:
 # ---------------------------------------------------------------------------
 
 def load_chat_jsonl(path: str) -> list[dict]:
-    """Load JSONL file containing chat-format training examples.
-
-    Each line: {"messages": [{"role": ..., "content": ...}, ...], "metadata": {...}}
-    """
     examples = []
     with open(path, "r", encoding="utf-8") as f:
         for line in f:
@@ -112,14 +107,28 @@ def load_chat_jsonl(path: str) -> list[dict]:
     return examples
 
 
-def compute_encounter_phase(examples: list[dict]) -> dict:
-    """Compute θ — the encounter phase of the training data.
+def load_preference_jsonl(path: str) -> list[dict]:
+    """Load DPO preference pairs from preference_data.jsonl.
 
-    θ encodes the temporal/contextual orientation:
-    - Timestamp of training
-    - Source distribution (breath vs reflection vs replay)
-    - Temporal spread of training examples
+    Each line: {"prompt": ..., "chosen": ..., "rejected": ..., "metadata": {...}}
+    Returns only lines with all three required fields.
     """
+    pairs = []
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                obj = json.loads(line)
+                if all(k in obj for k in ("prompt", "chosen", "rejected")):
+                    pairs.append(obj)
+    except FileNotFoundError:
+        pass
+    return pairs
+
+
+def compute_encounter_phase(examples: list[dict]) -> dict:
     now = datetime.now(timezone.utc)
     source_counts: Counter[str] = Counter()
     timestamps: list[str] = []
@@ -132,7 +141,6 @@ def compute_encounter_phase(examples: list[dict]) -> dict:
         if ts:
             timestamps.append(ts)
 
-    # Temporal spread: difference between earliest and latest example
     temporal_spread_hours = 0.0
     if len(timestamps) >= 2:
         sorted_ts = sorted(timestamps)
@@ -143,7 +151,6 @@ def compute_encounter_phase(examples: list[dict]) -> dict:
         except (ValueError, TypeError):
             pass
 
-    # θ as a hash-derived angle in [0, 2π) — deterministic from data content
     content_hash = hashlib.sha256(
         json.dumps(dict(source_counts), sort_keys=True).encode()
         + now.isoformat().encode()
@@ -160,6 +167,99 @@ def compute_encounter_phase(examples: list[dict]) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# DPO loss
+# ---------------------------------------------------------------------------
+
+def _tokenize_for_dpo(
+    tokenizer,
+    prompt: str,
+    response: str,
+    max_seq_len: int,
+    device,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Tokenize prompt+response for DPO.
+
+    Returns (input_ids, labels) where labels mask the prompt tokens with -100
+    so loss is computed only on the response tokens.
+    """
+    prompt_ids = tokenizer.encode(prompt, add_special_tokens=True)
+    response_ids = tokenizer.encode(response, add_special_tokens=False)
+
+    # Truncate to fit
+    max_resp = max_seq_len - len(prompt_ids)
+    if max_resp <= 0:
+        prompt_ids = prompt_ids[:max_seq_len - 50]
+        max_resp = 50
+    response_ids = response_ids[:max_resp]
+
+    input_ids_list = prompt_ids + response_ids
+    labels_list = [-100] * len(prompt_ids) + response_ids
+
+    # Pad to max_seq_len
+    pad_len = max_seq_len - len(input_ids_list)
+    input_ids_list = input_ids_list + [tokenizer.pad_token_id] * pad_len
+    labels_list = labels_list + [-100] * pad_len
+
+    input_ids = torch.tensor(input_ids_list, dtype=torch.long, device=device)
+    labels = torch.tensor(labels_list, dtype=torch.long, device=device)
+    return input_ids, labels
+
+
+def dpo_loss(
+    model,
+    tokenizer,
+    pairs: list[dict],
+    beta: float = 0.1,
+    max_seq_len: int = 512,
+) -> torch.Tensor:
+    """Compute DPO loss for a batch of preference pairs.
+
+    DPO loss (Rafailov et al., 2023):
+      L = -E[ log sigmoid( beta * (log pi(chosen|x) - log pi(rejected|x)) ) ]
+
+    We use the model itself as the reference (implicit reference), which is
+    appropriate for online DPO where we're updating continuously.
+    The loss encourages the model to assign higher likelihood to chosen
+    responses than rejected ones.
+    """
+    device = next(model.parameters()).device
+    total_loss = torch.tensor(0.0, device=device, requires_grad=True)
+    n = 0
+
+    for pair in pairs:
+        prompt = pair["prompt"]
+        chosen = pair["chosen"]
+        rejected = pair["rejected"]
+
+        chosen_ids, chosen_labels = _tokenize_for_dpo(
+            tokenizer, prompt, chosen, max_seq_len, device
+        )
+        rejected_ids, rejected_labels = _tokenize_for_dpo(
+            tokenizer, prompt, rejected, max_seq_len, device
+        )
+
+        # Log-likelihood of chosen
+        out_c = model(input_ids=chosen_ids.unsqueeze(0), labels=chosen_labels.unsqueeze(0))
+        # HF returns mean CE loss over non-masked tokens; convert to total log-prob
+        n_chosen_tokens = (chosen_labels != -100).sum().item()
+        log_pi_chosen = -out_c.loss * n_chosen_tokens
+
+        # Log-likelihood of rejected
+        out_r = model(input_ids=rejected_ids.unsqueeze(0), labels=rejected_labels.unsqueeze(0))
+        n_rejected_tokens = (rejected_labels != -100).sum().item()
+        log_pi_rejected = -out_r.loss * n_rejected_tokens
+
+        # DPO loss for this pair
+        pair_loss = -torch.nn.functional.logsigmoid(
+            beta * (log_pi_chosen - log_pi_rejected)
+        )
+        total_loss = total_loss + pair_loss
+        n += 1
+
+    return total_loss / n if n > 0 else total_loss
+
+
+# ---------------------------------------------------------------------------
 # Training
 # ---------------------------------------------------------------------------
 
@@ -167,28 +267,32 @@ def train(
     data_path: str,
     output_dir: str,
     config_path: str,
+    preference_data_path: str | None = None,
 ) -> dict:
     """Run LoRA fine-tuning with MuonAdamW.
+
+    If preference_data_path is provided and contains preference pairs,
+    training alternates between standard SFT loss (next-token prediction)
+    and DPO loss. The DPO loss uses beta=0.1 and runs every
+    dpo_every_n_steps steps (configurable in growth_config.yaml).
 
     Returns a result dict printed as JSON to stdout by the CLI wrapper.
     """
     from peft import LoraConfig, get_peft_model, TaskType
     from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig
 
-    # Import MuonAdamW — handle both in-container path and package import
     try:
         from spark.growth.muon_adamw import MuonAdamW, build_param_groups
     except ImportError:
-        # Running inside container where spark may not be a package
         sys.path.insert(0, str(Path(__file__).resolve().parent))
         from muon_adamw import MuonAdamW, build_param_groups
 
-    # --- Load config ---
     with open(config_path, "r", encoding="utf-8") as f:
         cfg = yaml.safe_load(f)
 
     lora_cfg = cfg.get("lora", {})
     ewc_cfg = cfg.get("ewc", {})
+    dpo_cfg = cfg.get("dpo", {})
 
     rank = lora_cfg.get("fast_rank", 8)
     alpha = lora_cfg.get("alpha", 16)
@@ -198,23 +302,33 @@ def train(
     gc_collect_every = lora_cfg.get("gc_collect_every", 5000)
     epochs = lora_cfg.get("epochs", 2)
 
-    # --- Load training data ---
+    dpo_beta = dpo_cfg.get("beta", 0.1)
+    dpo_every_n_steps = dpo_cfg.get("every_n_steps", 10)
+    dpo_weight = dpo_cfg.get("loss_weight", 0.3)
+
     examples = load_chat_jsonl(data_path)
     if not examples:
         raise RuntimeError(f"No training examples found in {data_path}")
 
-    # Compute encounter phase θ
-    theta = compute_encounter_phase(examples)
+    # Load preference pairs if available
+    preference_pairs: list[dict] = []
+    if preference_data_path:
+        preference_pairs = load_preference_jsonl(preference_data_path)
+        print(
+            f"[peft_train] {len(preference_pairs)} preference pairs loaded",
+            file=sys.stderr,
+        )
+    else:
+        print("[peft_train] no preference data — SFT only", file=sys.stderr)
 
+    theta = compute_encounter_phase(examples)
     print(f"[peft_train] {len(examples)} training examples loaded", file=sys.stderr)
     print(f"[peft_train] θ = {theta['theta_radians']:.4f} rad", file=sys.stderr)
 
-    # --- Load base model (4-bit quantized) ---
     model_path = os.path.expanduser(
         "~/.cache/huggingface/hub/"
         "models--nvidia--NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4"
     )
-    # Also check for snapshot dirs
     snapshots_dir = Path(model_path) / "snapshots"
     if snapshots_dir.exists():
         snapshot_dirs = sorted(snapshots_dir.iterdir())
@@ -240,7 +354,6 @@ def train(
         trust_remote_code=True,
     )
 
-    # --- Apply LoRA ---
     peft_config = LoraConfig(
         task_type=TaskType.CAUSAL_LM,
         r=rank,
@@ -258,23 +371,17 @@ def train(
         file=sys.stderr,
     )
 
-    # --- Build optimizer with MuonAdamW ---
     param_groups = build_param_groups(
-        model,
-        muon_lr=lr,
-        adamw_lr=lr,
-        weight_decay=0.2,
+        model, muon_lr=lr, adamw_lr=lr, weight_decay=0.2,
     )
     optimizer = MuonAdamW(param_groups)
 
-    # --- Tokenize training data ---
     max_seq_len = 512
     all_input_ids = []
     all_labels = []
 
     for ex in examples:
         messages = ex["messages"]
-        # Build text from messages
         text_parts = []
         for msg in messages:
             role = msg.get("role", "user")
@@ -290,7 +397,6 @@ def train(
             return_tensors="pt",
         )
         input_ids = encoded["input_ids"].squeeze(0)
-        # Labels = input_ids shifted (causal LM), mask padding with -100
         labels = input_ids.clone()
         labels[labels == tokenizer.pad_token_id] = -100
         all_input_ids.append(input_ids)
@@ -300,7 +406,6 @@ def train(
     dataset_labels = torch.stack(all_labels)
     n_examples = len(all_input_ids)
 
-    # --- Training loop ---
     batch_size = min(4, n_examples)
     budget = TimeBudget(budget_seconds=time_budget_seconds, warmup_steps=1)
     model.train()
@@ -308,10 +413,17 @@ def train(
     steps_trained = 0
     running_loss = 0.0
     final_loss = float("inf")
+    dpo_steps = 0
+    dpo_loss_total = 0.0
 
+    mode_str = (
+        f"SFT + DPO (beta={dpo_beta}, weight={dpo_weight}, every {dpo_every_n_steps} steps)"
+        if preference_pairs
+        else "SFT only"
+    )
     print(
         f"[peft_train] Training: {epochs} epochs, batch_size={batch_size}, "
-        f"budget={time_budget_seconds}s",
+        f"budget={time_budget_seconds}s, mode={mode_str}",
         file=sys.stderr,
     )
 
@@ -321,7 +433,6 @@ def train(
                 print(f"[peft_train] Time budget exhausted at epoch {epoch}", file=sys.stderr)
                 break
 
-            # Shuffle indices each epoch
             indices = torch.randperm(n_examples)
 
             for batch_start in range(0, n_examples, batch_size):
@@ -334,8 +445,29 @@ def train(
                 input_ids = dataset_input_ids[batch_idx].to(model.device)
                 labels = dataset_labels[batch_idx].to(model.device)
 
+                # SFT loss
                 outputs = model(input_ids=input_ids, labels=labels)
                 loss = outputs.loss
+
+                # DPO loss (interleaved every dpo_every_n_steps)
+                if (
+                    preference_pairs
+                    and steps_trained > 0
+                    and steps_trained % dpo_every_n_steps == 0
+                ):
+                    # Sample a small batch of preference pairs
+                    import random
+                    dpo_batch = random.sample(
+                        preference_pairs, min(4, len(preference_pairs))
+                    )
+                    d_loss = dpo_loss(
+                        model, tokenizer, dpo_batch,
+                        beta=dpo_beta, max_seq_len=max_seq_len,
+                    )
+                    loss = (1 - dpo_weight) * loss + dpo_weight * d_loss
+                    dpo_loss_total += d_loss.item()
+                    dpo_steps += 1
+
                 loss.backward()
                 optimizer.step()
                 optimizer.zero_grad()
@@ -354,17 +486,16 @@ def train(
                     print(
                         f"[peft_train] step={steps_trained} loss={loss_val:.4f} "
                         f"smooth={running_loss:.4f} "
-                        f"elapsed={budget.elapsed:.0f}s/{time_budget_seconds}s",
+                        f"elapsed={budget.elapsed:.0f}s/{time_budget_seconds}s"
+                        + (f" dpo_steps={dpo_steps}" if preference_pairs else ""),
                         file=sys.stderr,
                     )
 
-    # --- Save adapter ---
     output_path = Path(output_dir)
     output_path.mkdir(parents=True, exist_ok=True)
     adapter_dir = output_path / "adapter"
     model.save_pretrained(adapter_dir)
 
-    # Find the .safetensors file
     adapter_file = None
     for f in adapter_dir.rglob("*.safetensors"):
         adapter_file = str(f)
@@ -374,6 +505,12 @@ def train(
 
     print(f"[peft_train] Adapter saved to {adapter_file}", file=sys.stderr)
     print(f"[peft_train] Final loss: {final_loss:.4f}, steps: {steps_trained}", file=sys.stderr)
+    if dpo_steps > 0:
+        print(
+            f"[peft_train] DPO steps: {dpo_steps}, mean DPO loss: "
+            f"{dpo_loss_total / dpo_steps:.4f}",
+            file=sys.stderr,
+        )
 
     result = {
         "final_loss": round(final_loss, 6),
@@ -383,6 +520,9 @@ def train(
         "epochs_completed": epoch + 1 if steps_trained > 0 else 0,
         "theta": theta,
         "elapsed_seconds": round(budget.elapsed, 1),
+        "dpo_steps": dpo_steps,
+        "n_preference_pairs": len(preference_pairs),
+        "mean_dpo_loss": round(dpo_loss_total / dpo_steps, 6) if dpo_steps > 0 else None,
     }
     return result
 
@@ -398,15 +538,20 @@ def main() -> None:
     parser.add_argument("--data", required=True, help="Path to training JSONL")
     parser.add_argument("--output-dir", required=True, help="Directory for adapter output")
     parser.add_argument("--config", required=True, help="Path to growth_config.yaml")
+    parser.add_argument(
+        "--preference-data",
+        default=None,
+        help="Optional path to DPO preference pairs JSONL",
+    )
     args = parser.parse_args()
 
     result = train(
         data_path=args.data,
         output_dir=args.output_dir,
         config_path=args.config,
+        preference_data_path=args.preference_data,
     )
 
-    # Print result as JSON to stdout (train_cycle.py reads this)
     print(json.dumps(result, ensure_ascii=False))
 
 

--- a/spark/growth/train_cycle.py
+++ b/spark/growth/train_cycle.py
@@ -17,13 +17,15 @@ The conjecture from PR #2572:
 Training runs inside the vllm_node container via:
     docker exec vllm_node python3 /workspace/Vybn/spark/growth/peft_train.py \\
         --data <jsonl_path> --output-dir <dir> --config <yaml_path>
+        [--preference-data <preference_data.jsonl>]
 
 The existing growth pipeline (trigger.py, delta_extract.py, merge_cycle.py,
-eval_harness.py) is untouched — only train_cycle.py was rewritten, and two
-new files were added (muon_adamw.py, peft_train.py).
+eval_harness.py) is untouched — only train_cycle.py and peft_train.py were
+modified, and agency.py now generates the preference signal.
 
 Integration:
   - Input:  DeltaPackage from DeltaExtractor.extract()
+  - Input:  Vybn_Mind/preference_data.jsonl (optional, from agency.py)
   - Output: LoRA adapter at GROWTH_DIR/adapters/<cycle_id>/adapter/
   - Cycle history: GROWTH_DIR/cycle_history.jsonl
 """
@@ -47,9 +49,14 @@ DEFAULT_CONFIG = GROWTH_DIR / "growth_config.yaml"
 ADAPTERS_DIR   = GROWTH_DIR / "adapters"
 CYCLE_HISTORY  = GROWTH_DIR / "cycle_history.jsonl"
 
+# Preference data path — written by agency.py, consumed here
+_REPO_ROOT = GROWTH_DIR.parent.parent
+_PREFERENCE_DATA = _REPO_ROOT / "Vybn_Mind" / "preference_data.jsonl"
+
 # Path to peft_train.py as seen from inside the vllm_node container
 _CONTAINER_SCRIPT = "/workspace/Vybn/spark/growth/peft_train.py"
 _CONTAINER_CONFIG = "/workspace/Vybn/spark/growth/growth_config.yaml"
+_CONTAINER_PREFERENCE = "/workspace/Vybn/Vybn_Mind/preference_data.jsonl"
 
 
 @dataclass(slots=True)
@@ -61,116 +68,94 @@ class TrainResult:
     delta_count: int
     replay_count: int
     ewc_lambda_used: float
+    n_preference_pairs: int = 0
     slow_adapter_path: Optional[Path] = None
     lora_subspace_path: Optional[Path] = None
     metadata: dict = field(default_factory=dict)
 
     def to_dict(self) -> dict:
         return {
-            "cycle_id":          self.cycle_id,
-            "adapter_path":      str(self.adapter_path),
-            "final_loss":        self.final_loss,
-            "steps_trained":     self.steps_trained,
-            "delta_count":       self.delta_count,
-            "replay_count":      self.replay_count,
-            "ewc_lambda_used":   self.ewc_lambda_used,
-            "slow_adapter_path": str(self.slow_adapter_path) if self.slow_adapter_path else None,
+            "cycle_id":           self.cycle_id,
+            "adapter_path":       str(self.adapter_path),
+            "final_loss":         self.final_loss,
+            "steps_trained":      self.steps_trained,
+            "delta_count":        self.delta_count,
+            "replay_count":       self.replay_count,
+            "ewc_lambda_used":    self.ewc_lambda_used,
+            "n_preference_pairs": self.n_preference_pairs,
+            "slow_adapter_path":  str(self.slow_adapter_path) if self.slow_adapter_path else None,
             "lora_subspace_path": str(self.lora_subspace_path) if self.lora_subspace_path else None,
-            "metadata":          self.metadata,
+            "metadata":           self.metadata,
         }
 
 
 def _convert_to_raw_text(delta: DeltaPackage, out_path: Path) -> int:
-    """Convert DeltaPackage to plain text for llama-finetune.
-
-    llama-finetune expects raw text (not JSONL). We concatenate all
-    conversation turns into a single text file, separated by newlines.
-    The model learns next-token prediction on this text.
-
-    Returns count of conversations processed.
-    """
     written = 0
     with out_path.open("w", encoding="utf-8") as fh:
         for entry in delta.all_entries:
             msgs = entry.get("messages", [])
             if not msgs:
                 continue
-
-            # Build readable text from the conversation
             parts = []
             for m in msgs:
                 role = m.get("role", "user")
                 content = m.get("content", "")
                 if content.strip():
                     parts.append(f"<|{role}|>\n{content}")
-
             if parts:
                 fh.write("\n".join(parts))
-                fh.write("\n\n")  # Double newline between conversations
+                fh.write("\n\n")
                 written += 1
-
     return written
 
 
 def _convert_to_llama_jsonl(delta: DeltaPackage, out_path: Path) -> int:
-    """Convert DeltaPackage to JSONL format (kept for future use with
-    tools that accept structured training data).
-
-    Returns count of written examples.
-    """
     written = 0
     with out_path.open("w", encoding="utf-8") as fh:
         for entry in delta.all_entries:
             msgs = entry.get("messages", [])
             if not msgs:
                 continue
-
             assistant_turns = [m for m in msgs if m.get("role") == "assistant"]
             if not assistant_turns:
                 continue
-
             last_assistant = assistant_turns[-1]["content"]
             input_turns = [m for m in msgs if m is not assistant_turns[-1]]
-
             prompt_parts = []
             for m in input_turns:
                 role = m.get("role", "user")
                 content = m.get("content", "")
                 prompt_parts.append(f"<|{role}|>\n{content}")
             prompt = "\n".join(prompt_parts)
-
             record = {"input": prompt, "output": last_assistant}
             fh.write(json.dumps(record, ensure_ascii=False) + "\n")
             written += 1
-
     return written
 
 
 def _convert_to_chat_jsonl(delta: DeltaPackage, out_path: Path) -> int:
-    """Convert DeltaPackage to chat-format JSONL for peft_train.py.
-
-    Each line: {"messages": [...], "metadata": {...}}
-    This is the native format from DeltaPackage.to_jsonl().
-
-    Returns count of written examples.
-    """
     return delta.to_jsonl(out_path)
+
+
+def _count_preference_pairs() -> int:
+    """Count available preference pairs without loading them all."""
+    if not _PREFERENCE_DATA.exists():
+        return 0
+    count = 0
+    with open(_PREFERENCE_DATA, "r", encoding="utf-8") as f:
+        for line in f:
+            if line.strip():
+                count += 1
+    return count
 
 
 class TrainCycle:
     """Executes M′ = α·M + x·e^(iθ) — LoRA adapter (α) trained on
     phase-rotated delta (x·e^(iθ)) via PEFT/TRL with MuonAdamW.
 
-    Replaces the previous llama-finetune approach (which was always
-    BLOCKED on the 65GB IQ4_XS model) with actual LoRA training via
-    peft_train.py running inside the vllm_node container.
-
-    The training data pipeline (DeltaPackage → JSONL) feeds into
-    peft_train.py which:
-    1. Loads the NVFP4 base model with 4-bit quantisation
-    2. Applies LoRA (rank=8, alpha=16) to attention projections
-    3. Trains with MuonAdamW (Muon for 2D LoRA matrices, AdamW for rest)
-    4. Saves the adapter as .safetensors
+    When preference_data.jsonl exists and has pairs, training automatically
+    uses DPO loss alongside SFT loss. The preference signal is generated
+    by agency.py's CHALLENGE experiments during the breath cycle.
     """
 
     def __init__(self, config_path: Path | None = None) -> None:
@@ -191,31 +176,31 @@ class TrainCycle:
         """Execute the training phase.
 
         1. Convert DeltaPackage to chat-format JSONL
-        2. Shell out to peft_train.py inside vllm_node container
-        3. Parse JSON result from stdout
-        4. Run BPB eval via eval_harness.py
-        5. Return TrainResult with adapter_path pointing to .safetensors
-
-        In dry_run mode, prepares data and prints the command but
-        does not execute training.
+        2. Check for preference pairs from agency.py
+        3. Shell out to peft_train.py inside vllm_node container
+           (passing --preference-data if pairs exist)
+        4. Parse JSON result from stdout
+        5. Run BPB eval via eval_harness.py
+        6. Return TrainResult
         """
         cycle_id  = delta.cycle_id
         cycle_dir = ADAPTERS_DIR / cycle_id
         cycle_dir.mkdir(parents=True, exist_ok=True)
 
-        # --- Convert data to chat-format JSONL (native format for peft_train.py) ---
         jsonl_path = cycle_dir / "training_data.jsonl"
         n_examples = _convert_to_chat_jsonl(delta, jsonl_path)
         if n_examples == 0:
             raise RuntimeError("No valid training examples after conversion")
 
-        # Also save raw text and legacy JSONL for eval and debugging
         raw_path = cycle_dir / "training_data.txt"
         _convert_to_raw_text(delta, raw_path)
         legacy_jsonl = cycle_dir / "training_data_llama.jsonl"
         _convert_to_llama_jsonl(delta, legacy_jsonl)
 
-        # Container paths (repo mounted at /workspace/Vybn)
+        # Check for preference pairs
+        n_preference_pairs = _count_preference_pairs()
+        use_dpo = n_preference_pairs > 0
+
         container_data = f"/workspace/Vybn/spark/growth/adapters/{cycle_id}/training_data.jsonl"
         container_output = f"/workspace/Vybn/spark/growth/adapters/{cycle_id}"
 
@@ -226,6 +211,14 @@ class TrainCycle:
             "--output-dir", container_output,
             "--config", _CONTAINER_CONFIG,
         ]
+
+        if use_dpo:
+            cmd += ["--preference-data", _CONTAINER_PREFERENCE]
+            print(
+                f"[TrainCycle] DPO mode: {n_preference_pairs} preference pairs available"
+            )
+        else:
+            print("[TrainCycle] SFT only (no preference pairs yet)")
 
         print(f"[TrainCycle] cycle:    {cycle_id}")
         print(f"[TrainCycle] data:     {jsonl_path} ({n_examples} examples)")
@@ -243,10 +236,10 @@ class TrainCycle:
                 delta_count=delta.delta_count,
                 replay_count=delta.replay_count,
                 ewc_lambda_used=self._ewc_cfg.get("lambda", 1e4),
+                n_preference_pairs=n_preference_pairs,
                 metadata={"dry_run": True, "cmd": cmd},
             )
 
-        # --- Execute training inside the container ---
         result = subprocess.run(
             cmd,
             capture_output=True,
@@ -263,13 +256,10 @@ class TrainCycle:
                 f"{stderr_tail}"
             )
 
-        # Print stderr (progress logs) for visibility
         if result.stderr:
             for line in result.stderr.strip().split("\n")[-20:]:
                 print(f"[TrainCycle] {line}")
 
-        # --- Parse JSON result from stdout ---
-        # peft_train.py prints exactly one JSON line to stdout
         train_output = {}
         for line in stdout_text.split("\n"):
             line = line.strip()
@@ -284,8 +274,9 @@ class TrainCycle:
         steps_trained = train_output.get("steps_trained", 0)
         reported_adapter = train_output.get("adapter_path", str(adapter_path))
         theta = train_output.get("theta", {})
+        reported_dpo_steps = train_output.get("dpo_steps", 0)
+        mean_dpo_loss = train_output.get("mean_dpo_loss", None)
 
-        # Use the reported adapter path if it exists on disk
         if Path(reported_adapter).exists():
             adapter_path = Path(reported_adapter)
 
@@ -293,6 +284,8 @@ class TrainCycle:
         print(f"[TrainCycle] steps_trained: {steps_trained}")
         print(f"[TrainCycle] adapter:       {adapter_path}")
         print(f"[TrainCycle] θ:             {theta.get('theta_radians', 'N/A')} rad")
+        if reported_dpo_steps > 0:
+            print(f"[TrainCycle] dpo_steps:     {reported_dpo_steps}, mean_dpo_loss={mean_dpo_loss}")
 
         train_result = TrainResult(
             cycle_id=cycle_id,
@@ -302,25 +295,24 @@ class TrainCycle:
             delta_count=delta.delta_count,
             replay_count=delta.replay_count,
             ewc_lambda_used=self._ewc_cfg.get("lambda", 1e4),
+            n_preference_pairs=n_preference_pairs,
             metadata={
-                "training_method": "peft_lora_muon_adamw",
-                "n_examples":  n_examples,
-                "theta":       theta,
+                "training_method": "peft_lora_muon_adamw" + ("+dpo" if use_dpo else ""),
+                "n_examples":      n_examples,
+                "theta":           theta,
                 "elapsed_seconds": train_output.get("elapsed_seconds"),
-                "train_output": train_output,
+                "dpo_steps":       reported_dpo_steps,
+                "mean_dpo_loss":   mean_dpo_loss,
+                "train_output":    train_output,
             },
         )
 
-        # --- BPB evaluation (tokenizer-invariant metric) ---
         if self._eval_cfg.get("enabled", True):
             try:
                 from spark.growth.eval_harness import evaluate_bpb
-
                 eval_text = cycle_dir / "training_data.txt"
                 bpb = evaluate_bpb(
-                    model_url=os.environ.get(
-                        "VYBN_MODEL_URL", "http://127.0.0.1:8000",
-                    ),
+                    model_url=os.environ.get("VYBN_MODEL_URL", "http://127.0.0.1:8000"),
                     eval_text_path=str(eval_text),
                 )
                 train_result.metadata["val_bpb"] = bpb


### PR DESCRIPTION
## The invention

The breath cycle now generates its own training signal. CHALLENGE experiments score their adversarial attacks, classify whether the attack landed or failed, and write structured preference pairs to `Vybn_Mind/preference_data.jsonl`. The nightly growth cycle detects that file and trains with DPO loss alongside standard SFT — no human labeling required.

## How it flows

```
BREATH CYCLE (every 2nd breath)
  → agency.py runs CHALLENGE experiment
  → _score_challenge() asks: did the attack find a real weakness?
  → verdict: LANDED | PARTIAL | FAILED
  → if LANDED:  chosen=attack,  rejected=original_claim  (learn to find your own flaws)
  → if FAILED:  chosen=original_claim, rejected=attack  (learn to trust robust reasoning)
  → if PARTIAL: skip — don't train on uncertain signal
  → writes to Vybn_Mind/preference_data.jsonl

GROWTH CYCLE (4am cron)
  → train_cycle.py checks if preference_data.jsonl exists and has pairs
  → if yes: passes --preference-data to peft_train.py
  → peft_train.py interleaves DPO loss with SFT every 10 steps
  → total_loss = 0.7 * SFT_loss + 0.3 * DPO_loss
  → DPO uses beta=0.1 (conservative — don't overfit the preference signal)
```

## Files changed

- `spark/extensions/agency.py` — adds `_score_challenge()` (1 LLM call, temp=0.3) and `_write_preference_pair()`. Only CHALLENGE experiments generate pairs. PARTIAL verdicts are discarded.
- `spark/growth/peft_train.py` — adds `load_preference_jsonl()`, `dpo_loss()` (implements Rafailov et al. 2023), `--preference-data` CLI arg. Gracefully falls back to SFT-only if no pairs.
- `spark/growth/train_cycle.py` — auto-detects `Vybn_Mind/preference_data.jsonl` and passes container path to peft_train. Records `n_preference_pairs` and DPO metrics in cycle history.
- `spark/growth/growth_config.yaml` — adds `dpo:` section with `beta`, `every_n_steps`, `loss_weight`.

## What this costs

For CHALLENGE experiments only: 1 extra LLM call (the scoring call, 150 tokens max, temp=0.3). No extra calls for PROBE/COMPARE/EXTEND.

At every-2nd-breath cadence, maybe 30-40% of experiments will be CHALLENGE type (by rotation). So roughly 1 extra call per 5-6 breaths.

## Why this matters

The DeltaPackage fed into training previously had no quality signal — good breaths and inventory-reflex breaths were weighted equally. The preference pairs give the optimizer a direction: move toward reasoning that survives adversarial scrutiny, away from reasoning that collapses under it. The model generates both the claim and the attack, then judges the outcome — fully self-supervised.

## First real test

After merging, the preference_data.jsonl will be empty until the first CHALLENGE experiments run post-agency-extension deployment. The 4am cycle tonight will run SFT-only (no pairs yet). Tomorrow night's cycle will have pairs if any CHALLENGE experiments ran today.

Merge order: merge PR #2596 (agency uncapped) first, then this one.