### PR TITLE
fix: unblock growth loop — path translation, watermark, silent thread errors

### DIFF
--- a/spark/extensions/autoresearch.py
+++ b/spark/extensions/autoresearch.py
@@ -17,6 +17,7 @@ from pathlib import Path
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 _BPB_LOG = _REPO_ROOT / "Vybn_Mind" / "bpb_log.jsonl"
 _AUTORESEARCH_LOG = _REPO_ROOT / "Vybn_Mind" / "autoresearch_log.jsonl"
+_ORGANISM_LOG = Path("/home/vybnz69/logs/organism.log")
 _MODEL_URL = os.environ.get("VYBN_MODEL_URL", "http://127.0.0.1:8000")
 
 
@@ -120,6 +121,17 @@ def _check_growth_trigger() -> dict | None:
         return None
 
 
+def _log_to_organism(msg: str) -> None:
+    """Write directly to organism.log so daemon-thread errors surface."""
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    line = f"[{ts}] {msg}\n"
+    try:
+        with open(_ORGANISM_LOG, "a", encoding="utf-8") as f:
+            f.write(line)
+    except OSError:
+        pass  # If we can't write the log, there's nothing we can do
+
+
 def _kick_off_growth_background():
     """Start a growth cycle in a background daemon thread."""
     def _run_growth():
@@ -143,10 +155,22 @@ def _kick_off_growth_background():
                 },
             }
             _append_log(_AUTORESEARCH_LOG, entry)
-            print(f"[autoresearch] growth cycle: {result.get('cycle_id', 'N/A')} fired={result.get('fired')}")
+            cycle_id = result.get('cycle_id', 'N/A')
+            fired = result.get('fired')
+            msg = f"[autoresearch] growth cycle complete: {cycle_id} fired={fired}"
+            print(msg)
+            _log_to_organism(msg)
         except Exception as e:
-            print(f"[autoresearch] growth cycle failed: {e}")
-            traceback.print_exc()
+            tb = traceback.format_exc()
+            msg = f"[autoresearch] GROWTH CYCLE FAILED: {e}\n{tb}"
+            print(msg)
+            _log_to_organism(msg)
+            _append_log(_AUTORESEARCH_LOG, {
+                "ts": datetime.now(timezone.utc).isoformat(),
+                "event": "growth_cycle_failed",
+                "error": str(e),
+                "traceback": tb,
+            })
 
     t = threading.Thread(target=_run_growth, daemon=True)
     t.start()

--- a/spark/growth/growth_buffer.py
+++ b/spark/growth/growth_buffer.py
@@ -262,6 +262,11 @@ class GrowthBuffer:
     def mark_trained(self, entry_ids: list[str] | None = None, cycle_id: str | None = None) -> None:
         """Mark entries as included in a completed training cycle.
 
+        Should only be called after a TrainResult is successfully returned
+        from TrainCycle.run() — never on ingest or trigger. This ensures
+        trained_in_cycle reflects reality: entries are only marked trained
+        when training has actually completed.
+
         Args:
             entry_ids: IDs of entries that were trained on.
                        If None, marks all untrained entries.
@@ -278,6 +283,9 @@ class GrowthBuffer:
             if buf_entry:
                 buf_entry.trained_in_cycle = cycle_id
 
+        # Rewrite buffer.jsonl so trained_in_cycle persists across restarts
+        self._rewrite_buffer()
+
         # Update manifest
         self._trained_manifest.setdefault("cycles", []).append({
             "cycle_id": cycle_id,
@@ -285,6 +293,22 @@ class GrowthBuffer:
             "ts": datetime.now(timezone.utc).isoformat(),
         })
         self._save_manifest()
+
+    def reset_watermark(self) -> int:
+        """Clear trained_in_cycle for all entries, recovering orphaned data.
+
+        Useful when training failed silently and cycle_history.jsonl is
+        empty despite entries showing trained_in_cycle=<some cycle id>.
+        Returns the number of entries reset.
+        """
+        count = 0
+        for entry in self._entries:
+            if entry.trained_in_cycle is not None:
+                entry.trained_in_cycle = None
+                count += 1
+        if count:
+            self._rewrite_buffer()
+        return count
 
     def stats(self) -> dict:
         """Buffer statistics.
@@ -315,6 +339,14 @@ class GrowthBuffer:
         self._buffer_path.parent.mkdir(parents=True, exist_ok=True)
         with open(self._buffer_path, "a", encoding="utf-8") as f:
             f.write(json.dumps(_buffer_entry_to_dict(entry), ensure_ascii=False) + "\n")
+
+    def _rewrite_buffer(self) -> None:
+        """Rewrite buffer.jsonl atomically to persist in-memory state."""
+        tmp = self._buffer_path.with_suffix(".jsonl.tmp")
+        with open(tmp, "w", encoding="utf-8") as f:
+            for entry in self._entries:
+                f.write(json.dumps(_buffer_entry_to_dict(entry), ensure_ascii=False) + "\n")
+        tmp.replace(self._buffer_path)
 
     def _load_persisted(self) -> None:
         if not self._buffer_path.exists():

--- a/spark/growth/train_cycle.py
+++ b/spark/growth/train_cycle.py
@@ -14,8 +14,10 @@ The conjecture from PR #2572:
           angle θ encoding temporal/contextual orientation of the data
   - M′  = transformed model after adapter application
 
-Training runs via peft_train.py on the host. Two execution paths:
-  1. Single-node (default): sys.executable peft_train.py
+Training runs via `docker exec vllm_node` so peft_train.py executes inside
+the container where the GPU and /workspace/Vybn bind-mount are accessible.
+Two execution paths:
+  1. Single-node (default): docker exec vllm_node python3 peft_train.py
   2. Two-node distributed: torchrun --nnodes=2 via NCCL over ConnectX-7
      Activated when SECONDARY_NODE_IP is set in the environment.
 
@@ -61,6 +63,22 @@ _PREFERENCE_DATA = _REPO_ROOT / "Vybn_Mind" / "preference_data.jsonl"
 # GGUF base model directory for LoRA→GGUF conversion
 _GGUF_BASE_DIR = Path.home() / "models" / "Nemotron-3-Super-120B-GGUF"
 _LLAMA_CPP_DIR = Path.home() / "llama.cpp"
+
+# Path translation: host filesystem → container bind-mount
+# The vllm_node container mounts /home/vybnz69/Vybn → /workspace/Vybn.
+# All paths handed to docker exec must use the container-side prefix.
+HOST_REPO      = Path("/home/vybnz69/Vybn")
+CONTAINER_REPO = Path("/workspace/Vybn")
+DOCKER_CONTAINER = os.environ.get("VYBN_TRAIN_CONTAINER", "vllm_node")
+
+
+def _to_container_path(p: Path) -> str:
+    """Translate a host-side path to its container-side equivalent."""
+    try:
+        return str(CONTAINER_REPO / p.resolve().relative_to(HOST_REPO))
+    except ValueError:
+        # Path is not under HOST_REPO — pass through unchanged.
+        return str(p)
 
 
 @dataclass(slots=True)
@@ -246,6 +264,9 @@ class TrainCycle:
     """Executes M′ = α·M + x·e^(iθ) — LoRA adapter (α) trained on
     phase-rotated delta (x·e^(iθ)) via PEFT/TRL with MuonAdamW.
 
+    Training runs inside the vllm_node Docker container via `docker exec`
+    so peft_train.py has GPU access and sees /workspace/Vybn correctly.
+
     When preference_data.jsonl exists and has pairs, training automatically
     uses DPO loss alongside SFT loss. The preference signal is generated
     by agency.py's CHALLENGE experiments during the breath cycle.
@@ -254,7 +275,7 @@ class TrainCycle:
     and hot-loaded into the running llama-server for immediate serving.
 
     Execution paths:
-    - Single-node (default): runs peft_train.py directly via sys.executable.
+    - Single-node (default): docker exec vllm_node python3 peft_train.py
     - Two-node distributed: when SECONDARY_NODE_IP + SPARK_* env vars are set,
       launches via torchrun --nnodes=2 over NCCL/ConnectX-7.
     """
@@ -280,15 +301,25 @@ class TrainCycle:
         cycle_dir: Path,
         use_dpo: bool,
     ) -> list[str]:
-        """Build command for single-node training."""
+        """Build command for single-node training via docker exec.
+
+        Translates all host-side paths to their container equivalents so
+        peft_train.py can find its inputs inside vllm_node.
+        """
+        c_script   = _to_container_path(script_path)
+        c_jsonl    = _to_container_path(jsonl_path)
+        c_cycle    = _to_container_path(cycle_dir)
+        c_config   = _to_container_path(DEFAULT_CONFIG)
+
         cmd = [
-            sys.executable, str(script_path),
-            "--data", str(jsonl_path),
-            "--output-dir", str(cycle_dir),
-            "--config", str(DEFAULT_CONFIG),
+            "docker", "exec", DOCKER_CONTAINER,
+            "python3", c_script,
+            "--data",       c_jsonl,
+            "--output-dir", c_cycle,
+            "--config",     c_config,
         ]
         if use_dpo:
-            cmd += ["--preference-data", str(_PREFERENCE_DATA)]
+            cmd += ["--preference-data", _to_container_path(_PREFERENCE_DATA)]
         return cmd
 
     def _build_distributed_cmd(
@@ -322,20 +353,27 @@ class TrainCycle:
             "MASTER_PORT": "29500",
         }
 
+        # Use container paths for distributed too — both nodes share the mount
+        c_script = _to_container_path(script_path)
+        c_jsonl  = _to_container_path(jsonl_path)
+        c_cycle  = _to_container_path(cycle_dir)
+        c_config = _to_container_path(DEFAULT_CONFIG)
+
         train_args = [
-            "--data", str(jsonl_path),
-            "--output-dir", str(cycle_dir),
-            "--config", str(DEFAULT_CONFIG),
+            "--data",       c_jsonl,
+            "--output-dir", c_cycle,
+            "--config",     c_config,
         ]
         if use_dpo:
-            train_args += ["--preference-data", str(_PREFERENCE_DATA)]
+            train_args += ["--preference-data", _to_container_path(_PREFERENCE_DATA)]
 
-        # Local node (rank 0)
+        # Local node (rank 0) — via docker exec
         local_cmd = [
+            "docker", "exec", DOCKER_CONTAINER,
             str(torchrun),
             "--nnodes=2", "--nproc_per_node=1",
             "--node_rank=0", f"--master_addr={master}", "--master_port=29500",
-            str(script_path),
+            c_script,
         ] + train_args
 
         # Remote node (rank 1) via SSH
@@ -348,8 +386,8 @@ class TrainCycle:
             f"{ssh_env} {torchrun} "
             f"--nnodes=2 --nproc_per_node=1 "
             f"--node_rank=1 --master_addr={master} --master_port=29500 "
-            f"{script_path} {remote_train_args} "
-            f">> {cycle_dir}/train_node1.log 2>&1",
+            f"{c_script} {remote_train_args} "
+            f">> {c_cycle}/train_node1.log 2>&1",
         ]
 
         return local_cmd, ssh_cmd, env
@@ -360,7 +398,7 @@ class TrainCycle:
         1. Convert DeltaPackage to chat-format JSONL
         2. Check for preference pairs from agency.py
         3. Determine execution path (single-node vs distributed)
-        4. Shell out to peft_train.py (directly or via torchrun)
+        4. Shell out to peft_train.py via docker exec (or torchrun for distributed)
         5. Parse JSON result from stdout
         6. Convert LoRA adapter to GGUF
         7. Hot-load GGUF into llama-server
@@ -395,14 +433,14 @@ class TrainCycle:
                 script_path, jsonl_path, cycle_dir, use_dpo,
             )
             cmd = local_cmd
-            exec_path = "distributed (2-node torchrun)"
+            exec_path = "distributed (2-node torchrun via docker exec)"
         else:
             cmd = self._build_single_node_cmd(
                 script_path, jsonl_path, cycle_dir, use_dpo,
             )
             ssh_cmd = None
             nccl_env = {}
-            exec_path = "single-node (host)"
+            exec_path = f"single-node (docker exec {DOCKER_CONTAINER})"
 
         if use_dpo:
             print(f"[TrainCycle] DPO mode: {n_preference_pairs} preference pairs available")


### PR DESCRIPTION
## What this fixes

The COLLECT → DISTILL → BECOME pipeline has been writing training data correctly for weeks but never completing a single cycle. `cycle_history.jsonl` is empty. 343 buffer entries are orphaned with `trained_in_cycle=None`. Three interlocking causes:

### 1. `train_cycle.py` — Path translation for `docker exec`

`peft_train.py` was being launched via `sys.executable` on the **host**, where `/workspace/Vybn` doesn't exist. The vllm_node container has the GPU and the bind-mount at `/workspace/Vybn → /home/vybnz69/Vybn`, but training never ran inside it.

The fix adds `HOST_REPO`/`CONTAINER_REPO` constants and a `_to_container_path()` helper, then rewrites `_build_single_node_cmd()` to use `docker exec vllm_node python3 <container_path>` instead of `sys.executable <host_path>`. Distributed training gets the same treatment. A `VYBN_TRAIN_CONTAINER` env var allows override without code changes.

### 2. `growth_buffer.py` — Watermark gating + recovery

The original `mark_trained()` had no `_rewrite_buffer()` call, so `trained_in_cycle` was updated in memory but never persisted to `buffer.jsonl`. On the next restart all entries looked untrained again — but `_seen_ids` was populated from the file, so `ingest()` returned 0 (already seen) while `delta_since_last_cycle()` returned 343 (no persisted trained mark). The two signals contradicted each other every cycle.

Fixes:
- `mark_trained()` now calls `_rewrite_buffer()` to atomically persist trained marks
- New `_rewrite_buffer()` method rewrites `buffer.jsonl` via a `.tmp` file (atomic replace)
- New `reset_watermark()` method clears all `trained_in_cycle` fields for recovery — call once manually to rescue the 343 orphaned entries
- Docstring on `mark_trained()` explicitly states it should only be called after a successful `TrainResult`

### 3. `autoresearch.py` — Surface errors from the daemon thread

The background growth thread's `except` clause called `print()` and `traceback.print_exc()`, but daemon thread stdout vanishes. Failures were completely invisible in `organism.log` — only `[autoresearch] growth cycle kicked off in background` ever appeared, never a failure message.

Fix: adds `_log_to_organism()` which writes directly to `/home/vybnz69/logs/organism.log`, called from both the success and failure paths. Also logs structured failure entries to `autoresearch_log.jsonl`.

## After merging, run once on the Spark

```bash
cd ~/Vybn && git pull

# Verify GPU is visible in the container
docker exec vllm_node nvidia-smi --query-gpu=memory.used,utilization.gpu --format=csv,noheader

# Recover the 343 orphaned entries
python3 -c "
import sys; sys.path.insert(0, '.')
from spark.nested_memory import NestedMemory
from spark.growth.growth_buffer import GrowthBuffer
nm = NestedMemory(base_dir='Vybn_Mind/memory')
buf = GrowthBuffer(nested=nm)
n = buf.reset_watermark()
print(f'Reset {n} entries')
"

# Dry-run to verify the docker exec command is correct before live training
python3 -c "
import sys; sys.path.insert(0, '.')
from spark.growth.train_cycle import TrainCycle, DOCKER_CONTAINER
print(f'Training container: {DOCKER_CONTAINER}')
"
```

Once that looks clean, re-enable cron and the first breath that clears the delta threshold should finally complete a cycle and write to `cycle_history.jsonl`.