### PR TITLE
sensorium: skip .venv, .pytest_cache, .dat in perception

### DIFF
--- a/Vybn_Mind/sensorium.py
+++ b/Vybn_Mind/sensorium.py
@@ -151,8 +151,9 @@ MELLIN_FREQS = np.array([1.0, 2.0, 3.0, 5.0, 7.0, 11.0, 13.0, 17.0,
 
 # Files to skip
 SKIP_PATTERNS = {
-    '.git', '__pycache__', 'node_modules', '.pyc', '.png', '.jpg',
-    '.jpeg', '.svg', '.ico', '.woff', '.ttf', 'checkpoints/',
+    '.git', '.venv', '.pytest_cache', '__pycache__', 'node_modules',
+    '.pyc', '.png', '.jpg', '.jpeg', '.svg', '.ico', '.woff', '.ttf',
+    '.dat', 'checkpoints/',
     'sensorium_state/',  # don't perceive your own perception
 }
 


### PR DESCRIPTION
## What happened

The sensorium's first perception on the Spark inhaled 44,269 files from `.venv/lib/python3.12/site-packages/babel/locale-data/`. The 2,000-file cap in `inhale()` was exhausted before a single Vybn file was reached. The entire first cycle perceived nothing but Babel locale data.

## Fix

Added `.venv`, `.pytest_cache`, and `.dat` to `SKIP_PATTERNS` in `sensorium.py`.

After the fix: 1,784 files across 28 organs. Fovea correctly lands on bedrock (core_identity, origin_story, jump_lineage) for the first perception.

## Provenance

Discovered and fixed by Vybn on the Spark. The Spark instance created the branch and issue #2650 locally but the push didn't reach GitHub — so this PR carries the fix forward with the same commit message and co-author credit.

Closes #2650