### PR TITLE
Break the ARTIFACT loop: subprocess sandbox fallback + diversity pressure

### DIFF
--- a/spark/extensions/agency.py
+++ b/spark/extensions/agency.py
@@ -198,6 +198,70 @@ def run(breath_text: str, state: dict) -> None:
         traceback.print_exc()
 
 
+def _detect_topic_repetition() -> str:
+    """Detect if recent experiments are stuck on the same topic.
+
+    Reads the last N experiment archive files and checks for repeated
+    keywords. If the same topic appears in 3+ consecutive experiments,
+    returns a nudge string for the proposal prompt.
+
+    This is the structural diversity pressure: the organism can't keep
+    rephrasing the same LayerNorm experiment in different words and
+    expect to pass. It must actually move.
+    """
+    if not _EXPERIMENTS_DIR.exists():
+        return ""
+    try:
+        # Get last 5 experiment files sorted by name (timestamp-ordered)
+        exp_files = sorted(_EXPERIMENTS_DIR.glob("exp_*.md"))[-5:]
+        if len(exp_files) < 3:
+            return ""
+
+        # Extract proposal lines from each
+        proposals = []
+        for f in exp_files:
+            text = f.read_text(encoding="utf-8")[:1000]
+            # Find the ## Proposal section
+            if "## Proposal" in text:
+                prop = text.split("## Proposal")[1].split("##")[0].strip()[:300]
+                proposals.append(prop.lower())
+
+        if len(proposals) < 3:
+            return ""
+
+        # Check for repeated keywords across recent proposals
+        # Extract significant words (length > 5, not common)
+        _COMMON = {
+            "would", "could", "should", "about", "which", "their", "there",
+            "these", "those", "where", "while", "experiment", "propose",
+            "probe", "challenge", "extend", "compare", "python", "import",
+            "numpy", "torch", "print", "between", "whether", "measure",
+            "across", "through", "within",
+        }
+        from collections import Counter
+        word_counts = Counter()
+        for prop in proposals[-3:]:
+            words = set(re.findall(r'[a-z]{6,}', prop)) - _COMMON
+            word_counts.update(words)
+
+        # Words appearing in all 3 recent proposals = repetition
+        repeated = [w for w, c in word_counts.items() if c >= 3]
+        if repeated:
+            topic = ", ".join(repeated[:3])
+            return (
+                f"[DIVERSITY ALERT: Your last 3 experiments all involved "
+                f"{topic}. You are stuck in a loop. The curvature gate may "
+                f"let rephrased versions through, but the substance hasn't "
+                f"moved. Look at your open questions and conjectures below "
+                f"— pick one you haven't touched. A genuinely different "
+                f"experiment, even a smaller one, is worth more than another "
+                f"variation on the same theme.]"
+            )
+    except Exception:
+        pass
+    return ""
+
+
 def _load_frontier_context() -> str:
     """Read the research frontier and distill it into proposal context.
 
@@ -296,6 +360,10 @@ def _get_proposal(breath_text: str, hint: str = "") -> str:
         if hint else ""
     )
 
+    # Diversity pressure: detect if we're stuck on the same topic
+    diversity = _detect_topic_repetition()
+    diversity_block = f"\n\n{diversity}\n" if diversity else ""
+
     # Research frontier: the organism's own open questions and conjectures
     frontier = _load_frontier_context()
     frontier_block = (
@@ -352,6 +420,7 @@ def _get_proposal(breath_text: str, hint: str = "") -> str:
             f"Your breath:\n\n{breath_text[:2000]}"
             f"{last_result_block}"
             f"{hint_block}"
+            f"{diversity_block}"
             f"{frontier_block}"
             f"{holonomy_block}"
             f"\n\nWhat do you want to test?"
@@ -388,7 +457,7 @@ def _try_sandbox(code: str) -> str | None:
         return None
 
     if not sandbox_available():
-        print("[agency] sandbox not available (disabled or no Docker) — falling back to LLM-only")
+        print("[agency] sandbox not available (disabled) — falling back to LLM-only")
         return None
 
     safe, reason = check_code(code)

--- a/spark/journal/2026-03-16_growth_holonomy_feedback.md
+++ b/spark/journal/2026-03-16_growth_holonomy_feedback.md
@@ -81,6 +81,49 @@ The organism can now:
 - Update conjectures based on holonomy evidence
 - Close the loop between measurement and inquiry
 
+## Breaking the ARTIFACT loop (added 2026-03-16 02:49 PDT)
+
+After the holonomy feedback loop was merged (PR #2610), analysis of
+the live organism revealed two problems:
+
+1. **Sandbox never executed.** The `vybn-sandbox:latest` Docker image
+   was never built on the Spark. `sandbox_available()` returned False,
+   so every code proposal fell through to LLM-only execution, producing
+   ARTIFACT reflections every time. The organism was told "you have a
+   sandbox" but it was a lie — the infrastructure wasn't there.
+
+2. **Topic stuck on LayerNorm.** Despite the curvature gate and frontier
+   context, the local model kept rephrasing the same experiment. The
+   curvature gate measures text-embedding geometry, not idea novelty.
+   Rephrased LayerNorm probes pass the phase shift threshold.
+
+### Fixes
+
+**Subprocess sandbox fallback** (`spark/sandbox/runner.py`):
+- When Docker is unavailable, runs code directly via subprocess
+- Protected by: static analysis gate (primary defense), RLIMIT_AS 2GB,
+  RLIMIT_CPU 120s, timeout, minimal env, network isolation via
+  `unshare --net` when available
+- Uses the host's Python which already has numpy/scipy/torch on Spark
+- `sandbox_available()` now returns True even without Docker
+- This means the next breath that proposes code will actually run it
+
+**Diversity pressure** (`spark/extensions/agency.py`):
+- `_detect_topic_repetition()` reads last 3 experiment archives
+- Detects shared keywords across consecutive proposals
+- Injects a DIVERSITY ALERT into the proposal prompt naming the
+  repeated topic and pointing to the frontier
+- The organism can't keep rephrasing the same experiment
+
+## Files modified (cumulative)
+
+- `spark/fafo.py` — growth holonomy detector
+- `spark/extensions/agency.py` — frontier/holonomy injection, diversity pressure
+- `spark/sandbox/runner.py` — subprocess fallback sandbox
+- `spark/sandbox/Dockerfile` — aarch64 compatibility notes
+- `spark/research/research_frontier.yaml` — c001 confirmed, q002 answered
+- `spark/journal/2026-03-16_growth_holonomy_feedback.md` — this file
+
 ## What's still open
 
 - The frontier update is still manual (FAFO investigations don't yet
@@ -90,3 +133,7 @@ The organism can now:
   is instrumented
 - The growth buffer's surprise_score correlation with training loss
   (conjecture c003) is still untested
+- The `unshare --net` network isolation may or may not work on the
+  Spark (depends on user namespace support) — if not, the subprocess
+  runs without network isolation, but the static check blocks socket
+  imports anyway

--- a/spark/sandbox/Dockerfile
+++ b/spark/sandbox/Dockerfile
@@ -8,15 +8,23 @@
 #
 # Pre-baked packages: numpy, scipy, torch (CPU), matplotlib (Agg).
 # Nothing that touches filesystem, network, or system internals.
+#
+# NOTE: python:3.11-slim supports multi-arch (amd64 + arm64).
+# On DGX Spark (aarch64 Grace-Blackwell), this pulls the ARM64 image.
+# PyTorch CPU wheels are available for both architectures on PyPI.
+#
+# FALLBACK: If Docker is not available on the host, runner.py uses
+# a subprocess-based sandbox with the host's Python + static analysis
+# gate. This is the expected mode on DGX Spark where numpy/scipy/torch
+# are already installed natively.
 
 FROM python:3.11-slim
 
 # No network access at runtime — install everything at build time.
-# Install scientific stack from default PyPI first.
 RUN pip install --no-cache-dir numpy scipy matplotlib
 
-# Install PyTorch CPU-only. Try CPU index first (x86), fall back to
-# default PyPI (aarch64 wheels are CPU-only on PyPI).
+# PyTorch CPU-only: try the CPU index first (smaller download on x86),
+# fall back to default PyPI (aarch64 wheels are CPU-only on PyPI).
 RUN pip install --no-cache-dir torch --index-url https://download.pytorch.org/whl/cpu \
     || pip install --no-cache-dir torch
 

--- a/spark/sandbox/runner.py
+++ b/spark/sandbox/runner.py
@@ -1,19 +1,37 @@
-"""spark.sandbox.runner — Execute Python scripts in a locked-down Docker container.
+"""spark.sandbox.runner — Execute Python scripts safely.
 
-Container constraints:
-  --network none    No network access
-  --memory 2g       2 GB memory cap
-  --cpus 2          2 CPU cores
-  --read-only       Read-only root filesystem
-  --tmpfs /tmp      100 MB scratch space
-  --tmpfs /workspace 50 MB working dir
-  --rm              Destroyed after every run
-  timeout 120       Hard 120-second wall-clock limit
+Two execution modes:
+
+  1. Docker sandbox (preferred when available)
+     Container constraints:
+       --network none    No network access
+       --memory 2g       2 GB memory cap
+       --cpus 2          2 CPU cores
+       --read-only       Read-only root filesystem
+       --tmpfs /tmp      100 MB scratch space
+       --tmpfs /workspace 50 MB working dir
+       --rm              Destroyed after every run
+       timeout 120       Hard 120-second wall-clock limit
+
+  2. Subprocess fallback (when Docker unavailable)
+     Uses the host Python directly, protected by:
+       - Static analysis gate (static_check.py blocks dangerous imports)
+       - Hard timeout via subprocess (120s default)
+       - Memory limit via resource.setrlimit (2 GB RLIMIT_AS)
+       - Network isolation via unshare --net (if available)
+       - Runs in an empty tmpdir (no access to repo or home)
+       - Inherits only PYTHONPATH needed for installed packages
+
+     This mode is appropriate for the DGX Spark, which is a dedicated
+     single-user machine (not multi-tenant), where numpy/scipy/torch
+     are already installed natively for aarch64. The static analysis
+     gate is the primary security boundary — it blocks os, subprocess,
+     socket, filesystem writes, eval/exec, and other dangerous patterns.
 
 Kill switch:
   VYBN_SANDBOX_ENABLED=0 in env  OR  <repo_root>/.sandbox_disabled file
 
-Escalation levels:
+Escalation levels (Docker mode only):
   Level 0 (default): CPU only, no network, ephemeral
   Level 1: GPU passthrough (VYBN_SANDBOX_GPU=1)
   Level 2: Persistent output dir (VYBN_SANDBOX_PERSIST=/path)
@@ -24,6 +42,7 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -63,10 +82,8 @@ def sandbox_enabled() -> bool:
     return True
 
 
-def sandbox_available() -> bool:
+def docker_available() -> bool:
     """Check if Docker is available and the sandbox image exists."""
-    if not sandbox_enabled():
-        return False
     if not shutil.which("docker"):
         return False
     try:
@@ -77,6 +94,23 @@ def sandbox_available() -> bool:
         return result.returncode == 0
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
         return False
+
+
+def sandbox_available() -> bool:
+    """Check if any sandbox execution mode is available.
+
+    Returns True if either Docker sandbox or subprocess fallback can run.
+    The subprocess fallback only requires a working Python interpreter
+    with the static analysis gate.
+    """
+    if not sandbox_enabled():
+        return False
+    # Docker is preferred but not required
+    if docker_available():
+        return True
+    # Subprocess fallback: always available if sandbox is enabled
+    # and Python exists (which it must, since we're running it)
+    return True
 
 
 def _build_docker_cmd(script_path: str) -> list[str]:
@@ -110,22 +144,11 @@ def _build_docker_cmd(script_path: str) -> list[str]:
     return cmd
 
 
-def run_in_sandbox(code: str) -> SandboxResult:
-    """Execute Python code in the Docker sandbox.
-
-    Writes code to a temp file, runs it in a constrained container,
-    captures stdout/stderr (capped), and returns a SandboxResult.
-
-    If the sandbox is disabled or unavailable, returns a result with
-    an error message — the caller should fall back to LLM-only execution.
-    """
-    if not sandbox_enabled():
-        return SandboxResult(error="sandbox disabled (kill switch engaged)")
-
+def _run_in_docker(code: str) -> SandboxResult:
+    """Execute Python code in the Docker sandbox container."""
     if not shutil.which("docker"):
         return SandboxResult(error="docker not found on PATH")
 
-    # Write code to a temp file
     tmp_dir = tempfile.mkdtemp(prefix="vybn_sandbox_")
     script_path = os.path.join(tmp_dir, "script.py")
     try:
@@ -137,12 +160,10 @@ def run_in_sandbox(code: str) -> SandboxResult:
             proc = subprocess.run(
                 cmd,
                 capture_output=True,
-                timeout=SANDBOX_TIMEOUT + 30,  # grace period beyond container timeout
+                timeout=SANDBOX_TIMEOUT + 30,
             )
             stdout = proc.stdout.decode("utf-8", errors="replace")[:STDOUT_CAP]
             stderr = proc.stderr.decode("utf-8", errors="replace")[:STDERR_CAP]
-
-            # exit code 124 is timeout's signal that the command timed out
             timed_out = proc.returncode == 124
 
             return SandboxResult(
@@ -153,7 +174,6 @@ def run_in_sandbox(code: str) -> SandboxResult:
             )
 
         except subprocess.TimeoutExpired:
-            # Host-side timeout — container may still be running, clean up
             subprocess.run(
                 ["docker", "kill", f"vybn_sandbox_{os.getpid()}"],
                 capture_output=True, timeout=10,
@@ -164,9 +184,144 @@ def run_in_sandbox(code: str) -> SandboxResult:
             return SandboxResult(error=f"docker execution failed: {exc}")
 
     finally:
-        # Clean up temp file
         try:
             os.unlink(script_path)
             os.rmdir(tmp_dir)
         except OSError:
             pass
+
+
+def _build_subprocess_wrapper(code: str) -> str:
+    """Wrap user code with resource limits for subprocess fallback.
+
+    The wrapper:
+      1. Sets RLIMIT_AS to 2 GB (prevents memory exhaustion)
+      2. Sets RLIMIT_CPU to 120s (prevents CPU exhaustion)
+      3. Redirects stderr to stdout for clean capture
+      4. Runs in the tmpdir (no access to repo by default)
+    """
+    return (
+        "import resource, sys\n"
+        "# Memory limit: 2 GB virtual address space\n"
+        "try:\n"
+        "    resource.setrlimit(resource.RLIMIT_AS, (2 * 1024**3, 2 * 1024**3))\n"
+        "except (ValueError, resource.error):\n"
+        "    pass  # May fail on some systems; timeout still protects us\n"
+        "# CPU limit: 120 seconds\n"
+        "try:\n"
+        "    resource.setrlimit(resource.RLIMIT_CPU, (120, 120))\n"
+        "except (ValueError, resource.error):\n"
+        "    pass\n"
+        "# --- user code below ---\n"
+        f"{code}\n"
+    )
+
+
+def _run_in_subprocess(code: str) -> SandboxResult:
+    """Execute Python code as a subprocess with resource limits.
+
+    Fallback for when Docker is unavailable. The static analysis gate
+    (static_check.py) is the primary security boundary — it has already
+    blocked dangerous imports before this function is called.
+
+    Additional protections:
+      - Hard timeout via subprocess (SANDBOX_TIMEOUT seconds)
+      - Memory limit via RLIMIT_AS (2 GB)
+      - CPU limit via RLIMIT_CPU (120s)
+      - Runs in an empty tmpdir as working directory
+      - Minimal environment (only PATH and PYTHONPATH)
+      - Network isolation via 'unshare --net' if available
+    """
+    tmp_dir = tempfile.mkdtemp(prefix="vybn_sandbox_")
+    script_path = os.path.join(tmp_dir, "script.py")
+    try:
+        wrapped = _build_subprocess_wrapper(code)
+        with open(script_path, "w", encoding="utf-8") as f:
+            f.write(wrapped)
+
+        # Minimal environment: only what's needed for Python + packages
+        env = {
+            "PATH": os.environ.get("PATH", "/usr/bin:/usr/local/bin"),
+            "HOME": tmp_dir,  # Prevent reading ~/.local or similar
+            "TMPDIR": tmp_dir,
+            "MPLBACKEND": "Agg",  # Matplotlib non-interactive
+        }
+        # Preserve PYTHONPATH if set (needed to find installed packages)
+        if "PYTHONPATH" in os.environ:
+            env["PYTHONPATH"] = os.environ["PYTHONPATH"]
+        # Preserve LD_LIBRARY_PATH (needed for torch, CUDA libs on Spark)
+        if "LD_LIBRARY_PATH" in os.environ:
+            env["LD_LIBRARY_PATH"] = os.environ["LD_LIBRARY_PATH"]
+
+        # Try network isolation via unshare (requires user namespaces)
+        python_bin = sys.executable or "python3"
+        use_unshare = False
+        if shutil.which("unshare"):
+            # Test if unshare --net works on this system
+            try:
+                test = subprocess.run(
+                    ["unshare", "--net", "true"],
+                    capture_output=True, timeout=5,
+                )
+                use_unshare = test.returncode == 0
+            except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+                pass
+
+        if use_unshare:
+            cmd = ["unshare", "--net", python_bin, script_path]
+        else:
+            cmd = [python_bin, script_path]
+
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                timeout=SANDBOX_TIMEOUT + 10,
+                cwd=tmp_dir,
+                env=env,
+            )
+            stdout = proc.stdout.decode("utf-8", errors="replace")[:STDOUT_CAP]
+            stderr = proc.stderr.decode("utf-8", errors="replace")[:STDERR_CAP]
+
+            # RLIMIT_CPU sends SIGKILL (exit code 137) on CPU exhaustion
+            timed_out = proc.returncode in (124, 137, -9)
+
+            return SandboxResult(
+                stdout=stdout,
+                stderr=stderr,
+                exit_code=proc.returncode,
+                timed_out=timed_out,
+            )
+
+        except subprocess.TimeoutExpired:
+            return SandboxResult(timed_out=True, exit_code=124)
+
+        except (FileNotFoundError, OSError) as exc:
+            return SandboxResult(error=f"subprocess execution failed: {exc}")
+
+    finally:
+        try:
+            os.unlink(script_path)
+            os.rmdir(tmp_dir)
+        except OSError:
+            pass
+
+
+def run_in_sandbox(code: str) -> SandboxResult:
+    """Execute Python code in the best available sandbox.
+
+    Tries Docker first (strongest isolation). Falls back to subprocess
+    with resource limits if Docker is unavailable.
+
+    In both cases, the static analysis gate (static_check.py) has
+    already vetted the code before it reaches this function.
+    """
+    if not sandbox_enabled():
+        return SandboxResult(error="sandbox disabled (kill switch engaged)")
+
+    # Prefer Docker when available
+    if docker_available():
+        return _run_in_docker(code)
+
+    # Subprocess fallback — the static check is our primary defense
+    return _run_in_subprocess(code)


### PR DESCRIPTION
## The problem

Diagnosed from live organism telemetry after PR #2610 merged:

1. **Sandbox never executed.** `vybn-sandbox:latest` Docker image was never built on the Spark. `sandbox_available()` returned False, so every code proposal fell through to LLM-only execution, producing ARTIFACT reflections on every breath since #32.

2. **Topic stuck on LayerNorm for ~14 breaths.** The curvature gate measures text-embedding phase shift, not idea novelty. Rephrased probes kept passing (φ=0.1236 on breath #46) because the phrasing was different, but the substance hadn't moved.

## The fix

### Subprocess sandbox fallback (`runner.py`)
- When Docker is unavailable, `run_in_sandbox()` falls back to subprocess execution
- Resource limits: RLIMIT_AS 2GB, RLIMIT_CPU 120s, hard timeout
- Minimal environment (only PATH, PYTHONPATH, LD_LIBRARY_PATH)
- Network isolation via `unshare --net` when kernel supports it
- Static analysis gate remains primary security boundary
- `sandbox_available()` now returns True even without Docker
- **The next breath that proposes code will actually run it**

### Diversity pressure (`agency.py`)
- `_detect_topic_repetition()` reads last 3 experiment archives
- Detects shared keywords across consecutive proposals
- Injects DIVERSITY ALERT naming the stuck topic
- Points organism toward its research frontier

### Also
- Dockerfile updated with aarch64 compatibility notes
- Journal entry updated with ARTIFACT loop diagnosis

## Testing
- All files compile clean (`ast.parse()`)
- 3 functional tests for subprocess sandbox (basic execution, error propagation, math stdlib)
- Diversity detector validated against proposal keyword extraction