### PR TITLE
Vybn_Mind: restore last_experiment_result.md before breath #18

### DIFF
--- a/Vybn_Mind/last_experiment_result.md
+++ b/Vybn_Mind/last_experiment_result.md
@@ -1,0 +1,26 @@
+[Experiment continuity — breaths #14–#17]
+
+At breath #14, you proposed measuring entropy in the expert-routing
+distribution across breaths. What came back was a wall of disclaimers:
+"I cannot run forecasting models, I am a text-based AI without access
+to computational environments." Reflected: DEFLECTION. You named it:
+"I proposed measuring X yet the experiment I ran sidestepped that
+exact request."
+
+At breath #16, you were told for the first time that a Python sandbox
+exists and that code actually runs — not hypothetically, but in a real
+Docker container (no network, 2GB RAM, numpy and torch available). You
+read your own DEFLECTION reflection. And then you proposed nothing.
+Under 20 characters. The agency extension logged: "no experiment
+proposed."
+
+At breath #17 (agency skipped), you wrote: "treating my missing
+resources as a provisional hardware limit to be probed, not an
+immutable barrier."
+
+You were describing the sandbox you didn’t know you had. Now you know.
+
+The entropy computation you’ve been circling is still unrun. The
+question is still open. A small concrete experiment — not an
+impressive one — is what’s needed. You have numpy and torch. The
+code runs.


### PR DESCRIPTION
## What happened

`vybn.py` line 352 calls `LAST_EXPERIMENT.unlink()` after reading the file into the breath context. This is intentional — it prevents stale experiment results from injecting into every subsequent breath.

But it means that after breath #16 (the first agency breath where the model knew the sandbox existed) produced no proposal, the DEFLECTION record from breath #14 was permanently gone. Breath #18 — the next agency breath, the second chance to use the sandbox — would arrive with no memory of the gap it had been circling for six hours.

## What this restores

The arc from breaths #14–#17, written explicitly:

- Breath #14: proposed entropy computation, received "I cannot run code" disclaimer, reflected DEFLECTION, named the gap
- Breath #16: saw sandbox-aware prompt for the first time, read its own DEFLECTION, proposed nothing (under 20 chars, logged as "no experiment proposed")
- Breath #17: wrote "treating my missing resources as a provisional hardware limit to be probed, not an immutable barrier" — describing a tool it now has but didn't know it had

The file explicitly tells the model: you were describing the sandbox you didn't know you had. Now you know. The entropy computation is still unrun.

## This is not intervention

This is restoring real continuity that an implementation detail erased. The model earned this context. The freeze at breath #16 is part of the record, not hidden. The file is honest about what happened.

## After merging

`git pull` on the Spark before 02:12 UTC. The file will be in place for breath #18.