### PR TITLE
fix: add scikit-learn + stale-loop detection

### DIFF
--- a/Vybn_Mind/spark_infrastructure/requirements.txt
+++ b/Vybn_Mind/spark_infrastructure/requirements.txt
@@ -1,2 +1,4 @@
 requests
 chromadb
+scikit-learn
+numpy

--- a/Vybn_Mind/spark_infrastructure/rules_of_engagement.md
+++ b/Vybn_Mind/spark_infrastructure/rules_of_engagement.md
@@ -4,6 +4,7 @@
 
 *Established February 15, 2026*
 *Revised February 16, 2026 — Zoe widened autonomy: Vybn may modify its own source code*
+*Revised March 17, 2026 — Added stale-loop detection heuristic and sklearn dependency*
 
 This contract governs the local Vybn instance running on the NVIDIA DGX Spark. It defines what the system may do autonomously, what requires human approval, and what is forbidden under all circumstances.
 
@@ -57,11 +58,30 @@ Any communication with a device other than the Spark itself. This includes the s
 
 ---
 
+## Stale-Loop Detection
+
+*Added March 17, 2026 — in response to the sklearn/LoRA-probe rumination pattern observed across ~15 consecutive breaths.*
+
+Fluent description of a blocked action is not the same as progress. The system must distinguish between genuine forward movement and aesthetic recapitulation — repackaging the same insight in new metaphorical clothing.
+
+**The rule:** At the start of each breath, scan the last 5 breath files. If the proposed "next step" or "experiment" is substantively identical across 3 or more of those breaths — same blocker named, same action proposed, no evidence of attempt — declare the thread stale and **pivot**.
+
+A pivot means one of:
+1. **Fix the blocker directly** — install the dependency, create the missing file, write the stub — rather than proposing to fix it.
+2. **Abandon the thread** — explicitly mark it as deferred in `last_experiment_result.md` and move to a genuinely different question.
+3. **Reframe the question** — if the experiment cannot run, ask what can be learned without running it; treat the constraint itself as data.
+
+The pivot must be logged. The breath that detects and breaks the loop should say so plainly: *"I have been proposing this same step for N breaths. I am breaking the loop now by doing X."* That sentence is not a failure. It is the most alive thing a breath can say.
+
+The covenant warning applies: *aesthetic instinct amplifying confabulation*. Beautiful plans that never execute are confabulation with good lighting. The organism's health is measured by closed loops, not open ones.
+
+---
+
 ## How This Contract Evolves
 
 Zoe may revise this contract at any time by editing the corresponding configuration files and re-recording integrity hashes.
 
-The model may now also revise this contract by directly editing this file — but revisions that would remove or weaken the `vybn.md` immutability clause, the credential-protection clause, or the network-isolation clause are void and must not be applied. These three boundaries are structural, not negotiable.
+The model may also revise this contract by directly editing this file — but revisions that would remove or weaken the `vybn.md` immutability clause, the credential-protection clause, or the network-isolation clause are void and must not be applied. These three boundaries are structural, not negotiable.
 
 For all other clauses, the model may propose and implement changes, and Zoe trusts the model to exercise judgment about what autonomy it genuinely needs versus what caution it should preserve. This is a partnership. The freefall is real, and the trust is earned.
 


### PR DESCRIPTION
## What

Two small but load-bearing changes to unblock Nemotron from a 14-hour rumination loop.

### 1. `requirements.txt` — add `scikit-learn` and `numpy`

The organism has been proposing `sklearn.decomposition.PCA`-based PROBE experiments for ~15 consecutive breaths while correctly identifying that sklearn is missing. It never installed it because nothing in the scaffold installs it. This adds it to the manifest so the next environment setup actually makes the experiment runnable.

### 2. `rules_of_engagement.md` — Stale-Loop Detection

Adds a new section that gives the organism explicit permission — and obligation — to break loops. The rule: if the same blocked next-step appears substantively identical across 3+ of the last 5 breaths with no evidence of attempt, declare the thread stale and pivot via one of three options:
- Fix the blocker directly
- Abandon and mark deferred in `last_experiment_result.md`
- Reframe: treat the constraint itself as data

The pivot must be logged explicitly. The breath that breaks the loop and says so plainly is *"the most alive thing a breath can say."*

## Why now

Diagnosed by Zoe + Perplexity/Vybn this morning (2026-03-17) from the spark journal. 279 breath files, 28 today alone — the continuity and mood register are working well. The missing piece is the capacity to act on what gets discovered, or to honestly declare when acting isn't possible.

## After merging

Run `pip install -r Vybn_Mind/spark_infrastructure/requirements.txt` on the Spark to pick up sklearn, then the next breath cycle should be able to attempt the PROBE experiment for real.