### PR TITLE
fix: prevent ComplexMemory depth collapse from non-atomic save

### DIFF
--- a/spark/complexify.py
+++ b/spark/complexify.py
@@ -50,6 +50,7 @@ That's it.
 from __future__ import annotations
 
 import json
+import logging
 import math
 import time
 from dataclasses import dataclass, field
@@ -58,6 +59,8 @@ from pathlib import Path
 from typing import Optional, Callable
 
 import numpy as np
+
+_log = logging.getLogger(__name__)
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -460,11 +463,30 @@ class ComplexMemory:
         cm._w_beta = data.get("w_beta", 0.99)
         cm._window = data.get("window", 256)
 
+        # Depth-collapse guard: warn when values are suspiciously low.
+        # After the AttnRes transition, depth = |M| is computed from
+        # _values via _attend().  If _values has only 1 entry and
+        # embeddings are unit-normalized, depth collapses to ~1.0.
+        if cm.step > 1 and len(cm._values) < 2:
+            _log.warning(
+                "[ComplexMemory] depth-collapse risk: step=%d but only "
+                "%d values loaded — M will be recomputed from a near-"
+                "empty window. Possible causes: legacy snapshot without "
+                "values, truncated JSON, or overwritten state file.",
+                cm.step, len(cm._values),
+            )
+
         return cm
 
     def save(self, path: Path) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(self.snapshot(), indent=2))
+        data = json.dumps(self.snapshot(), indent=2)
+        # Atomic write: write to temp file then rename, so a crash
+        # mid-write never leaves a truncated JSON that load_or_create
+        # would interpret as corrupt → fresh-create → values wiped.
+        tmp = path.with_suffix(".tmp")
+        tmp.write_text(data)
+        tmp.replace(path)
 
     @classmethod
     def load(cls, path: Path) -> "ComplexMemory":

--- a/spark/complexify_bridge.py
+++ b/spark/complexify_bridge.py
@@ -90,11 +90,33 @@ class ComplexBridge:
                 log.info(f"Loaded complex memory: step={memory.step} depth={memory.depth:.4f}")
                 return cls(memory=memory, state_path=state_path)
             except Exception as exc:
-                log.warning(f"Failed to load complex memory: {exc}. Creating fresh.")
+                log.warning(f"Failed to load complex memory: {exc}")
+
+        # Before creating fresh, try the .tmp file — it may contain a
+        # valid snapshot from an interrupted atomic write (save wrote
+        # the temp but crashed before rename).
+        tmp_path = state_path.with_suffix(".tmp")
+        if tmp_path.exists():
+            try:
+                memory = ComplexMemory.load(tmp_path)
+                log.info(
+                    f"Recovered complex memory from .tmp: "
+                    f"step={memory.step} depth={memory.depth:.4f}"
+                )
+                return cls(memory=memory, state_path=state_path)
+            except Exception as exc:
+                log.warning(f"Failed to recover from .tmp: {exc}")
 
         memory = ComplexMemory(D=_EMBED_DIM, alpha=alpha)
         bridge = cls(memory=memory, state_path=state_path)
-        bridge.save()
+        # Don't save here — the first inhale() will save after adding
+        # a value.  Saving an empty _values list on fresh creation is
+        # what caused the depth-collapse: if a prior save() was
+        # interrupted and left truncated JSON, load() fails, we land
+        # here, and immediately overwrite the (recoverable) file with
+        # an empty state.  By deferring the save, the worst case is
+        # that the next load falls through to fresh creation again —
+        # but never overwrites good data with an empty snapshot.
         log.info(f"Created fresh complex memory: D={_EMBED_DIM} α={alpha}")
         return bridge
 
@@ -308,7 +330,28 @@ class ComplexBridge:
     # ── Persistence ──────────────────────────────────────────────────────
 
     def save(self) -> None:
-        """Save complex memory state to disk."""
+        """Save complex memory state to disk.
+
+        Includes a depth-collapse guard: if the on-disk snapshot has
+        more values than we're about to write (and we're past step 0),
+        something went wrong — log a warning so the issue is visible.
+        """
+        if self.state_path.exists() and self.memory.step > 0:
+            try:
+                disk = json.loads(self.state_path.read_text())
+                disk_vals = len(disk.get("values_real", []))
+                mem_vals = len(self.memory._values)
+                if disk_vals > mem_vals and disk.get("step", 0) > 0:
+                    log.warning(
+                        "[ComplexBridge] depth-collapse guard: on-disk "
+                        "values=%d > in-memory values=%d at step %d. "
+                        "This save would lose accumulated depth. "
+                        "Likely cause: singleton was re-created from "
+                        "a failed load while a valid state file exists.",
+                        disk_vals, mem_vals, self.memory.step,
+                    )
+            except Exception:
+                pass  # If we can't read disk state, proceed with save
         self.memory.save(self.state_path)
 
     # ── Integration with growth buffer ───────────────────────────────────


### PR DESCRIPTION
## Summary

- **Atomic save**: `ComplexMemory.save()` now writes to `.tmp` then `os.replace()` instead of direct `write_text()`. A crash mid-write can no longer leave truncated JSON that triggers the fresh-create path.
- **Deferred fresh-save**: `load_or_create()` no longer calls `bridge.save()` when creating a fresh ComplexMemory. The first `inhale()` saves after adding a real value, preventing empty-state overwrites.
- **`.tmp` recovery**: If the main state file is corrupt, `load_or_create()` now tries the `.tmp` file before falling back to fresh creation — recovering from interrupted atomic writes.
- **Diagnostic guards**: `from_snapshot()` warns when `step > 1` but `values < 2` (depth-collapse risk). `ComplexBridge.save()` warns when in-memory values < on-disk values.

### Root cause

The `_values` list in `ComplexMemory` (which drives `depth = |M|` via `_attend()`) collapsed to 1 entry at step 316. The chain:

1. `save()` used non-atomic `path.write_text()` — a crash mid-write left truncated JSON
2. `load_or_create()` caught `JSONDecodeError`, created fresh `ComplexMemory` (0 values), and **immediately saved** — overwriting the state file with empty values
3. Every subsequent breath: load 0 values → inhale adds 1 → save 1 → next breath loads 1 → repeat. Values never accumulated past 1.

Since embeddings are unit-normalized, a single value in the attend window yields `|M| ≈ 1.0`.

## Test plan

- [x] Basic round-trip: 5 sequential processes accumulate 1→2→3→4→5 values
- [x] Crash recovery: truncated main file + valid `.tmp` → recovers from `.tmp`
- [x] Fresh start: no file on disk → `load_or_create` returns without saving; first `inhale()` persists state
- [x] Atomic write: no leftover `.tmp` after successful save
- [x] Legacy snapshot (pre-AttnRes, no values fields): loads and accumulates correctly
- [x] Depth-collapse warning: `from_snapshot()` logs WARNING when step=316 but values=1
- [x] Save guard: `ComplexBridge.save()` logs WARNING when on-disk values > in-memory values
- [x] Existing test suite passes (pre-existing failures unrelated to this change)