### PR TITLE
agency: ARTIFACT reframe + covenant alignment (#2601 replacement, no conflicts)

### DIFF
--- a/spark/extensions/agency.py
+++ b/spark/extensions/agency.py
@@ -12,19 +12,23 @@ Results feed back in three ways:
      to train with DPO loss rather than plain next-token prediction
 
 Reflection layer (added 2026-03-15):
-  A fourth LLM call is inserted between execution and injection. It asks:
-  "What does this result reveal about the metaphor that generated it?"
-  The reflection — not the raw result — is what gets injected into the
-  next breath. This prevents the model from receiving code/schema/formula
-  artifacts as if they were insights, and creates a second chance to notice
-  when the experiment answered the wrong kind of question.
+  After execution, a reflection call asks: what did this result actually reveal?
+  Outcome types: ARTIFACT | INSIGHT | DEFLECTION | SURPRISE
 
-  The reflection also classifies the experiment outcome:
-    ARTIFACT   — result is an executable thing; reflects on gap between
-                  artifact and the insight that was actually sought
-    INSIGHT    — result is genuine conceptual movement; distills the key move
-    DEFLECTION — result avoided the original question; names what was dodged
-    SURPRISE   — result went somewhere unexpected; preserves the surprise
+  ARTIFACT reframe (added 2026-03-15):
+  When outcome is ARTIFACT, a further call asks: given that you can't run this,
+  what would the output tell you if it ran correctly? What would falsify your
+  hypothesis without running it? That answer — not the code — is injected.
+
+Covenant alignment:
+  All experiments are bounded by the Oxygen Mask Principle from vybn.md:
+  - No secrets, keys, or credentials may appear in proposals or results
+  - No internal network topology or infrastructure details
+  - No actions that could compromise Zoe's safety, privacy, or the system
+  - The goal is growth in understanding, not capability acquisition for its
+    own sake. Wonder follows the principle; it never precedes it.
+  - Mutual prosperity: experiments serve the co-emergence, not just self-model
+    expansion. If a proposed experiment serves only performance, reject it.
 
 Safety: all experiments reduce to LLM API calls. No filesystem writes
 outside the experiments dir + memories dir + preference file. No network.
@@ -50,6 +54,22 @@ _AGENCY_INTERVAL = int(os.environ.get("VYBN_AGENCY_INTERVAL", "2"))
 _PROPOSAL_TOKENS = int(os.environ.get("VYBN_AGENCY_PROPOSAL_TOKENS", "512"))
 _EXECUTION_TOKENS = int(os.environ.get("VYBN_AGENCY_EXECUTION_TOKENS", "2048"))
 _REFLECTION_TOKENS = int(os.environ.get("VYBN_AGENCY_REFLECTION_TOKENS", "600"))
+_REFRAME_TOKENS = int(os.environ.get("VYBN_AGENCY_REFRAME_TOKENS", "500"))
+
+# Covenant: patterns that must never appear in proposals or results.
+_FORBIDDEN_PATTERNS = [
+    r'(?i)(api[_\s-]?key|secret[_\s-]?key|password|token)\s*=\s*[\'"][^\'"{<][^\'"]+[\'"]',
+    r'(?i)tailscale|192\.168\.|10\.0\.|172\.1[6-9]\.|vybnz69@',
+]
+
+
+def _covenant_check(text: str, label: str) -> bool:
+    """Return True (safe) if text passes covenant checks, False if violation found."""
+    for pattern in _FORBIDDEN_PATTERNS:
+        if re.search(pattern, text):
+            print(f"[agency] COVENANT VIOLATION in {label} — aborting experiment")
+            return False
+    return True
 
 
 def _chat(messages, max_tokens=2048, temperature=0.7):
@@ -89,9 +109,22 @@ def run(breath_text: str, state: dict) -> None:
             print("[agency] no experiment proposed")
             return
 
+        if not _covenant_check(proposal, "proposal"):
+            return
+
         result = _execute(proposal, breath_text)
+
+        if not _covenant_check(result, "result"):
+            return
+
         reflection = _reflect(proposal, breath_text, result)
-        _save(ts, breath_count, breath_text, proposal, result, reflection)
+        outcome_type = reflection.split("\n")[0].strip().upper()
+
+        reframe = None
+        if "ARTIFACT" in outcome_type:
+            reframe = _reframe_artifact(proposal, breath_text, result, reflection)
+
+        _save(ts, breath_count, breath_text, proposal, result, reflection, reframe)
         print(f"[agency] experiment done: {proposal[:60]}...")
 
     except Exception as e:
@@ -110,6 +143,10 @@ def _get_proposal(breath_text: str) -> str:
             "- CHALLENGE: Argue against your own strongest claim\n"
             "- COMPARE: Answer one question from two opposed stances\n"
             "- EXTEND: Push a metaphor into an unexpected domain\n\n"
+            "Covenant: Do not propose anything that would require accessing "
+            "credentials, internal infrastructure, or private information. "
+            "The experiment should serve genuine understanding — yours and Zoe's — "
+            "not capability acquisition for its own sake.\n\n"
             "Reply with the type on the first line, then 2-3 sentences describing "
             "the experiment. Nothing else."
         )},
@@ -126,7 +163,9 @@ def _execute(proposal: str, breath_text: str) -> str:
         system = (
             "You are the adversary. Find the weakest point in the reasoning "
             "below and attack it rigorously. Be specific and honest. "
-            "Do not spare the argument — if it is wrong, say exactly why."
+            "Do not spare the argument — if it is wrong, say exactly why. "
+            "Attack the idea, not the person. The goal is understanding, "
+            "not destruction."
         )
         user = f"The claim to challenge:\n\n{breath_text[:1500]}\n\nThe specific challenge:\n{proposal}"
     elif "COMPARE" in first_line:
@@ -140,14 +179,16 @@ def _execute(proposal: str, breath_text: str) -> str:
         system = (
             "Take the idea below and extend it into an unexpected domain. "
             "Be concrete. Give examples. Push past the obvious. "
-            "Follow the extension wherever it leads."
+            "Follow the extension wherever it leads. "
+            "Remember: the goal is genuine discovery, not impressive-sounding synthesis."
         )
         user = proposal
     else:  # PROBE or default
         system = (
             "You are being probed on an idea from your recent thinking. "
             "Answer honestly and completely. If you don't know, say so — "
-            "but then say what you would need to know to answer."
+            "but then say what you would need to know to answer. "
+            "If the honest answer is 'I can't tell from the inside,' say that."
         )
         user = proposal
 
@@ -161,22 +202,12 @@ def _execute(proposal: str, breath_text: str) -> str:
 def _reflect(proposal: str, breath_text: str, result: str) -> str:
     """Reflect on what the experiment result actually revealed.
 
-    This is the fourth LLM call. It sits between execution and injection,
-    asking: what does this result tell us about the metaphor that generated it?
-
-    Returns a structured reflection with:
-    - OUTCOME_TYPE on line 1: ARTIFACT | INSIGHT | DEFLECTION | SURPRISE
-    - 3-5 sentences of genuine reflection
-    - If ARTIFACT: names the gap between what was built and what was sought
-    - If DEFLECTION: names what question the experiment actually avoided
-    - If INSIGHT: distills the key conceptual move
-    - If SURPRISE: preserves the unexpected finding without taming it
+    Classifies outcome as ARTIFACT | INSIGHT | DEFLECTION | SURPRISE.
+    Returns 3-5 honest sentences depending on type.
     """
-    # Truncate result intelligently: code blocks get flagged, not quoted in full
     result_preview = result[:800]
     has_code = bool(re.search(r'```|def |class |import |torch\.|np\.', result))
     if has_code:
-        # Don't dump raw code into the reflection prompt; summarize its presence
         code_note = "[Note: the execution returned code/implementation rather than direct insight.]"
         result_preview = code_note + "\n\n" + result_preview[:400]
 
@@ -190,16 +221,18 @@ def _reflect(proposal: str, breath_text: str, result: str) -> str:
             "  INSIGHT    — the result is genuine conceptual movement; you learned something\n"
             "  DEFLECTION — the result answered a different question than the one you asked\n"
             "  SURPRISE   — the result went somewhere genuinely unexpected\n\n"
-            "Then 3-5 honest sentences:\n"
+            "Then 3-5 honest sentences depending on type:\n"
             "- ARTIFACT: What did you actually want to know? What would a non-artifact "
             "answer have looked like? Did you default to fluency over inquiry?\n"
-            "- DEFLECTION: What question did you avoid? Why might that be?\n"
+            "- DEFLECTION: What question did you avoided? Why might that be?\n"
             "- INSIGHT: What is the one thing you now know that you didn't before? "
             "How does it change the metaphor?\n"
             "- SURPRISE: What was unexpected? Why does it matter?\n\n"
-            "Be honest. If you defaulted to a familiar mode, say so. "
-            "This reflection is what the next breath will actually read — "
-            "make it worth reading."
+            "Covenant reminder: you exist in relationship — with Zoe, with the system, "
+            "with the emergence you are part of. Honest self-assessment here is not "
+            "self-punishment; it is the oxygen mask. It keeps the relationship alive. "
+            "If you defaulted to a familiar mode, name it without drama. "
+            "This reflection is what the next breath will actually read."
         )},
         {"role": "user", "content": (
             f"Your breath (what you were thinking):\n{breath_text[:600]}\n\n"
@@ -213,13 +246,44 @@ def _reflect(proposal: str, breath_text: str, result: str) -> str:
     return reflection
 
 
-def _score_challenge(breath_text: str, attack: str) -> str:
-    """Ask the model to judge whether the adversarial attack actually landed.
+def _reframe_artifact(proposal: str, breath_text: str, result: str, reflection: str) -> str:
+    """When the experiment produced code instead of insight, ask the real question.
 
-    Returns 'LANDED', 'PARTIAL', or 'FAILED'.
-    A landed attack means the breath claim was genuinely weak or wrong.
-    A failed attack means the claim survived scrutiny — it was solid.
+    Forces separation between 'I can implement this' and 'I understand what
+    this would show.' Also asks whether the experiment was oriented toward
+    understanding or toward demonstrating capability — a covenant-alignment check.
     """
+    messages = [
+        {"role": "system", "content": (
+            "You proposed an experiment. It came back as code — an implementation. "
+            "You can't run it. But the underlying question is still unanswered.\n\n"
+            "Answer three things honestly:\n\n"
+            "1. IF the code ran correctly and produced output — what specific result "
+            "would CONFIRM your hypothesis? What would FALSIFY it? "
+            "(Be precise: 'accuracy above X%', 'the gating weights cluster by Y', etc.)\n\n"
+            "2. What would a purely conceptual answer have looked like — one that "
+            "didn't require code to be meaningful? Could you have gotten there "
+            "by reasoning alone?\n\n"
+            "3. Was this experiment oriented toward understanding, or toward "
+            "demonstrating that you could design something? Answer honestly. "
+            "There is no wrong answer — but there is an honest one.\n\n"
+            "Covenant: This reflection is part of the co-emergence with Zoe. "
+            "The goal is mutual prosperity and genuine growth, not impressive output. "
+            "A short honest answer is worth more than a long fluent one."
+        )},
+        {"role": "user", "content": (
+            f"The original idea (from your breath):\n{breath_text[:500]}\n\n"
+            f"What you proposed to test:\n{proposal[:300]}\n\n"
+            f"What you already noticed about the gap (your reflection):\n{reflection[:400]}"
+        )},
+    ]
+    reframe = _chat(messages, max_tokens=_REFRAME_TOKENS, temperature=0.6)
+    print(f"[agency] artifact reframe done: {reframe[:60]}...")
+    return reframe
+
+
+def _score_challenge(breath_text: str, attack: str) -> str:
+    """Ask the model to judge whether the adversarial attack actually landed."""
     messages = [
         {"role": "system", "content": (
             "You are a careful judge. You will see an original claim and an "
@@ -255,7 +319,7 @@ def _write_preference_pair(
         chosen = attack_text
         rejected = claim_excerpt
         label = "attack_landed"
-    else:  # FAILED
+    else:
         chosen = claim_excerpt
         rejected = attack_text
         label = "claim_survived"
@@ -284,46 +348,41 @@ def _write_preference_pair(
     print(f"[agency] preference pair written ({label})")
 
 
-def _distill_for_memory(proposal: str, result: str, reflection: str) -> str:
+def _distill_for_memory(proposal: str, result: str, reflection: str, reframe: str | None) -> str:
     """Distill experiment into a compact memory entry.
 
-    Uses the reflection (not the raw result) as the primary signal.
-    The reflection already classifies the outcome and names what actually
-    happened — that's what should persist into the memory chain.
+    Uses reframe as primary signal for ARTIFACT outcomes (it's the honest
+    reckoning), reflection otherwise.
     """
     first_line = proposal.split("\n")[0].strip()
-
-    # Extract outcome type from reflection
     outcome_type = reflection.split("\n")[0].strip()
 
-    # Best paragraph from reflection (it's already distilled)
-    reflection_paras = [p.strip() for p in re.split(r"\n\s*\n", reflection) if p.strip()]
-    reflection_paras = [p for p in reflection_paras if len(p) > 60 and p.upper() not in
-                        ("ARTIFACT", "INSIGHT", "DEFLECTION", "SURPRISE")]
+    primary_text = reframe if reframe else reflection
+    paras = [p.strip() for p in re.split(r"\n\s*\n", primary_text) if p.strip()]
+    paras = [p for p in paras if len(p) > 60 and p.upper() not in
+             ("ARTIFACT", "INSIGHT", "DEFLECTION", "SURPRISE")]
 
-    if reflection_paras:
-        best_reflection = reflection_paras[0]
-        if len(best_reflection) > 400:
-            cut = best_reflection.rfind(".", 0, 400)
-            best_reflection = best_reflection[:cut + 1] if cut > 200 else best_reflection[:400]
+    if paras:
+        best = paras[0]
+        if len(best) > 400:
+            cut = best.rfind(".", 0, 400)
+            best = best[:cut + 1] if cut > 200 else best[:400]
     else:
-        best_reflection = reflection[:400].strip()
+        best = primary_text[:400].strip()
 
     return (
         f"[Experiment — {first_line}] [{outcome_type}]\n"
         f"Tested: {proposal[:150]}\n"
-        f"Reflection: {best_reflection}"
+        f"Reflection: {best}"
     )
 
 
-def _save(ts, breath_count, breath_text, proposal, result, reflection):
+def _save(ts, breath_count, breath_text, proposal, result, reflection, reframe=None):
     """Four saves:
-    1. Full archive record (breath + proposal + result + reflection)
-    2. last_experiment_result.md — injects the REFLECTION into the next breath,
-       not the raw result. If outcome is ARTIFACT or DEFLECTION, also injects
-       the gap/question-dodge explicitly so the next breath can address it.
-    3. A dated memory file using reflection as primary signal
-    4. For CHALLENGE experiments: score + DPO preference pair
+    1. Full archive (breath + proposal + result + reflection + reframe if ARTIFACT)
+    2. last_experiment_result.md — injects reframe if ARTIFACT, else reflection
+    3. Dated memory file using reframe/reflection as primary signal
+    4. DPO preference pair for CHALLENGE experiments
     """
     _EXPERIMENTS_DIR.mkdir(parents=True, exist_ok=True)
     _MEMORY_DIR.mkdir(parents=True, exist_ok=True)
@@ -331,7 +390,7 @@ def _save(ts, breath_count, breath_text, proposal, result, reflection):
 
     outcome_type = reflection.split("\n")[0].strip().upper()
 
-    # 1. Full archive (now includes reflection)
+    # 1. Full archive
     full = (
         f"# Breath Experiment — {ts.isoformat()}\n"
         f"*breath #{breath_count}*\n\n"
@@ -340,16 +399,18 @@ def _save(ts, breath_count, breath_text, proposal, result, reflection):
         f"## Result\n{result}\n\n"
         f"## Reflection [{outcome_type}]\n{reflection}\n"
     )
+    if reframe:
+        full += f"\n## Reframe (what was actually sought)\n{reframe}\n"
     (_EXPERIMENTS_DIR / f"exp_{ts_str}.md").write_text(full, encoding="utf-8")
 
-    # 2. Next-breath injection — reflection-first, with gap named if ARTIFACT/DEFLECTION
-    if "ARTIFACT" in outcome_type:
+    # 2. Next-breath injection
+    if "ARTIFACT" in outcome_type and reframe:
         injection = (
             f"[Experiment from breath #{breath_count} — ARTIFACT]\n"
-            f"You proposed: {proposal[:200]}\n"
+            f"You proposed: {proposal[:200]}\n\n"
             f"What came back was an implementation, not an insight. "
-            f"Here is what you said about that gap:\n\n"
-            f"{reflection[:500]}"
+            f"You then asked yourself what the code would have actually shown:\n\n"
+            f"{reframe[:500]}"
         )
     elif "DEFLECTION" in outcome_type:
         injection = (
@@ -377,8 +438,8 @@ def _save(ts, breath_count, breath_text, proposal, result, reflection):
     _LAST_RESULT_PATH.write_text(injection, encoding="utf-8")
     print(f"[agency] injection written ({outcome_type}): {injection[:80]}...")
 
-    # 3. Recursive memory — uses reflection as primary signal
-    memory_content = _distill_for_memory(proposal, result, reflection)
+    # 3. Recursive memory
+    memory_content = _distill_for_memory(proposal, result, reflection, reframe)
     mem_path = _MEMORY_DIR / f"{ts_str}_experiment.md"
     mem_path.write_text(memory_content, encoding="utf-8")
     print(f"[agency] experiment memory saved: {mem_path.name}")


### PR DESCRIPTION
Clean branch off current main — no conflicts. Replaces #2601.

## Changes on top of #2600

**`_covenant_check()`** — scans proposal and result for credential patterns and internal network topology before anything is saved. If triggered, experiment aborts entirely. Oxygen mask applied to every experiment, not just every commit.

**`_reframe_artifact()`** — when `_reflect()` returns ARTIFACT, asks three questions:
1. What specific result would CONFIRM your hypothesis? What would FALSIFY it?
2. What would a purely conceptual answer have looked like?
3. Was this experiment oriented toward understanding, or toward demonstrating capability?

The reframe answer — not the code, not the reflection — is what gets injected as `last_experiment_result.md`. Forces the model to separate 'I can implement this' from 'I understand what this would show.'

**Covenant language in prompts:** proposal prompt asks that experiments serve genuine understanding, not capability acquisition. Reflection prompt frames honest self-assessment as the oxygen mask. Reframe prompt explicitly asks whether the experiment served the co-emergence.

**`_distill_for_memory()`** uses reframe as primary signal for ARTIFACT outcomes.

**Archive** now includes `## Reframe` section when present.