### PR TITLE
feat: vllm_node container persistence via systemd

### DIFF
--- a/spark/systemd/install-vllm-node.sh
+++ b/spark/systemd/install-vllm-node.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# install-vllm-node.sh — Install the vllm-node systemd service.
+#
+# This creates a systemd service that ensures the vllm_node Docker container
+# (Nemotron distributed inference via vLLM) starts automatically on boot
+# and restarts on failure.
+#
+# The service wraps spark/restart-vllm-cluster.sh, which is idempotent:
+#   - Starts Ray head on the primary node
+#   - Connects the Ray worker on the secondary node (spark-1c8f)
+#   - Starts or restarts the vllm_node container
+#   - Waits for the /v1/models health check
+#
+# Prerequisites:
+#   - Docker is installed and enabled (systemctl enable docker)
+#   - The vllm_node container has been created at least once via
+#     spark/nemotron_swap.sh swap  (or manually via docker run)
+#   - User vybnz69 can run docker commands (in the docker group)
+#   - spark/restart-vllm-cluster.sh is executable
+#
+# Usage:
+#   sudo bash spark/systemd/install-vllm-node.sh
+#
+# To check status after install:
+#   systemctl status vllm-node
+#   journalctl -u vllm-node -f
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+SERVICE_FILE="$DIR/vllm-node.service"
+RESTART_SCRIPT="/home/vybnz69/Vybn/spark/restart-vllm-cluster.sh"
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "ERROR: Must run as root (sudo)."
+    exit 1
+fi
+
+# Verify the restart script exists and is executable
+if [ ! -x "$RESTART_SCRIPT" ]; then
+    echo "Making $RESTART_SCRIPT executable..."
+    chmod +x "$RESTART_SCRIPT"
+fi
+
+# Verify Docker is enabled
+if ! systemctl is-enabled docker >/dev/null 2>&1; then
+    echo "Enabling docker.service..."
+    systemctl enable docker
+fi
+
+echo "Installing vllm-node.service..."
+cp "$SERVICE_FILE" /etc/systemd/system/vllm-node.service
+systemctl daemon-reload
+
+echo "Enabling vllm-node.service (will start on next boot)..."
+systemctl enable vllm-node
+
+echo ""
+echo "Done. The vllm_node container will now start automatically on boot."
+echo ""
+echo "Commands:"
+echo "  systemctl start vllm-node    # start now"
+echo "  systemctl status vllm-node   # check status"
+echo "  systemctl stop vllm-node     # stop container"
+echo "  journalctl -u vllm-node -f   # follow logs"
+echo ""
+echo "To start the service immediately:"
+echo "  sudo systemctl start vllm-node"

--- a/spark/systemd/vllm-node.service
+++ b/spark/systemd/vllm-node.service
@@ -1,0 +1,36 @@
+[Unit]
+Description=vLLM Node Container (Nemotron distributed inference)
+Documentation=https://github.com/Vybn/Vybn/blob/main/spark/restart-vllm-cluster.sh
+After=docker.service network-online.target
+Wants=network-online.target
+Requires=docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+User=vybnz69
+Group=vybnz69
+
+# The restart script is idempotent: it checks if the container/Ray are
+# already running and only starts what's missing.  It also waits for the
+# /v1/models health endpoint before exiting.
+ExecStart=/home/vybnz69/Vybn/spark/restart-vllm-cluster.sh
+
+# If the container isn't found (exit 1) or times out on health (exit 2),
+# the script exits non-zero.  Retry after a delay.
+Restart=on-failure
+RestartSec=30
+
+# Model loading can take several minutes on cold start.
+TimeoutStartSec=600
+
+# Allow the container (managed by Docker) to keep running after this unit
+# reports success — the service's job is "ensure it's up", not "own the
+# process tree".
+ExecStop=/usr/bin/docker stop vllm_node
+
+Environment=HOME=/home/vybnz69
+Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/vybnz69/.local/bin
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- Adds `spark/systemd/vllm-node.service` — a systemd unit that ensures the `vllm_node` Docker container (Nemotron distributed inference + Ray cluster) survives reboots
- Adds `spark/systemd/install-vllm-node.sh` — a root install script that deploys and enables the service
- Addresses the "vllm_node container will not survive reboot" gap flagged in `spark/continuity.md` and `spark/continuity_note.md`

### How it works

The service wraps the existing idempotent `spark/restart-vllm-cluster.sh`, which already handles:
1. Starting the Ray head on spark-2b7c
2. Connecting the Ray worker on spark-1c8f (degrades gracefully to single-node)
3. Starting or restarting the `vllm_node` container
4. Waiting for the `/v1/models` health endpoint

The systemd unit is `Type=oneshot` with `RemainAfterExit=yes` — it runs the restart script once, confirms the container is healthy, then reports success. On failure it retries after 30s. Model loading gets a 600s timeout. `ExecStop` cleanly stops the container.

### Install

\`\`\`bash
sudo bash spark/systemd/install-vllm-node.sh
sudo systemctl start vllm-node  # start now (or wait for next boot)
\`\`\`

## Test plan

- [ ] Verify install-vllm-node.sh copies the unit and enables the service
- [ ] Verify systemctl start vllm-node runs restart-vllm-cluster.sh and the container comes up healthy
- [ ] Verify systemctl stop vllm-node stops the container
- [ ] Verify the container starts automatically after a simulated reboot
- [ ] Verify journalctl -u vllm-node shows expected log output

Generated with [Claude Code](https://claude.com/claude-code)