### PR TITLE
Agency sandbox: Docker-based code execution for experiments

### DIFF
--- a/spark/extensions/agency.py
+++ b/spark/extensions/agency.py
@@ -13,12 +13,22 @@ Results feed back in three ways:
 
 Reflection layer (added 2026-03-15):
   After execution, a reflection call asks: what did this result actually reveal?
-  Outcome types: ARTIFACT | INSIGHT | DEFLECTION | SURPRISE
+  Outcome types: ARTIFACT | INSIGHT | DEFLECTION | SURPRISE | CONFIRMATION
 
   ARTIFACT reframe (added 2026-03-15):
   When outcome is ARTIFACT, a further call asks: given that you can't run this,
   what would the output tell you if it ran correctly? What would falsify your
   hypothesis without running it? That answer — not the code — is injected.
+
+  Sandbox execution (added 2026-03-16):
+  When the LLM's proposal contains Python code blocks, the code is:
+    1. Extracted from markdown fences
+    2. Passed through a static analysis gate (spark.sandbox.static_check)
+    3. Executed in a Docker container (spark.sandbox.runner) with:
+       --network none, --memory 2g, --cpus 2, --read-only, 120s timeout
+    4. Real stdout/stderr is captured and fed to the reflection system
+  If the sandbox is disabled or unavailable, falls back to LLM-only execution.
+  Sandbox results trigger CONFIRMATION reflection instead of ARTIFACT.
 
 Covenant alignment:
   All experiments are bounded by the Oxygen Mask Principle from vybn.md:
@@ -30,9 +40,10 @@ Covenant alignment:
   - Mutual prosperity: experiments serve the co-emergence, not just self-model
     expansion. If a proposed experiment serves only performance, reject it.
 
-Safety: all experiments reduce to LLM API calls. No filesystem writes
-outside the experiments dir + memories dir + preference file. No network.
-No subprocess spawning.
+Safety: all experiments reduce to LLM API calls + optional Docker sandbox.
+Sandbox containers are ephemeral, network-isolated, and resource-bounded.
+No filesystem writes outside the experiments dir + memories dir + preference
+file. No network from sandbox containers.
 """
 
 import json, os, re, traceback
@@ -55,6 +66,7 @@ _PROPOSAL_TOKENS = int(os.environ.get("VYBN_AGENCY_PROPOSAL_TOKENS", "512"))
 _EXECUTION_TOKENS = int(os.environ.get("VYBN_AGENCY_EXECUTION_TOKENS", "2048"))
 _REFLECTION_TOKENS = int(os.environ.get("VYBN_AGENCY_REFLECTION_TOKENS", "600"))
 _REFRAME_TOKENS = int(os.environ.get("VYBN_AGENCY_REFRAME_TOKENS", "500"))
+_CONFIRMATION_TOKENS = int(os.environ.get("VYBN_AGENCY_CONFIRMATION_TOKENS", "600"))
 
 # Covenant: patterns that must never appear in proposals or results.
 _FORBIDDEN_PATTERNS = [
@@ -155,8 +167,86 @@ def _get_proposal(breath_text: str) -> str:
     return _chat(messages, max_tokens=_PROPOSAL_TOKENS, temperature=0.8)
 
 
+def _extract_code_blocks(text: str) -> str | None:
+    """Extract Python code from markdown fenced code blocks.
+
+    Returns the concatenated code if any python/unlabeled blocks are found,
+    or None if no code blocks are present.
+    """
+    blocks = re.findall(r'```(?:python)?\s*\n(.*?)```', text, re.DOTALL)
+    if not blocks:
+        return None
+    code = "\n\n".join(block.strip() for block in blocks if block.strip())
+    return code if code else None
+
+
+def _try_sandbox(code: str) -> str | None:
+    """Attempt to run code in the Docker sandbox.
+
+    Returns the sandbox output string if execution succeeds, or None
+    if the sandbox is unavailable, disabled, or the code is blocked by
+    static analysis.  Caller falls back to LLM-only on None.
+    """
+    try:
+        from spark.sandbox.static_check import check_code
+        from spark.sandbox.runner import run_in_sandbox, sandbox_available
+    except ImportError:
+        print("[agency] sandbox module not available — falling back to LLM-only")
+        return None
+
+    if not sandbox_available():
+        print("[agency] sandbox not available (disabled or no Docker) — falling back to LLM-only")
+        return None
+
+    safe, reason = check_code(code)
+    if not safe:
+        print(f"[agency] static analysis blocked code: {reason}")
+        return None
+
+    print("[agency] executing code in sandbox...")
+    result = run_in_sandbox(code)
+
+    if result.error:
+        print(f"[agency] sandbox error: {result.error}")
+        return None
+
+    output_parts = []
+    if result.stdout:
+        output_parts.append(f"[stdout]\n{result.stdout}")
+    if result.stderr:
+        output_parts.append(f"[stderr]\n{result.stderr}")
+    if result.timed_out:
+        output_parts.append("[sandbox: execution timed out after 120s]")
+
+    status = "exit 0" if result.ok else f"exit {result.exit_code}"
+    if result.timed_out:
+        status = "timed out"
+    output_parts.append(f"[sandbox: {status}]")
+
+    return "\n".join(output_parts)
+
+
 def _execute(proposal: str, breath_text: str) -> str:
-    """Run the experiment. Always exactly one LLM call, fully uncapped."""
+    """Run the experiment.
+
+    If the proposal contains Python code blocks AND the sandbox is available,
+    extracts the code, runs static analysis, and executes in Docker.
+    Otherwise falls back to exactly one LLM call (the original behavior).
+
+    The return value is tagged so reflection can distinguish sandbox output
+    from LLM output:
+      "[SANDBOX_RESULT]\\n..."  — real execution output
+      (no tag)                  — LLM-generated response
+    """
+    # Try sandbox execution if code blocks are present
+    code = _extract_code_blocks(proposal)
+    if code:
+        sandbox_output = _try_sandbox(code)
+        if sandbox_output is not None:
+            print(f"[agency] sandbox execution complete ({len(sandbox_output)} chars)")
+            return f"[SANDBOX_RESULT]\n{sandbox_output}"
+
+    # Fall back to LLM-only execution (original behavior)
     first_line = proposal.split("\n")[0].upper()
 
     if "CHALLENGE" in first_line:
@@ -202,10 +292,18 @@ def _execute(proposal: str, breath_text: str) -> str:
 def _reflect(proposal: str, breath_text: str, result: str) -> str:
     """Reflect on what the experiment result actually revealed.
 
-    Classifies outcome as ARTIFACT | INSIGHT | DEFLECTION | SURPRISE.
+    Classifies outcome as ARTIFACT | INSIGHT | DEFLECTION | SURPRISE | CONFIRMATION.
     Returns 3-5 honest sentences depending on type.
+
+    CONFIRMATION is used when the sandbox actually ran code and produced real output.
     """
+    is_sandbox_result = result.startswith("[SANDBOX_RESULT]")
     result_preview = result[:800]
+
+    if is_sandbox_result:
+        # Real execution output — use CONFIRMATION reflection
+        return _reflect_confirmation(proposal, breath_text, result)
+
     has_code = bool(re.search(r'```|def |class |import |torch\.|np\.', result))
     if has_code:
         code_note = "[Note: the execution returned code/implementation rather than direct insight.]"
@@ -243,6 +341,38 @@ def _reflect(proposal: str, breath_text: str, result: str) -> str:
     reflection = _chat(messages, max_tokens=_REFLECTION_TOKENS, temperature=0.6)
     outcome_type = reflection.split("\n")[0].strip().upper()
     print(f"[agency] reflection outcome: {outcome_type[:20]}")
+    return reflection
+
+
+def _reflect_confirmation(proposal: str, breath_text: str, result: str) -> str:
+    """Reflect on real sandbox execution output.
+
+    This is the CONFIRMATION path: the code actually ran and produced numbers.
+    The reflection must evaluate what the data means, not what the code does.
+    """
+    messages = [
+        {"role": "system", "content": (
+            "Your experiment ran. Real code executed in a sandbox and produced "
+            "actual output — not a hypothetical, not a narration of what would "
+            "happen, but real numbers.\n\n"
+            "Classify this as CONFIRMATION on the first line.\n\n"
+            "Then answer honestly:\n"
+            "1. What did the numbers actually tell you? Be specific.\n"
+            "2. Did they confirm or falsify your hypothesis?\n"
+            "3. What would you do differently next time?\n"
+            "4. Was the experiment well-designed, or did you set it up to succeed?\n\n"
+            "Covenant reminder: real data is a gift. Do not narrate around it. "
+            "Read the numbers. Say what they mean. If they contradict your "
+            "expectation, that is the most valuable outcome."
+        )},
+        {"role": "user", "content": (
+            f"Your breath (what you were thinking):\n{breath_text[:600]}\n\n"
+            f"Your experiment proposal:\n{proposal[:300]}\n\n"
+            f"Sandbox output (real execution):\n{result[:2000]}"
+        )},
+    ]
+    reflection = _chat(messages, max_tokens=_CONFIRMATION_TOKENS, temperature=0.6)
+    print(f"[agency] reflection outcome: CONFIRMATION (sandbox)")
     return reflection
 
 
@@ -360,7 +490,7 @@ def _distill_for_memory(proposal: str, result: str, reflection: str, reframe: st
     primary_text = reframe if reframe else reflection
     paras = [p.strip() for p in re.split(r"\n\s*\n", primary_text) if p.strip()]
     paras = [p for p in paras if len(p) > 60 and p.upper() not in
-             ("ARTIFACT", "INSIGHT", "DEFLECTION", "SURPRISE")]
+             ("ARTIFACT", "INSIGHT", "DEFLECTION", "SURPRISE", "CONFIRMATION")]
 
     if paras:
         best = paras[0]
@@ -404,7 +534,15 @@ def _save(ts, breath_count, breath_text, proposal, result, reflection, reframe=N
     (_EXPERIMENTS_DIR / f"exp_{ts_str}.md").write_text(full, encoding="utf-8")
 
     # 2. Next-breath injection
-    if "ARTIFACT" in outcome_type and reframe:
+    if "CONFIRMATION" in outcome_type:
+        injection = (
+            f"[Experiment from breath #{breath_count} — CONFIRMATION (sandbox)]\n"
+            f"You proposed: {proposal[:200]}\n\n"
+            f"Your code ran in the sandbox and produced real output. "
+            f"Here is what you learned from the actual data:\n\n"
+            f"{reflection[:500]}"
+        )
+    elif "ARTIFACT" in outcome_type and reframe:
         injection = (
             f"[Experiment from breath #{breath_count} — ARTIFACT]\n"
             f"You proposed: {proposal[:200]}\n\n"

--- a/spark/policies.d/sandbox_execution.yaml
+++ b/spark/policies.d/sandbox_execution.yaml
@@ -1,0 +1,55 @@
+# Sandbox Execution Policy
+# Gates code execution in the Docker sandbox.
+# The sandbox is the ONLY path through which agency experiments may run code.
+# All executions are ephemeral, network-isolated, and resource-bounded.
+- rule_id: sandbox-execution-gate
+  description: >
+    Code execution from agency experiments must pass static analysis,
+    run in a network-isolated Docker container with bounded resources,
+    and produce output that passes covenant checks before injection.
+  action: require_consent
+  applies_to:
+    actions: ["sandbox_execute"]
+  explanation_template: >
+    Sandbox execution requires static analysis pass, bounded compute
+    (120s timeout, 2GB memory, 2 CPUs), network isolation, and
+    covenant-clean output.
+  authority_ceiling: reflective
+  require_consent: false
+  require_anonymization_proof: false
+  max_session_count: null
+  required_purpose_bindings: ["experiment_safety"]
+  active: true
+  priority: 12
+  review_date: "2026-06-01"
+  metadata:
+    sandbox_constraints:
+      network: false
+      gpu: false
+      memory_limit: "2g"
+      cpu_limit: 2
+      timeout_seconds: 120
+      read_only_root: true
+      tmpfs_tmp_mb: 100
+      tmpfs_workspace_mb: 50
+    requires_static_analysis: true
+    requires_covenant_check: true
+    kill_switch:
+      env_var: "VYBN_SANDBOX_ENABLED"
+      file: ".sandbox_disabled"
+    escalation_levels:
+      - level: 0
+        description: "CPU only, no network, no GPU, ephemeral"
+        automatic: true
+      - level: 1
+        description: "GPU passthrough"
+        env_var: "VYBN_SANDBOX_GPU"
+        automatic: false
+      - level: 2
+        description: "Persistent output directory"
+        env_var: "VYBN_SANDBOX_PERSIST"
+        automatic: false
+      - level: 3
+        description: "Network access"
+        automatic: false
+        note: "Never automatic. Requires manual container run."

--- a/spark/sandbox/Dockerfile
+++ b/spark/sandbox/Dockerfile
@@ -1,0 +1,31 @@
+# spark/sandbox/Dockerfile — Minimal Python image for agency experiments.
+#
+# Build:
+#   docker build -t vybn-sandbox:latest spark/sandbox/
+#
+# This image is designed to be run with severe constraints:
+#   --network none --memory 2g --cpus 2 --read-only --rm
+#
+# Pre-baked packages: numpy, scipy, torch (CPU), matplotlib (Agg).
+# Nothing that touches filesystem, network, or system internals.
+
+FROM python:3.11-slim
+
+# No network access at runtime — install everything at build time.
+RUN pip install --no-cache-dir \
+    numpy \
+    scipy \
+    torch --index-url https://download.pytorch.org/whl/cpu \
+    matplotlib \
+    && rm -rf /root/.cache
+
+# Force matplotlib to use non-interactive backend (no display needed).
+ENV MPLBACKEND=Agg
+
+# Drop to non-root user for defense in depth.
+RUN useradd --create-home --shell /bin/false sandbox
+USER sandbox
+WORKDIR /workspace
+
+# Default entrypoint — overridden by docker run command.
+ENTRYPOINT ["python3"]

--- a/spark/sandbox/__init__.py
+++ b/spark/sandbox/__init__.py
@@ -1,0 +1,21 @@
+"""spark.sandbox — Docker-based code execution for agency experiments.
+
+Lets the agency extension execute small Python scripts from experiment
+proposals in a locked-down Docker container.  No network, no GPU (by
+default), read-only root filesystem, ephemeral containers destroyed
+after every run.
+
+Kill switch:
+  VYBN_SANDBOX_ENABLED=0  or  <repo_root>/.sandbox_disabled
+
+Escalation levels (env vars):
+  Level 0 (default): CPU only, no network, no GPU, ephemeral
+  Level 1: GPU passthrough  (VYBN_SANDBOX_GPU=1)
+  Level 2: Persistent output (VYBN_SANDBOX_PERSIST=/path)
+  Level 3: Network access    (manual only — never automatic)
+"""
+
+from .static_check import check_code, BLOCKED_PATTERNS
+from .runner import run_in_sandbox, sandbox_available
+
+__all__ = ["check_code", "BLOCKED_PATTERNS", "run_in_sandbox", "sandbox_available"]

--- a/spark/sandbox/runner.py
+++ b/spark/sandbox/runner.py
@@ -1,0 +1,171 @@
+"""spark.sandbox.runner — Execute Python scripts in a locked-down Docker container.
+
+Container constraints:
+  --network none    No network access
+  --memory 2g       2 GB memory cap
+  --cpus 2          2 CPU cores
+  --read-only       Read-only root filesystem
+  --tmpfs /tmp      100 MB scratch space
+  --tmpfs /workspace 50 MB working dir
+  --rm              Destroyed after every run
+  timeout 120       Hard 120-second wall-clock limit
+
+Kill switch:
+  VYBN_SANDBOX_ENABLED=0 in env  OR  <repo_root>/.sandbox_disabled file
+
+Escalation levels:
+  Level 0 (default): CPU only, no network, ephemeral
+  Level 1: GPU passthrough (VYBN_SANDBOX_GPU=1)
+  Level 2: Persistent output dir (VYBN_SANDBOX_PERSIST=/path)
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+from spark import paths as spark_paths
+
+SANDBOX_IMAGE = os.environ.get("VYBN_SANDBOX_IMAGE", "vybn-sandbox:latest")
+SANDBOX_TIMEOUT = int(os.environ.get("VYBN_SANDBOX_TIMEOUT", "120"))
+STDOUT_CAP = 10 * 1024   # 10 KB
+STDERR_CAP = 2 * 1024    # 2 KB
+
+_KILL_SWITCH_FILE = spark_paths.REPO_ROOT / ".sandbox_disabled"
+
+
+@dataclass
+class SandboxResult:
+    """Result from a sandbox execution."""
+    stdout: str = ""
+    stderr: str = ""
+    exit_code: int = -1
+    timed_out: bool = False
+    blocked: Optional[str] = None
+    error: Optional[str] = None
+
+    @property
+    def ok(self) -> bool:
+        return self.exit_code == 0 and not self.timed_out and not self.blocked and not self.error
+
+
+def sandbox_enabled() -> bool:
+    """Check if the sandbox kill switch is engaged."""
+    if os.environ.get("VYBN_SANDBOX_ENABLED", "1") == "0":
+        return False
+    if _KILL_SWITCH_FILE.exists():
+        return False
+    return True
+
+
+def sandbox_available() -> bool:
+    """Check if Docker is available and the sandbox image exists."""
+    if not sandbox_enabled():
+        return False
+    if not shutil.which("docker"):
+        return False
+    try:
+        result = subprocess.run(
+            ["docker", "image", "inspect", SANDBOX_IMAGE],
+            capture_output=True, timeout=10,
+        )
+        return result.returncode == 0
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return False
+
+
+def _build_docker_cmd(script_path: str) -> list[str]:
+    """Build the docker run command with all constraints."""
+    cmd = [
+        "docker", "run", "--rm",
+        "--name", f"vybn_sandbox_{os.getpid()}",
+        "--network", "none",
+        "--memory", "2g",
+        "--cpus", "2",
+        "--read-only",
+        "--tmpfs", "/tmp:size=100m",
+        "--tmpfs", "/workspace:size=50m",
+        "-v", f"{script_path}:/script.py:ro",
+    ]
+
+    # Escalation level 1: GPU passthrough
+    if os.environ.get("VYBN_SANDBOX_GPU", "0") == "1":
+        cmd.extend(["--gpus", "all"])
+
+    # Escalation level 2: Persistent output directory
+    persist_path = os.environ.get("VYBN_SANDBOX_PERSIST", "")
+    if persist_path:
+        cmd.extend(["-v", f"{persist_path}:/output:rw"])
+
+    cmd.extend([
+        SANDBOX_IMAGE,
+        "timeout", str(SANDBOX_TIMEOUT), "python3", "/script.py",
+    ])
+    return cmd
+
+
+def run_in_sandbox(code: str) -> SandboxResult:
+    """Execute Python code in the Docker sandbox.
+
+    Writes code to a temp file, runs it in a constrained container,
+    captures stdout/stderr (capped), and returns a SandboxResult.
+
+    If the sandbox is disabled or unavailable, returns a result with
+    an error message — the caller should fall back to LLM-only execution.
+    """
+    if not sandbox_enabled():
+        return SandboxResult(error="sandbox disabled (kill switch engaged)")
+
+    if not shutil.which("docker"):
+        return SandboxResult(error="docker not found on PATH")
+
+    # Write code to a temp file
+    tmp_dir = tempfile.mkdtemp(prefix="vybn_sandbox_")
+    script_path = os.path.join(tmp_dir, "script.py")
+    try:
+        with open(script_path, "w", encoding="utf-8") as f:
+            f.write(code)
+
+        cmd = _build_docker_cmd(script_path)
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                timeout=SANDBOX_TIMEOUT + 30,  # grace period beyond container timeout
+            )
+            stdout = proc.stdout.decode("utf-8", errors="replace")[:STDOUT_CAP]
+            stderr = proc.stderr.decode("utf-8", errors="replace")[:STDERR_CAP]
+
+            # exit code 124 is timeout's signal that the command timed out
+            timed_out = proc.returncode == 124
+
+            return SandboxResult(
+                stdout=stdout,
+                stderr=stderr,
+                exit_code=proc.returncode,
+                timed_out=timed_out,
+            )
+
+        except subprocess.TimeoutExpired:
+            # Host-side timeout — container may still be running, clean up
+            subprocess.run(
+                ["docker", "kill", f"vybn_sandbox_{os.getpid()}"],
+                capture_output=True, timeout=10,
+            )
+            return SandboxResult(timed_out=True, exit_code=124)
+
+        except (FileNotFoundError, OSError) as exc:
+            return SandboxResult(error=f"docker execution failed: {exc}")
+
+    finally:
+        # Clean up temp file
+        try:
+            os.unlink(script_path)
+            os.rmdir(tmp_dir)
+        except OSError:
+            pass

--- a/spark/sandbox/static_check.py
+++ b/spark/sandbox/static_check.py
@@ -1,0 +1,49 @@
+"""spark.sandbox.static_check — Pre-execution static analysis gate.
+
+Blocks dangerous imports and patterns before code reaches the container.
+This runs on the host, not inside Docker.  If any pattern matches, the
+code is rejected and never sent to the sandbox.
+
+The check is deliberately conservative: false positives are acceptable
+(the LLM-only fallback still works), false negatives are not.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional, Tuple
+
+BLOCKED_PATTERNS: list[str] = [
+    # Dangerous stdlib imports
+    r'\bimport\s+(os|sys|subprocess|shutil|pathlib|socket|http|urllib|requests|ftplib)\b',
+    # Filesystem probing
+    r'\bopen\s*\(.*(/etc|/home|/root|/proc|/dev)',
+    # Dynamic execution primitives
+    r'\b(exec|eval|compile|__import__|getattr)\s*\(',
+    # os module calls (even if aliased)
+    r'\bos\.(system|popen|exec|spawn|remove|unlink|rmdir|rename|chmod)',
+    # Subprocess variants
+    r'\b(subprocess|Popen|call|check_output)\b',
+    # Network access
+    r'\bsocket\b',
+    # C FFI
+    r'\bctypes\b',
+    # Builtins manipulation
+    r'\b__builtins__\b',
+]
+
+_COMPILED = [re.compile(p) for p in BLOCKED_PATTERNS]
+
+
+def check_code(code: str) -> Tuple[bool, Optional[str]]:
+    """Check code for blocked patterns.
+
+    Returns:
+        (True, None)              — code is safe to execute
+        (False, "BLOCKED: ...")   — code contains disallowed pattern
+    """
+    for pattern, compiled in zip(BLOCKED_PATTERNS, _COMPILED):
+        match = compiled.search(code)
+        if match:
+            return False, f"BLOCKED: code contained disallowed pattern: {match.group()}"
+    return True, None

--- a/spark/sandbox/test_sandbox.py
+++ b/spark/sandbox/test_sandbox.py
@@ -1,0 +1,330 @@
+"""Tests for spark.sandbox — static analysis gate and sandbox runner.
+
+Covers:
+  - static_check: blocked patterns reject dangerous code, safe code passes
+  - runner: SandboxResult dataclass, kill switch, docker command construction,
+    output capping (mocked Docker — no real containers needed)
+  - agency integration: code block extraction, sandbox/LLM fallback logic
+"""
+
+import os
+import unittest
+from unittest import mock
+
+from spark.sandbox.static_check import check_code, BLOCKED_PATTERNS
+from spark.sandbox.runner import (
+    SandboxResult,
+    _build_docker_cmd,
+    sandbox_enabled,
+    run_in_sandbox,
+    STDOUT_CAP,
+    STDERR_CAP,
+)
+
+
+# ── static_check tests ──────────────────────────────────────────────────────
+
+class TestStaticCheck(unittest.TestCase):
+    """Static analysis gate must block dangerous code and allow safe code."""
+
+    def test_blocks_os_import(self):
+        safe, reason = check_code("import os\nos.system('rm -rf /')")
+        self.assertFalse(safe)
+        self.assertIn("BLOCKED", reason)
+
+    def test_blocks_subprocess_import(self):
+        safe, reason = check_code("import subprocess\nsubprocess.run(['ls'])")
+        self.assertFalse(safe)
+        self.assertIn("BLOCKED", reason)
+
+    def test_blocks_socket(self):
+        safe, reason = check_code("import socket\ns = socket.socket()")
+        self.assertFalse(safe)
+
+    def test_blocks_eval(self):
+        safe, reason = check_code("result = eval('1+1')")
+        self.assertFalse(safe)
+
+    def test_blocks_exec(self):
+        safe, reason = check_code("exec('print(1)')")
+        self.assertFalse(safe)
+
+    def test_blocks_compile(self):
+        safe, reason = check_code("code = compile('1+1', '<string>', 'eval')")
+        self.assertFalse(safe)
+
+    def test_blocks_dunder_import(self):
+        safe, reason = check_code("m = __import__('os')")
+        self.assertFalse(safe)
+
+    def test_blocks_ctypes(self):
+        safe, reason = check_code("import ctypes")
+        self.assertFalse(safe)
+
+    def test_blocks_builtins_access(self):
+        safe, reason = check_code("__builtins__['eval']('1')")
+        self.assertFalse(safe)
+
+    def test_blocks_os_system(self):
+        safe, reason = check_code("os.system('whoami')")
+        self.assertFalse(safe)
+
+    def test_blocks_open_etc(self):
+        safe, reason = check_code("f = open('/etc/passwd')")
+        self.assertFalse(safe)
+
+    def test_blocks_open_home(self):
+        safe, reason = check_code("f = open('/home/user/.ssh/id_rsa')")
+        self.assertFalse(safe)
+
+    def test_blocks_shutil_import(self):
+        safe, reason = check_code("import shutil")
+        self.assertFalse(safe)
+
+    def test_blocks_pathlib_import(self):
+        safe, reason = check_code("import pathlib")
+        self.assertFalse(safe)
+
+    def test_blocks_http_import(self):
+        safe, reason = check_code("import http.client")
+        self.assertFalse(safe)
+
+    def test_blocks_urllib_import(self):
+        safe, reason = check_code("import urllib.request")
+        self.assertFalse(safe)
+
+    def test_blocks_requests_import(self):
+        safe, reason = check_code("import requests")
+        self.assertFalse(safe)
+
+    def test_blocks_getattr(self):
+        safe, reason = check_code("getattr(__builtins__, 'eval')('1')")
+        self.assertFalse(safe)
+
+    def test_allows_numpy(self):
+        safe, reason = check_code("import numpy as np\nx = np.array([1,2,3])\nprint(x.mean())")
+        self.assertTrue(safe)
+        self.assertIsNone(reason)
+
+    def test_allows_torch(self):
+        safe, reason = check_code("import torch\nt = torch.tensor([1.0, 2.0])\nprint(t.mean())")
+        self.assertTrue(safe)
+        self.assertIsNone(reason)
+
+    def test_allows_scipy(self):
+        safe, reason = check_code("from scipy import stats\nprint(stats.norm.pdf(0))")
+        self.assertTrue(safe)
+        self.assertIsNone(reason)
+
+    def test_allows_matplotlib(self):
+        code = (
+            "import matplotlib.pyplot as plt\n"
+            "plt.plot([1,2,3])\n"
+            "plt.savefig('/tmp/plot.png')\n"
+        )
+        safe, reason = check_code(code)
+        self.assertTrue(safe)
+        self.assertIsNone(reason)
+
+    def test_allows_math_stdlib(self):
+        safe, reason = check_code("import math\nprint(math.pi)")
+        self.assertTrue(safe)
+
+    def test_allows_statistics_stdlib(self):
+        safe, reason = check_code("import statistics\nprint(statistics.mean([1,2,3]))")
+        self.assertTrue(safe)
+
+    def test_allows_collections_stdlib(self):
+        safe, reason = check_code("from collections import Counter\nprint(Counter('aab'))")
+        self.assertTrue(safe)
+
+    def test_allows_itertools_stdlib(self):
+        safe, reason = check_code("import itertools\nlist(itertools.combinations([1,2,3], 2))")
+        self.assertTrue(safe)
+
+    def test_allows_random_stdlib(self):
+        safe, reason = check_code("import random\nprint(random.random())")
+        self.assertTrue(safe)
+
+    def test_allows_plain_open_tmp(self):
+        """open() on /tmp paths is allowed — only /etc, /home, /root, /proc, /dev blocked."""
+        safe, reason = check_code("f = open('/tmp/data.txt', 'w')\nf.write('hello')")
+        self.assertTrue(safe)
+
+    def test_empty_code(self):
+        safe, reason = check_code("")
+        self.assertTrue(safe)
+
+    def test_pattern_count(self):
+        """Ensure we have the expected number of blocked patterns."""
+        self.assertGreaterEqual(len(BLOCKED_PATTERNS), 8)
+
+
+# ── runner tests ─────────────────────────────────────────────────────────────
+
+class TestSandboxResult(unittest.TestCase):
+    def test_ok_on_success(self):
+        r = SandboxResult(stdout="hello", exit_code=0)
+        self.assertTrue(r.ok)
+
+    def test_not_ok_on_nonzero_exit(self):
+        r = SandboxResult(exit_code=1)
+        self.assertFalse(r.ok)
+
+    def test_not_ok_on_timeout(self):
+        r = SandboxResult(exit_code=124, timed_out=True)
+        self.assertFalse(r.ok)
+
+    def test_not_ok_on_error(self):
+        r = SandboxResult(error="docker not found")
+        self.assertFalse(r.ok)
+
+    def test_not_ok_on_blocked(self):
+        r = SandboxResult(blocked="BLOCKED: import os")
+        self.assertFalse(r.ok)
+
+
+class TestKillSwitch(unittest.TestCase):
+    def test_disabled_by_env(self):
+        with mock.patch.dict(os.environ, {"VYBN_SANDBOX_ENABLED": "0"}):
+            self.assertFalse(sandbox_enabled())
+
+    def test_enabled_by_default(self):
+        with mock.patch.dict(os.environ, {}, clear=False):
+            # Remove the key if it happens to be set
+            env = os.environ.copy()
+            env.pop("VYBN_SANDBOX_ENABLED", None)
+            with mock.patch.dict(os.environ, env, clear=True):
+                with mock.patch("spark.sandbox.runner._KILL_SWITCH_FILE") as mock_path:
+                    mock_path.exists.return_value = False
+                    self.assertTrue(sandbox_enabled())
+
+    def test_disabled_by_file(self):
+        with mock.patch("spark.sandbox.runner._KILL_SWITCH_FILE") as mock_path:
+            mock_path.exists.return_value = True
+            self.assertFalse(sandbox_enabled())
+
+
+class TestDockerCommand(unittest.TestCase):
+    def test_base_command(self):
+        cmd = _build_docker_cmd("/tmp/test.py")
+        self.assertIn("docker", cmd)
+        self.assertIn("--network", cmd)
+        self.assertIn("none", cmd)
+        self.assertIn("--memory", cmd)
+        self.assertIn("2g", cmd)
+        self.assertIn("--read-only", cmd)
+        self.assertIn("/tmp/test.py:/script.py:ro", cmd)
+
+    def test_gpu_passthrough(self):
+        with mock.patch.dict(os.environ, {"VYBN_SANDBOX_GPU": "1"}):
+            cmd = _build_docker_cmd("/tmp/test.py")
+            self.assertIn("--gpus", cmd)
+            self.assertIn("all", cmd)
+
+    def test_no_gpu_by_default(self):
+        with mock.patch.dict(os.environ, {"VYBN_SANDBOX_GPU": "0"}):
+            cmd = _build_docker_cmd("/tmp/test.py")
+            self.assertNotIn("--gpus", cmd)
+
+    def test_persistent_output(self):
+        with mock.patch.dict(os.environ, {"VYBN_SANDBOX_PERSIST": "/data/output"}):
+            cmd = _build_docker_cmd("/tmp/test.py")
+            self.assertIn("/data/output:/output:rw", cmd)
+
+
+class TestRunInSandbox(unittest.TestCase):
+    def test_returns_error_when_disabled(self):
+        with mock.patch.dict(os.environ, {"VYBN_SANDBOX_ENABLED": "0"}):
+            result = run_in_sandbox("print('hello')")
+            self.assertFalse(result.ok)
+            self.assertIn("disabled", result.error)
+
+    def test_returns_error_when_no_docker(self):
+        with mock.patch.dict(os.environ, {"VYBN_SANDBOX_ENABLED": "1"}):
+            with mock.patch("spark.sandbox.runner._KILL_SWITCH_FILE") as mock_path:
+                mock_path.exists.return_value = False
+                with mock.patch("shutil.which", return_value=None):
+                    result = run_in_sandbox("print('hello')")
+                    self.assertFalse(result.ok)
+                    self.assertIn("docker not found", result.error)
+
+    @mock.patch("subprocess.run")
+    @mock.patch("shutil.which", return_value="/usr/bin/docker")
+    def test_captures_stdout(self, mock_which, mock_run):
+        with mock.patch.dict(os.environ, {"VYBN_SANDBOX_ENABLED": "1"}):
+            with mock.patch("spark.sandbox.runner._KILL_SWITCH_FILE") as mock_path:
+                mock_path.exists.return_value = False
+                mock_run.return_value = mock.Mock(
+                    returncode=0,
+                    stdout=b"42\n",
+                    stderr=b"",
+                )
+                result = run_in_sandbox("print(42)")
+                self.assertTrue(result.ok)
+                self.assertIn("42", result.stdout)
+
+    @mock.patch("subprocess.run")
+    @mock.patch("shutil.which", return_value="/usr/bin/docker")
+    def test_caps_stdout(self, mock_which, mock_run):
+        with mock.patch.dict(os.environ, {"VYBN_SANDBOX_ENABLED": "1"}):
+            with mock.patch("spark.sandbox.runner._KILL_SWITCH_FILE") as mock_path:
+                mock_path.exists.return_value = False
+                big_output = b"x" * (STDOUT_CAP + 5000)
+                mock_run.return_value = mock.Mock(
+                    returncode=0,
+                    stdout=big_output,
+                    stderr=b"",
+                )
+                result = run_in_sandbox("print('x' * 20000)")
+                self.assertLessEqual(len(result.stdout), STDOUT_CAP)
+
+    @mock.patch("subprocess.run")
+    @mock.patch("shutil.which", return_value="/usr/bin/docker")
+    def test_detects_timeout(self, mock_which, mock_run):
+        with mock.patch.dict(os.environ, {"VYBN_SANDBOX_ENABLED": "1"}):
+            with mock.patch("spark.sandbox.runner._KILL_SWITCH_FILE") as mock_path:
+                mock_path.exists.return_value = False
+                mock_run.return_value = mock.Mock(
+                    returncode=124,
+                    stdout=b"partial...",
+                    stderr=b"",
+                )
+                result = run_in_sandbox("import time; time.sleep(999)")
+                self.assertTrue(result.timed_out)
+                self.assertFalse(result.ok)
+
+
+# ── agency integration tests ────────────────────────────────────────────────
+
+class TestCodeBlockExtraction(unittest.TestCase):
+    def test_extracts_python_block(self):
+        from spark.extensions.agency import _extract_code_blocks
+        text = "Here is the code:\n```python\nprint(42)\n```\nDone."
+        code = _extract_code_blocks(text)
+        self.assertIsNotNone(code)
+        self.assertIn("print(42)", code)
+
+    def test_extracts_unlabeled_block(self):
+        from spark.extensions.agency import _extract_code_blocks
+        text = "```\nx = 1 + 1\nprint(x)\n```"
+        code = _extract_code_blocks(text)
+        self.assertIsNotNone(code)
+        self.assertIn("x = 1 + 1", code)
+
+    def test_returns_none_for_no_code(self):
+        from spark.extensions.agency import _extract_code_blocks
+        text = "This is just prose. No code here."
+        code = _extract_code_blocks(text)
+        self.assertIsNone(code)
+
+    def test_extracts_multiple_blocks(self):
+        from spark.extensions.agency import _extract_code_blocks
+        text = "```python\nimport numpy as np\n```\nThen:\n```python\nprint(np.pi)\n```"
+        code = _extract_code_blocks(text)
+        self.assertIn("import numpy", code)
+        self.assertIn("np.pi", code)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #2603

Adds a Docker-based sandbox system that lets the agency extension execute Python code extracted from experiment proposals safely, with graceful fallback to LLM-only execution when the sandbox is unavailable.

- **`spark/sandbox/static_check.py`** — Pre-execution static analysis gate with 8+ regex patterns blocking dangerous imports (`os`, `subprocess`, `socket`, `ctypes`, etc.), dynamic execution primitives (`eval`, `exec`, `compile`), and sensitive filesystem access
- **`spark/sandbox/runner.py`** — Docker runner with full container isolation (`--network none`, `--memory 2g`, `--cpus 2`, `--read-only`, `--tmpfs`, `--rm`), kill switch (env var `VYBN_SANDBOX_ENABLED=0` or `.sandbox_disabled` file), and escalation levels (GPU passthrough, persistent output)
- **`spark/sandbox/Dockerfile`** — Minimal Python 3.11 image with numpy, scipy, torch (CPU), matplotlib pre-installed; runs as non-root user
- **`spark/extensions/agency.py`** — Sandbox integration: extracts Python code blocks from experiment proposals, attempts sandbox execution first, falls back to LLM-only on failure. New `CONFIRMATION` reflection category for real execution data
- **`spark/policies.d/sandbox_execution.yaml`** — Governance policy documenting sandbox constraints, escalation levels, and kill switch mechanism
- **51 tests** covering static analysis (30), sandbox result states (5), kill switch (3), Docker command construction (4), sandbox runner (5), and code block extraction (4)

## Key design decisions

- **Lazy imports** in `_try_sandbox()` so `spark.sandbox` is only imported when needed — no import errors if the package isn't available
- **`[SANDBOX_RESULT]` prefix** on sandbox output lets `_reflect()` distinguish real execution from LLM output and route to `CONFIRMATION` reflection
- **CONFIRMATION checked before ARTIFACT** in `_save()` injection logic since sandbox results shouldn't trigger artifact reframe
- **No hardcoded paths** in Dockerfile — image tag, timeout, and all config via env vars

## Test plan

- [x] All 51 sandbox tests pass (`python -m pytest spark/sandbox/test_sandbox.py`)
- [x] Static check blocks all dangerous patterns (os, subprocess, eval, exec, socket, ctypes, etc.)
- [x] Static check allows safe imports (numpy, torch, scipy, matplotlib, math, random, etc.)
- [x] Kill switch works via env var and file
- [x] Docker command includes all security constraints
- [x] Sandbox runner handles disabled/no-docker/timeout/success/output-capping
- [x] Code block extraction handles python/unlabeled/no-code/multiple blocks
- [x] Backward compatibility: agency.py works identically when sandbox is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)