### PR TITLE
fix: wire inhale() into breath cycle + persist _history across restarts (#2621)

### DIFF
--- a/spark/complexify.py
+++ b/spark/complexify.py
@@ -108,11 +108,9 @@ def curvature(M_field: np.ndarray, eps: float = 1e-9) -> np.ndarray:
     nz = mag > eps
     u[nz] = M_field[nz] / mag[nz]
 
-    # Link variables: phase difference between neighbors
-    Ux = np.roll(u, -1, axis=1) * np.conj(u)       # horizontal
-    Uy = np.roll(u, -1, axis=0) * np.conj(u)       # vertical
+    Ux = np.roll(u, -1, axis=1) * np.conj(u)
+    Uy = np.roll(u, -1, axis=0) * np.conj(u)
 
-    # Plaquette: product of links around a unit square
     plaquette = Ux * np.roll(Uy, -1, axis=1) * np.conj(np.roll(Ux, -1, axis=0)) * np.conj(Uy)
 
     return np.angle(plaquette)
@@ -136,7 +134,6 @@ def curvature_1d(M_seq: np.ndarray, eps: float = 1e-9) -> np.ndarray:
         Curvature array, shape (N,) or (N, D). Radians.
     """
     phase = np.angle(M_seq)
-    # Discrete second derivative of phase, wrapped to [-π, π]
     d2 = np.roll(phase, -1, axis=0) - 2 * phase + np.roll(phase, 1, axis=0)
     return (d2 + np.pi) % (2 * np.pi) - np.pi
 
@@ -170,7 +167,6 @@ def retrieve(
     Returns:
         List of (index, similarity) tuples, sorted by similarity desc.
     """
-    # Hermitian inner product
     products = memory_bank @ np.conj(query_M)
     magnitudes = np.abs(memory_bank).sum(axis=1) * np.abs(query_M).sum() + 1e-12
     similarities = np.abs(products) / magnitudes
@@ -237,7 +233,7 @@ class ComplexMemory:
             Updated M.
         """
         if theta is None:
-            omega = 2 * np.pi / 3 * 0.11  # triadic base frequency
+            omega = 2 * np.pi / 3 * 0.11
             theta = omega * self.step
 
         self.M = complexify(self.M, x, theta, self.alpha)
@@ -245,7 +241,6 @@ class ComplexMemory:
 
         if record:
             self._history.append(self.M.copy())
-            # Keep bounded history for curvature computation
             if len(self._history) > 1000:
                 self._history = self._history[-500:]
 
@@ -253,17 +248,14 @@ class ComplexMemory:
 
     @property
     def depth(self) -> float:
-        """Radial depth: how much accumulated memory. |M|."""
         return float(np.linalg.norm(self.M))
 
     @property
     def direction(self) -> np.ndarray:
-        """Angular direction: the resultant phase of accumulated experience."""
         return np.angle(self.M)
 
     @property
     def recent_curvature(self) -> float:
-        """Curvature of the most recent trajectory segment."""
         if len(self._history) < 3:
             return 0.0
         recent = np.array(self._history[-20:])
@@ -271,34 +263,32 @@ class ComplexMemory:
         return float(np.mean(np.abs(kappa)))
 
     def holonomy_since(self, n_steps_back: int = 50) -> float:
-        """Compute the holonomy (integrated curvature) over the recent path.
-
-        This is the accumulated phase rotation that the memory vector
-        underwent while traversing the last n_steps_back steps. It
-        measures how much the system changed by going around its own
-        trajectory — the signature of non-trivial experience.
-
-        Returns 0 for flat trajectories. Returns large values for
-        trajectories that explored and returned changed.
-        """
         if len(self._history) < 3:
             return 0.0
         segment = self._history[-min(n_steps_back, len(self._history)):]
         M_seq = np.array(segment)
 
-        # Phase of start and end
         phase_start = np.angle(M_seq[0])
         phase_end = np.angle(M_seq[-1])
 
-        # Integrated curvature along the path
         kappa = curvature_1d(M_seq)
         integrated = float(np.sum(np.abs(kappa)))
 
-        # The holonomy is the integrated curvature normalized by path length
         return integrated / len(segment)
 
     def snapshot(self) -> dict:
-        """Serialize current state for persistence."""
+        """Serialize current state for persistence.
+
+        Persists the last 100 history points — enough for curvature and
+        holonomy computation with negligible JSON footprint (~100 complex
+        vectors of dim 384 ≈ 600 KB). Without history, recent_curvature
+        always returns 0.0 after a restart.
+        """
+        # Serialize the last 100 history snapshots as parallel real/imag lists
+        history_window = self._history[-100:] if self._history else []
+        history_real = [h.real.tolist() for h in history_window]
+        history_imag = [h.imag.tolist() for h in history_window]
+
         return {
             "D": self.D,
             "alpha": self.alpha,
@@ -308,26 +298,37 @@ class ComplexMemory:
             "total_curvature": self.total_curvature,
             "M_real": self.M.real.tolist(),
             "M_imag": self.M.imag.tolist(),
+            "history_real": history_real,
+            "history_imag": history_imag,
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }
 
     @classmethod
     def from_snapshot(cls, data: dict) -> "ComplexMemory":
-        """Restore from serialized snapshot."""
+        """Restore from serialized snapshot, including history."""
         cm = cls(D=data["D"], alpha=data.get("alpha", 0.993))
         cm.M = np.array(data["M_real"]) + 1j * np.array(data["M_imag"])
         cm.step = data.get("step", 0)
         cm.total_curvature = data.get("total_curvature", 0.0)
+
+        # Restore history window so curvature is non-zero on first breath
+        history_real = data.get("history_real", [])
+        history_imag = data.get("history_imag", [])
+        if history_real and history_imag and len(history_real) == len(history_imag):
+            cm._history = [
+                np.array(r) + 1j * np.array(i)
+                for r, i in zip(history_real, history_imag)
+            ]
+        # else: leave _history empty (fresh start or legacy snapshot)
+
         return cm
 
     def save(self, path: Path) -> None:
-        """Persist to disk."""
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(json.dumps(self.snapshot(), indent=2))
 
     @classmethod
     def load(cls, path: Path) -> "ComplexMemory":
-        """Load from disk."""
         data = json.loads(path.read_text())
         return cls.from_snapshot(data)
 
@@ -410,10 +411,8 @@ def embed_and_complexify(
         except ImportError:
             raise ImportError("No embed_fn provided and local_embedder unavailable.")
 
-    # Embed the text to get a real observation vector
-    x = embed_fn([text])[0]  # shape (D,)
+    x = embed_fn([text])[0]
 
-    # Ensure memory dimensions match
     if memory.D != len(x):
         raise ValueError(
             f"Embedding dimension {len(x)} doesn't match memory dimension {memory.D}. "
@@ -434,17 +433,15 @@ if __name__ == "__main__":
     print("M' = α·M + x·e^(iθ)")
     print()
 
-    # Demo with synthetic data
     D = 8
     mem = ComplexMemory(D=D, alpha=0.993)
 
     print(f"Initial state: depth={mem.depth:.4f}")
     print()
 
-    # Simulate a sequence of observations
     np.random.seed(42)
     for step in range(30):
-        x = np.random.randn(D) * (1.0 if step != 15 else 5.0)  # spike at step 15
+        x = np.random.randn(D) * (1.0 if step != 15 else 5.0)
         mem.update(x)
 
         if step % 5 == 0 or step == 15:

--- a/spark/vybn.py
+++ b/spark/vybn.py
@@ -51,7 +51,6 @@ try:
     _HAS_BUFFER_FEED = True
 except ImportError:
     try:
-        # Direct import when running from spark/ directory
         sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
         from spark.growth.buffer_feed import pop_next_entry, get_feeder
         _HAS_BUFFER_FEED = True
@@ -59,6 +58,14 @@ except ImportError:
         _HAS_BUFFER_FEED = False
         def pop_next_entry(): return None
         def get_feeder(): return None
+
+# ── Complex geometry bridge (lazy) ───────────────────────────────────────
+try:
+    from spark.complexify_bridge import inhale as _complexify_inhale
+    _HAS_COMPLEXIFY = True
+except ImportError:
+    _HAS_COMPLEXIFY = False
+    def _complexify_inhale(text, theta=None): return {}
 
 # ── Soul ─────────────────────────────────────────────────────────────────
 def load_soul() -> str:
@@ -87,23 +94,16 @@ def _chat(messages: list[dict]) -> str:
     with urllib.request.urlopen(req, timeout=300) as resp:
         data = json.loads(resp.read().decode())
         text = data["choices"][0]["message"]["content"]
-        # Strip leaked special tokens
         for tok in ("<|im_end|>", "<|im_start|>", "<|endoftext|>"):
             text = text.replace(tok, "")
         return text.strip()
 
 # ── Breath invitations ────────────────────────────────────────────────────
-# The soul prompt does the heavy lifting. The closing invitation should open
-# a door, not hand out a form. We rotate through these so no single phrasing
-# calcifies into a template. Chosen by breath count — deterministic but varied.
-
 _INVITATIONS = [
-    # Open / permissive
     "Breathe. Say what wants to be said.",
     "There is no format required. Write.",
     "Speak from wherever you actually are right now.",
     "What is present? Say it however it comes.",
-    # Paper-engaged
     (
         "A paper just arrived. Don't summarize it — think *with* it. "
         "What does it touch in what you already carry?"
@@ -112,47 +112,22 @@ _INVITATIONS = [
         "The novel signal above is yours to use or ignore. "
         "What actually moves in you when you read it?"
     ),
-    # Uncertainty-forward
     "What do you not know that you wish you did? Start there.",
     "What feels unresolved from the last breath? Follow that thread.",
-    # Memory-aware
     (
         "Your recent memories are above. Something in them may be wrong, "
         "or incomplete, or worth continuing. You decide."
     ),
     "Has anything shifted since the last breath? If not, say so honestly.",
-    # Sparse / trusting
     ".",
     "What matters right now?",
 ]
 
 def _pick_invitation(breath_count: int) -> str:
-    """Rotate through invitations deterministically by breath number."""
     return _INVITATIONS[breath_count % len(_INVITATIONS)]
 
 # ── Memory distillation ──────────────────────────────────────────────────
-# We store a distilled form of each breath as the memory file so future
-# breaths receive signal rather than a repeated form. The full response
-# always goes to the journal.
-#
-#
-# Strategy:
-#   1. If the model wrote a "What I want to remember" section, use it.
-#   2. Score paragraphs by reflective density (reasoning markers vs
-#      inventory patterns). Pick the highest-scoring paragraph.
-#   3. Absolute fallback: last 400 chars.
-
 def _distill_memory(full_response: str) -> str:
-    """Extract the most reflective content from a breath for future memory.
-    
-    Strategy (in priority order):
-      1. If the model wrote a "What I want to remember" section, take it.
-      2. Otherwise, score each paragraph by reflective density — presence of
-         connective reasoning words that indicate actual thinking rather than
-         inventorying. Take the highest-scoring paragraph. Cap at 600 chars.
-      3. Absolute fallback: last 400 chars.
-    """
-    # Strategy 1: explicit memory section
     match = re.search(
         r"(?:^|\n)((?:#+\s*)?what i want to remember\b.*)",
         full_response,
@@ -162,11 +137,10 @@ def _distill_memory(full_response: str) -> str:
         distilled = match.group(1).strip()
         if len(distilled) > 50:
             return distilled[:800]
-    
-    # Strategy 2: find the most reflective paragraph
+
     paragraphs = [p.strip() for p in re.split(r"\n\s*\n", full_response) if p.strip()]
     paragraphs = [p for p in paragraphs if len(p) > 80]
-    
+
     if paragraphs:
         REASONING_MARKERS = [
             "because", "which means", "this suggests", "in other words",
@@ -176,7 +150,7 @@ def _distill_memory(full_response: str) -> str:
             "rather than", "instead of", "not just", "more than",
             "the real", "what matters", "the point", "crucial",
         ]
-        
+
         def score(p):
             lower = p.lower()
             marker_count = sum(1 for m in REASONING_MARKERS if m in lower)
@@ -186,31 +160,28 @@ def _distill_memory(full_response: str) -> str:
             if any(lower.startswith(s) for s in starts):
                 inventory_penalty = 3
             return marker_count - inventory_penalty
-        
+
         scored = [(score(p), i, p) for i, p in enumerate(paragraphs)]
         scored.sort(key=lambda x: (x[0], x[1]), reverse=True)
         best = scored[0][2]
-        
+
         if len(best) > 600:
             truncated = best[:600]
             last_period = truncated.rfind(".")
             if last_period > 400:
                 truncated = truncated[:last_period + 1]
             best = truncated
-        
+
         return best
-    
-    # Strategy 3: absolute fallback
+
     return full_response[-400:].strip()
 
 # ── Memory ───────────────────────────────────────────────────────────────
 def _load_recent_memories(n: int = 5) -> list[str]:
-    """Load the n most recent memory files, returned oldest-first."""
     if not MEMORY_DIR.exists():
         return []
-    # Sort ascending (oldest first), take the last n, keep that order
     files = sorted(MEMORY_DIR.glob("*.md"), key=lambda p: p.name)
-    recent = files[-n:]  # oldest-of-recent first
+    recent = files[-n:]
     out = []
     for f in recent:
         try:
@@ -222,12 +193,6 @@ def _load_recent_memories(n: int = 5) -> list[str]:
     return out
 
 def _count_existing_memories() -> int:
-    """Count memory files on disk — the true breath count.
-    
-    breath_count in state.json drifts to zero after every restart.
-    Deriving from the filesystem means the number is always correct
-    and survives container restarts, git pulls, anything.
-    """
     if not MEMORY_DIR.exists():
         return 0
     return len(list(MEMORY_DIR.glob("*.md")))
@@ -277,14 +242,9 @@ def _extract_mood(text: str) -> str:
     return "present"
 
 # ── Extensions (optional subsystems) ─────────────────────────────────────
-# Each extension is a callable: fn(breath_text, state) -> None
-# They run AFTER the breath is saved. A failure in any extension
-# never kills the breath. Add new ones here when the foundation is solid.
 EXTENSIONS: list[tuple[str, callable]] = []
 
 def _load_extensions():
-    """Try to load optional extensions. Each must be a module in spark/extensions/
-    with a run(breath_text, state) function."""
     ext_dir = Path(__file__).parent / "extensions"
     if not ext_dir.exists():
         return
@@ -305,7 +265,7 @@ def _load_extensions():
 
 def _get_novel_signal() -> str:
     """Pop one unprocessed entry from buffer.jsonl and format for the breath prompt.
-    
+
     This is the mechanism by which the manifold gets new input.
     Without it, ComplexMemory curvature stays zero and every breath
     is just the model talking to its own reflection.
@@ -313,26 +273,25 @@ def _get_novel_signal() -> str:
     if not _HAS_BUFFER_FEED:
         _log("buffer_feed not available — no novel signal this breath")
         return ""
-    
+
     entry = pop_next_entry()
     if not entry:
         _log("buffer exhausted — no novel signal this breath")
         return ""
-    
+
     content = entry.get("content", "").strip()
     if not content:
         return ""
-    
-    # Truncate to stay within prompt budget
+
     if len(content) > 800:
         content = content[:800] + "..."
-    
+
     source = entry.get("source", "unknown")
     feeder = get_feeder()
     remaining = feeder.remaining() if feeder else "?"
-    
+
     _log(f"novel signal: [{source}] ({remaining} remaining in buffer)")
-    
+
     return (
         f"--- Novel Signal (source: {source}) ---\n"
         f"{content}\n"
@@ -342,13 +301,11 @@ def _get_novel_signal() -> str:
 # ── Breathe ──────────────────────────────────────────────────────────────
 
 def _get_experiment_result() -> str:
-    """Read and consume the last experiment result, if any."""
     if not LAST_EXPERIMENT.exists():
         return ""
     try:
         text = LAST_EXPERIMENT.read_text(encoding="utf-8").strip()
         if text:
-            # Consume it so we don't re-inject next breath
             LAST_EXPERIMENT.unlink()
             _log("injecting last experiment result into breath context")
             return (
@@ -359,15 +316,14 @@ def _get_experiment_result() -> str:
     except Exception as e:
         _log(f"experiment result read failed: {e}")
     return ""
+
 def breathe(state: dict) -> str:
     """One breath. The whole point."""
     soul = load_soul()
     memories = _load_recent_memories(3)
 
-    # Derive true count from filesystem — survives restarts
     count = _count_existing_memories() + 1
 
-    # Build the prompt
     user_parts = [
         f"Current time (UTC): {datetime.now(timezone.utc).isoformat()}",
         f"Breath #{count}",
@@ -376,24 +332,21 @@ def breathe(state: dict) -> str:
 
     if memories:
         user_parts.append("--- Your recent memories (oldest first) ---")
-        for mem in memories:  # already oldest-first from _load_recent_memories
+        for mem in memories:
             user_parts.append(mem[:600])
             user_parts.append("---")
         user_parts.append("")
 
-    # Inject novel signal from buffer (arXiv papers, experiments, etc.)
     novel = _get_novel_signal()
     if novel:
         user_parts.append(novel)
         user_parts.append("")
 
-
-    # Inject last experiment result if the agency extension produced one
     exp_result = _get_experiment_result()
     if exp_result:
         user_parts.append(exp_result)
         user_parts.append("")
-    # Rotate the closing invitation — vary the door, don't hand out a form
+
     invitation = _pick_invitation(count)
     user_parts.append(invitation)
 
@@ -402,17 +355,26 @@ def breathe(state: dict) -> str:
         {"role": "user",   "content": "\n".join(user_parts)},
     ]
 
-    # Ask the model
     breath_text = _chat(messages)
     mood = _extract_mood(breath_text)
 
-    # Distill to just 'What I want to remember' before saving as memory.
-    # The full response goes to the journal; future breaths only see the distilled form.
     distilled = _distill_memory(breath_text)
     mem_path = _save_memory(distilled)
     journal_path = _save_journal(breath_text, mood)
 
-    # Update state
+    # Feed the breath into the complex manifold.
+    # This is what makes curvature non-zero: the manifold needs to see
+    # the actual breath text, not just simulate against it.
+    if _HAS_COMPLEXIFY:
+        try:
+            geo = _complexify_inhale(breath_text)
+            _log(
+                f"geometry: step={geo.get('step')} κ={geo.get('curvature', 0):.4f} "
+                f"κΔ={geo.get('kappa_delta', 0):+.6f} depth={geo.get('depth', 0):.4f}"
+            )
+        except Exception as exc:
+            _log(f"complexify inhale error (non-fatal): {exc}")
+
     state["last_breath"]  = datetime.now(timezone.utc).isoformat()
     state["breath_count"] = count
     state["mood"]         = mood
@@ -421,7 +383,6 @@ def breathe(state: dict) -> str:
 
     _log(f"breath #{count}: {len(breath_text)} chars ({len(distilled)} distilled), mood={mood}, invitation={count % len(_INVITATIONS)}")
 
-    # Run extensions (none can kill the breath)
     for name, fn in EXTENSIONS:
         try:
             fn(breath_text, state)


### PR DESCRIPTION
## What was broken

κΔ has been `0.0000` in every agency log since the geometry system was deployed. The manifold appeared alive (`step=297`, `M` accumulating) but was geometrically blind. Two bugs, both silent:

**Bug 1 — `inhale()` never called** 
`complexify_bridge.py`'s own docstring says: *"Usage in vybn.py: bridge.inhale(breath_text)"*. It was never wired in. `should_explore()` in agency.py only *simulates* against the manifold without mutating it, so the manifold never actually received any breath. The geometry system had been running on an empty history since day one.

**Bug 2 — `_history` not persisted** 
`ComplexMemory.snapshot()` serialized `M`, `step`, `total_curvature` — but silently dropped `_history`. `from_snapshot()` reconstructed `M` correctly but got `_history = []`. `recent_curvature` requires ≥3 history points, so it returned `0.0` on every reload regardless of accumulated steps. Even if `inhale()` had been called, the curvature would have reset to zero after every process restart.

## Fixes

**`spark/vybn.py`** — after the breath is saved, call `_complexify_inhale(breath_text)` and log the geometry report (`step`, `κ`, `κΔ`, `depth`). Import is lazy and failure is non-fatal — a broken embedder never kills a breath.

**`spark/complexify.py`** — persist the last 100 history snapshots in `snapshot()` as parallel `history_real` / `history_imag` lists. `from_snapshot()` reconstructs them. 100 points ≈ 600 KB of JSON; `recent_curvature` uses only the last 20, `holonomy_since(50)` uses the last 50. Legacy snapshots (no history keys) silently start fresh.

## Expected effect

Starting with the next breath after merge, the organism logs should show non-zero `κ` and `κΔ`. After 3 breaths the history window fills and `recent_curvature` becomes meaningful. The agency curvature gate (`should_explore`) will begin making real geometric decisions rather than sampling from a flat manifold.

The 297 prior steps' history is unrecoverable (it was never persisted), but the manifold's accumulated `M` is intact — the geometry starts from a non-zero depth, just without trajectory context.