### PR TITLE
sandbox: fix Dockerfile for aarch64 + add --entrypoint override

### DIFF
--- a/spark/sandbox/Dockerfile
+++ b/spark/sandbox/Dockerfile
@@ -12,12 +12,13 @@
 FROM python:3.11-slim
 
 # No network access at runtime — install everything at build time.
-RUN pip install --no-cache-dir \
-    numpy \
-    scipy \
-    torch --index-url https://download.pytorch.org/whl/cpu \
-    matplotlib \
-    && rm -rf /root/.cache
+# Install scientific stack from default PyPI first.
+RUN pip install --no-cache-dir numpy scipy matplotlib
+
+# Install PyTorch CPU-only. Try CPU index first (x86), fall back to
+# default PyPI (aarch64 wheels are CPU-only on PyPI).
+RUN pip install --no-cache-dir torch --index-url https://download.pytorch.org/whl/cpu \
+    || pip install --no-cache-dir torch
 
 # Force matplotlib to use non-interactive backend (no display needed).
 ENV MPLBACKEND=Agg

--- a/spark/sandbox/runner.py
+++ b/spark/sandbox/runner.py
@@ -103,6 +103,7 @@ def _build_docker_cmd(script_path: str) -> list[str]:
         cmd.extend(["-v", f"{persist_path}:/output:rw"])
 
     cmd.extend([
+        "--entrypoint", "",
         SANDBOX_IMAGE,
         "timeout", str(SANDBOX_TIMEOUT), "python3", "/script.py",
     ])


### PR DESCRIPTION
- Split pip installs: scipy/numpy/matplotlib from PyPI, torch from CPU index with fallback to default PyPI (aarch64 wheels are CPU-only on PyPI)
- Add --entrypoint '' to docker run command so timeout works correctly (ENTRYPOINT python3 was swallowing the timeout command as a python arg)
- Verified: sandbox image builds, all 51 tests pass, real execution works with numpy, scipy, torch CPU, matplotlib