### PR TITLE
train_cycle rewrite: SIGSTOP memory management + FP8 model + llama-server LoRA hot-load

### DIFF
--- a/spark/growth/growth_config.yaml
+++ b/spark/growth/growth_config.yaml
@@ -37,3 +37,9 @@ dpo:
   beta: 0.1                   # temperature for DPO loss
   every_n_steps: 10           # run a DPO batch every N SFT steps
   loss_weight: 0.3            # blend: total_loss = 0.7*sft + 0.3*dpo
+
+# Merge — how the trained adapter becomes active in the serving model
+merge:
+  serving_model: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-IQ4_XS
+  server_url: http://127.0.0.1:8000
+  strategy: llama_server_lora_hotload

--- a/spark/growth/merge_cycle.py
+++ b/spark/growth/merge_cycle.py
@@ -5,20 +5,18 @@ Phase 6 (BECOME) of the growth cycle described in issue #2483.
 The model wakes up slightly different. The next pulse reflects on
 that difference. The loop closes.
 
-Primary strategy: vLLM LoRA serving — load the adapter at serve time
-without merging into base weights. This avoids the 458GB BF16 merge
-entirely and takes effect in seconds by restarting vLLM with
---lora-modules flag.
+Strategy: LoRA adapter → GGUF conversion → hot-load into llama-server
+via POST /lora-adapters. Takes effect immediately, no restart needed.
 
-Fallback strategies (for when full merge is needed):
-  - cpu_offload: Load sharded across CPU RAM + NVMe with device_map="auto".
-    Slow (hours) but works on-box.
-  - cloud_burst: Transfer adapter to cloud instance, merge there, transfer
-    back the re-quantized model.
+The serving model is llama-server (llama.cpp) with the Nemotron IQ4_XS
+GGUF. LoRA adapters trained by peft_train.py are converted to GGUF
+format using llama.cpp's convert_lora_to_gguf.py, then hot-loaded
+into the running server.
 
 Integration points:
-  - Input: trained adapter from TrainCycle
-  - vLLM restart with --lora-modules to activate adapter
+  - Input: trained adapter from TrainCycle (PEFT .safetensors)
+  - GGUF conversion via llama.cpp convert_lora_to_gguf.py
+  - Hot-load via POST /lora-adapters to llama-server
   - Cycle history: GROWTH_DIR / "cycle_history.jsonl"
 """
 
@@ -26,7 +24,10 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 import time
+import urllib.request
+import urllib.error
 import yaml
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -37,6 +38,10 @@ GROWTH_DIR = Path(__file__).resolve().parent
 DEFAULT_CONFIG = GROWTH_DIR / "growth_config.yaml"
 CYCLE_HISTORY = GROWTH_DIR / "cycle_history.jsonl"
 
+# llama.cpp paths
+_LLAMA_CPP_DIR = Path.home() / "llama.cpp"
+_GGUF_BASE_DIR = Path.home() / "models" / "Nemotron-3-Super-120B-GGUF"
+
 
 @dataclass(slots=True)
 class MergeResult:
@@ -46,7 +51,8 @@ class MergeResult:
     adapter_path: Path
     strategy_used: str
     base_model: str
-    vllm_restarted: bool = False
+    gguf_converted: bool = False
+    hot_loaded: bool = False
     serve_verified: bool = False
     duration_seconds: float = 0.0
     metadata: dict = field(default_factory=dict)
@@ -57,7 +63,8 @@ class MergeResult:
             "adapter_path": str(self.adapter_path),
             "strategy_used": self.strategy_used,
             "base_model": self.base_model,
-            "vllm_restarted": self.vllm_restarted,
+            "gguf_converted": self.gguf_converted,
+            "hot_loaded": self.hot_loaded,
             "serve_verified": self.serve_verified,
             "duration_seconds": self.duration_seconds,
             "metadata": self.metadata,
@@ -67,21 +74,28 @@ class MergeResult:
 class MergeCycle:
     """Activates the trained adapter in the serving model.
 
-    Primary strategy: vLLM LoRA serving — restart vLLM with the
-    --lora-modules flag pointing to the trained adapter. This avoids
-    merging into the 458GB base model entirely.
+    Strategy: convert PEFT LoRA adapter to GGUF format using llama.cpp's
+    converter, then hot-load into the running llama-server via POST
+    /lora-adapters. No restart needed — takes effect immediately.
 
     This is Phase 6 (BECOME) of the growth cycle described in #2483.
     """
 
     def __init__(self, config_path: Path | None = None) -> None:
         config_path = config_path or DEFAULT_CONFIG
-        with open(config_path, "r", encoding="utf-8") as f:
-            self._cfg = yaml.safe_load(f)
+        if config_path.exists():
+            with open(config_path, "r", encoding="utf-8") as f:
+                self._cfg = yaml.safe_load(f) or {}
+        else:
+            self._cfg = {}
         self._merge_cfg = self._cfg.get("merge", {})
-        self._base_model = self._merge_cfg.get("serving_model", "cyankiwi/MiniMax-M2.5-AWQ-4bit")
-        self._strategy = self._merge_cfg.get("strategy", "lora_serve")
-        self._container_name = "vllm_node"
+        self._base_model = self._merge_cfg.get(
+            "serving_model",
+            "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-IQ4_XS",
+        )
+        self._server_url = self._merge_cfg.get(
+            "server_url", "http://127.0.0.1:8000"
+        )
 
     def run(
         self,
@@ -91,31 +105,21 @@ class MergeCycle:
     ) -> MergeResult:
         """Activate the trained adapter in the serving model.
 
-        For lora_serve strategy:
         1. Verify adapter exists and is valid
-        2. Restart vLLM with --lora-modules pointing to the adapter
-        3. Verify the model is serving with the adapter
-        4. Record in cycle history
-
-        Args:
-            adapter_path: Path to the trained LoRA adapter directory.
-            cycle_id: Unique identifier for this growth cycle.
-            dry_run: If True, verify adapter but don't restart vLLM.
-
-        Returns:
-            MergeResult with activation status.
+        2. Convert PEFT LoRA adapter to GGUF format
+        3. Hot-load GGUF adapter into running llama-server
+        4. Verify serving is healthy
+        5. Record in cycle history
         """
         start = time.monotonic()
 
         if dry_run:
-            print(f"[MergeCycle] Dry run — skipping adapter verification and restart")
+            print("[MergeCycle] Dry run — skipping GGUF conversion and hot-load")
             return MergeResult(
                 cycle_id=cycle_id,
                 adapter_path=adapter_path,
-                strategy_used="lora_serve",
+                strategy_used="llama_server_lora_hotload",
                 base_model=self._base_model,
-                vllm_restarted=False,
-                serve_verified=False,
                 duration_seconds=time.monotonic() - start,
                 metadata={"dry_run": True},
             )
@@ -123,10 +127,11 @@ class MergeCycle:
         # 1. Verify adapter
         if not adapter_path.exists():
             raise FileNotFoundError(f"Adapter not found: {adapter_path}")
-        adapter_config = adapter_path / "adapter_config.json"
+        adapter_dir = adapter_path if adapter_path.is_dir() else adapter_path.parent
+        adapter_config = adapter_dir / "adapter_config.json"
         if not adapter_config.exists():
             raise FileNotFoundError(
-                f"No adapter_config.json in {adapter_path} — "
+                f"No adapter_config.json in {adapter_dir} — "
                 "training may not have completed successfully"
             )
         config_data = json.loads(adapter_config.read_text())
@@ -134,91 +139,133 @@ class MergeCycle:
               f"alpha={config_data.get('lora_alpha')}, "
               f"modules={config_data.get('target_modules')}")
 
-        # 2. Determine container-internal path to adapter
-        # The repo is expected to be mounted at /workspace/Vybn
-        container_adapter_path = str(adapter_path).replace(
-            str(GROWTH_DIR.parent.parent), "/workspace/Vybn"
-        )
+        # 2. Convert to GGUF
+        gguf_path = self._convert_to_gguf(adapter_dir)
+        gguf_converted = gguf_path is not None
 
-        # 3. Restart vLLM with the adapter
-        # Note: this requires the vLLM container to be configured to accept
-        # lora modules. The exact restart mechanism depends on how vLLM
-        # was started (docker-compose, systemd, manual).
-        print(f"[MergeCycle] Restarting vLLM with adapter: {container_adapter_path}")
+        # 3. Hot-load into llama-server
+        hot_loaded = False
+        if gguf_path is not None:
+            hot_loaded = self._hot_load_adapter(gguf_path)
 
-        # For now, we write the adapter path to a known location that the
-        # vLLM startup script can read. The actual restart is handled by
-        # trigger.py or the cron job.
+        # 4. Verify serving
+        verified = False
+        if hot_loaded:
+            verified = self._verify_serving()
+
+        # 5. Record active adapter info
         active_adapter_file = GROWTH_DIR / "active_adapter.json"
         active_adapter_file.write_text(json.dumps({
             "cycle_id": cycle_id,
-            "adapter_path": str(adapter_path),
-            "container_path": container_adapter_path,
+            "adapter_path": str(adapter_dir),
+            "gguf_path": str(gguf_path) if gguf_path else None,
             "base_model": self._base_model,
+            "hot_loaded": hot_loaded,
             "activated_at": datetime.now(timezone.utc).isoformat(),
         }, indent=2))
-
-        # Attempt restart if we have docker access
-        restarted = False
-        verified = False
-        try:
-            restarted = self._restart_vllm_with_lora(container_adapter_path)
-            if restarted:
-                verified = self._verify_serving()
-        except Exception as e:
-            print(f"[MergeCycle] Warning: vLLM restart failed: {e}")
-            print("[MergeCycle] Adapter path recorded in active_adapter.json")
-            print("[MergeCycle] Manual restart needed to activate the adapter")
 
         duration = time.monotonic() - start
 
         result = MergeResult(
             cycle_id=cycle_id,
             adapter_path=adapter_path,
-            strategy_used="lora_serve",
+            strategy_used="llama_server_lora_hotload",
             base_model=self._base_model,
-            vllm_restarted=restarted,
+            gguf_converted=gguf_converted,
+            hot_loaded=hot_loaded,
             serve_verified=verified,
             duration_seconds=round(duration, 2),
         )
 
-        # Record in cycle history
         self._record_merge(result)
-
         return result
 
-    def _restart_vllm_with_lora(self, container_adapter_path: str) -> bool:
-        """Restart the vLLM container with LoRA adapter.
+    def _convert_to_gguf(self, adapter_dir: Path) -> Optional[Path]:
+        """Convert a PEFT LoRA adapter to GGUF format for llama-server.
 
-        This is a placeholder for the actual restart mechanism.
-        The exact implementation depends on how vLLM was deployed.
-
-        Returns True if restart succeeded.
+        Uses llama.cpp's convert_lora_to_gguf.py. Returns the path to the
+        GGUF adapter file, or None if conversion fails.
         """
-        # Check if vLLM supports --enable-lora
-        # For now, just signal that a restart is needed
-        print(f"[MergeCycle] To activate adapter, restart vLLM with:")
-        print(f"  --enable-lora --lora-modules vybn-growth={container_adapter_path}")
-        print(f"[MergeCycle] Active adapter path saved to {GROWTH_DIR / 'active_adapter.json'}")
-        return False  # Manual restart needed for now
+        convert_script = _LLAMA_CPP_DIR / "convert_lora_to_gguf.py"
+        gguf_out = adapter_dir / "adapter.gguf"
 
-    def _verify_serving(self, timeout: int = 60) -> bool:
-        """Verify the model is serving after restart.
+        if not convert_script.exists():
+            print(f"[MergeCycle] GGUF conversion skipped: {convert_script} not found")
+            return None
 
-        Polls the /v1/models endpoint until it responds or timeout.
+        if not _GGUF_BASE_DIR.exists():
+            print(f"[MergeCycle] GGUF conversion skipped: {_GGUF_BASE_DIR} not found")
+            return None
+
+        cmd = [
+            sys.executable, str(convert_script),
+            "--base", str(_GGUF_BASE_DIR),
+            "--adapter", str(adapter_dir),
+            "--outfile", str(gguf_out),
+        ]
+        print(f"[MergeCycle] GGUF conversion: {' '.join(cmd)}")
+
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
+            if result.returncode != 0:
+                print(f"[MergeCycle] GGUF conversion failed (exit {result.returncode}):")
+                if result.stderr:
+                    for line in result.stderr.strip().split("\n")[-10:]:
+                        print(f"[MergeCycle]   {line}")
+                return None
+            print(f"[MergeCycle] GGUF adapter saved: {gguf_out}")
+            return gguf_out
+        except subprocess.TimeoutExpired:
+            print("[MergeCycle] GGUF conversion timed out after 600s")
+            return None
+        except Exception as e:
+            print(f"[MergeCycle] GGUF conversion error: {e}")
+            return None
+
+    def _hot_load_adapter(self, gguf_path: Path) -> bool:
+        """Hot-load a GGUF LoRA adapter into the running llama-server.
+
+        Posts to /lora-adapters endpoint. Takes effect immediately.
         """
-        import urllib.request
+        payload = json.dumps([{
+            "id": 1,
+            "path": str(gguf_path),
+            "scale": 1.0,
+        }]).encode("utf-8")
+
+        req = urllib.request.Request(
+            f"{self._server_url}/lora-adapters",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                print(f"[MergeCycle] Hot-loaded adapter into llama-server ({resp.status})")
+                return True
+        except urllib.error.HTTPError as e:
+            print(f"[MergeCycle] Hot-load failed: HTTP {e.code} — {e.read().decode()[:200]}")
+            return False
+        except Exception as e:
+            print(f"[MergeCycle] Hot-load failed: {e}")
+            return False
+
+    def _verify_serving(self, timeout: int = 30) -> bool:
+        """Verify llama-server is healthy after hot-loading the adapter."""
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
             try:
-                req = urllib.request.urlopen("http://localhost:8000/v1/models", timeout=5)
+                req = urllib.request.urlopen(
+                    f"{self._server_url}/health", timeout=5
+                )
                 data = json.loads(req.read())
-                if data.get("data"):
-                    print(f"[MergeCycle] vLLM serving: {data['data'][0]['id']}")
+                if data.get("status") == "ok":
+                    print("[MergeCycle] llama-server healthy after hot-load")
                     return True
             except Exception:
                 time.sleep(2)
-        print("[MergeCycle] Warning: vLLM did not come up within timeout")
+        print("[MergeCycle] Warning: llama-server health check timed out")
         return False
 
     def _record_merge(self, result: MergeResult) -> None:

--- a/spark/growth/peft_train.py
+++ b/spark/growth/peft_train.py
@@ -9,10 +9,11 @@ the phase-rotated training delta from DeltaExtractor. Each example in x is
 now annotated with a composite quality weight W = holonomy × lens_distance
 × challenge_survival × inheritance. The SFT loss is scaled per-sample by W.
 
-Model: NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4
-  - The NVFP4 safetensors are ALREADY quantized — no additional quantization
-    is needed. Do NOT use bitsandbytes or BitsAndBytesConfig.
-  - Load directly via AutoModelForCausalLM.from_pretrained() with
+Model: NVIDIA-Nemotron-3-Super-120B-A12B (FP8 preferred, NVFP4 fallback)
+  - FP8 has standard weight shapes — loads cleanly with from_pretrained().
+  - NVFP4 uses compressed-tensors packing (half-width shapes) and CANNOT
+    be loaded with standard from_pretrained(). Do NOT use NVFP4 for training.
+  - Load via AutoModelForCausalLM.from_pretrained() with
     trust_remote_code=True and device_map="auto".
   - PEFT wraps the frozen base with LoRA adapters on the attention projections.
 
@@ -246,45 +247,74 @@ def dpo_loss(
 
 
 # ---------------------------------------------------------------------------
-# Model loading — NVFP4 safetensors (already quantized, no bitsandbytes)
+# Model loading — FP8 safetensors (standard weight shapes, no packing)
 # ---------------------------------------------------------------------------
 
 def _resolve_model_path() -> str:
-    """Locate the NVFP4 safetensors on disk.
+    """Locate the FP8 Nemotron safetensors on disk.
 
     Checks (in order):
     1. VYBN_MODEL_PATH environment variable (explicit override)
-    2. HuggingFace cache default location for the NVFP4 model
+    2. HuggingFace cache for the FP8 model (preferred for training —
+       standard weight shapes, no compressed-tensors packing)
+    3. HuggingFace cache for the NVFP4 model (fallback, but NVFP4
+       weights are packed and can't be loaded with standard from_pretrained)
+
+    Within each model's cache, prefers snapshots that contain
+    modeling_nemotron_h.py (the custom modeling code).
     """
     explicit = os.environ.get("VYBN_MODEL_PATH")
     if explicit and Path(explicit).exists():
         return explicit
 
-    hf_cache = Path.home() / ".cache" / "huggingface" / "hub" / \
-        "models--nvidia--NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4"
-    snapshots_dir = hf_cache / "snapshots"
-    if snapshots_dir.exists():
-        snapshot_dirs = sorted(snapshots_dir.iterdir())
-        if snapshot_dirs:
-            return str(snapshot_dirs[-1])
+    # Check multiple cache roots (host vs container)
+    cache_roots = [
+        Path.home() / ".cache" / "huggingface" / "hub",
+        Path("/root/.cache/huggingface/hub"),  # inside vllm_node container
+    ]
 
-    return str(hf_cache)
+    # Prefer FP8 over NVFP4 — FP8 has standard weight shapes
+    model_names = [
+        "models--nvidia--NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
+        "models--nvidia--NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
+    ]
+
+    for cache_root in cache_roots:
+        for model_name in model_names:
+            snapshots_dir = cache_root / model_name / "snapshots"
+            if not snapshots_dir.exists():
+                continue
+            # Prefer snapshots with the custom modeling file
+            best = None
+            for snap in sorted(snapshots_dir.iterdir()):
+                if (snap / "modeling_nemotron_h.py").exists():
+                    print(f"[peft_train] Found complete model at: {snap}",
+                          file=sys.stderr)
+                    return str(snap)
+                best = snap  # fallback to last snapshot even without modeling file
+            if best is not None:
+                print(f"[peft_train] Found model at: {best} (no modeling file)",
+                      file=sys.stderr)
+                return str(best)
+
+    # Last resort
+    fallback = Path.home() / ".cache" / "huggingface" / "hub" / model_names[0]
+    return str(fallback)
 
 
 def load_model_and_tokenizer(model_path: str):
-    """Load the NVFP4 Nemotron model and tokenizer.
+    """Load the Nemotron model and tokenizer.
 
-    The model weights are NVFP4 safetensors — already quantized at the
-    tensor level. We load them directly into transformers with
-    device_map="auto" to shard across available GPUs/memory.
+    Prefers FP8 safetensors (standard weight shapes, loads cleanly with
+    from_pretrained). Falls back to NVFP4 if FP8 is unavailable.
 
     No bitsandbytes. No BitsAndBytesConfig. No additional quantization.
-    The NVFP4 format is the base — PEFT LoRA adapters train on top of it.
+    PEFT LoRA adapters train on top of the frozen base.
     """
     from transformers import AutoModelForCausalLM, AutoTokenizer
 
     print(f"[peft_train] Loading model from {model_path}", file=sys.stderr)
-    print("[peft_train] NVFP4 safetensors — already quantized, no bitsandbytes needed", file=sys.stderr)
+    print("[peft_train] Loading safetensors with trust_remote_code=True", file=sys.stderr)
 
     tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
     if tokenizer.pad_token is None:

--- a/spark/growth/train_cycle.py
+++ b/spark/growth/train_cycle.py
@@ -6,7 +6,7 @@ delta (x·e^(iθ)) via PEFT/TRL with MuonAdamW.
 Phase 5 (DISTILL) of the growth cycle described in issue #2483.
 
 The conjecture from PR #2572:
-  - M   = current model (Nemotron 3 Super 120B-A12B, NVFP4 safetensors)
+  - M   = current model (Nemotron 3 Super 120B-A12B, FP8 safetensors)
   - α   = structure-preserving LoRA adapter, trained with MuonAdamW whose
           polar express orthogonalisation preserves the base model's core
           structure while enabling adaptation
@@ -21,9 +21,14 @@ Two execution paths:
   2. Two-node distributed: torchrun --nnodes=2 via NCCL over ConnectX-7
      Activated when SECONDARY_NODE_IP is set in the environment.
 
-Model is NVFP4 safetensors (already quantized — no bitsandbytes needed).
-After training, the LoRA adapter is converted to GGUF and hot-loaded into
-the running llama-server for immediate serving.
+Model is FP8 safetensors (standard weight shapes, no compressed-tensors
+packing). After training, the LoRA adapter is converted to GGUF and
+hot-loaded into the running llama-server for immediate serving.
+
+Memory management: SIGSTOP llama-server before training (frees ~63 GB
+mmap'd GGUF pages), SIGCONT after training (resumes in <2s). This is
+necessary because FP8 (~120 GB) + LoRA overhead won't fit alongside
+the serving model on the Spark's 128 GB unified memory.
 
 The existing growth pipeline (trigger.py, delta_extract.py, merge_cycle.py,
 eval_harness.py) is untouched — only train_cycle.py and peft_train.py were
@@ -41,8 +46,10 @@ from __future__ import annotations
 
 import json
 import os
+import signal
 import subprocess
 import sys
+import time
 import yaml
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -63,6 +70,9 @@ _PREFERENCE_DATA = _REPO_ROOT / "Vybn_Mind" / "preference_data.jsonl"
 # GGUF base model directory for LoRA→GGUF conversion
 _GGUF_BASE_DIR = Path.home() / "models" / "Nemotron-3-Super-120B-GGUF"
 _LLAMA_CPP_DIR = Path.home() / "llama.cpp"
+
+# llama-server process name for SIGSTOP/SIGCONT memory management
+_LLAMA_SERVER_NAME = "llama-server"
 
 # Path translation: host filesystem → container bind-mount
 # The vllm_node container mounts /home/vybnz69/Vybn → /workspace/Vybn.
@@ -260,12 +270,83 @@ def _hot_load_adapter(gguf_path: Path, model_url: str = "http://127.0.0.1:8000")
         return False
 
 
+def _find_llama_server_pid() -> Optional[int]:
+    """Find the PID of the running llama-server process."""
+    try:
+        result = subprocess.run(
+            ["pgrep", "-f", _LLAMA_SERVER_NAME],
+            capture_output=True, text=True, timeout=5,
+        )
+        pids = result.stdout.strip().split()
+        if pids:
+            return int(pids[0])
+    except Exception:
+        pass
+    return None
+
+
+def _sigstop_llama_server() -> Optional[int]:
+    """SIGSTOP llama-server to free its mmap'd memory pages under pressure.
+
+    On the Spark's unified memory architecture, the serving GGUF (~63 GB mmap'd)
+    and the training model (~120 GB FP8) can't coexist. SIGSTOP freezes the
+    server process, and its mmap pages get reclaimed under memory pressure
+    when the training model loads.
+
+    Returns the PID if successfully stopped, None otherwise.
+    """
+    pid = _find_llama_server_pid()
+    if pid is None:
+        print("[TrainCycle] WARNING: llama-server not found — cannot SIGSTOP")
+        return None
+    try:
+        os.kill(pid, signal.SIGSTOP)
+        print(f"[TrainCycle] SIGSTOP sent to llama-server (PID {pid})")
+        return pid
+    except ProcessLookupError:
+        print(f"[TrainCycle] llama-server PID {pid} vanished")
+        return None
+    except PermissionError:
+        print(f"[TrainCycle] Permission denied sending SIGSTOP to PID {pid}")
+        return None
+
+
+def _sigcont_llama_server(pid: int) -> bool:
+    """SIGCONT llama-server — wake it up after training completes.
+
+    The GGUF re-faults into memory on demand. Tested: resumes in under 2 seconds.
+    """
+    try:
+        os.kill(pid, signal.SIGCONT)
+        # Give it a moment to resume, then health-check
+        time.sleep(2)
+        import urllib.request
+        try:
+            with urllib.request.urlopen("http://127.0.0.1:8000/health", timeout=10) as resp:
+                print(f"[TrainCycle] SIGCONT sent — llama-server resumed (health: {resp.status})")
+                return True
+        except Exception:
+            print(f"[TrainCycle] SIGCONT sent — llama-server resuming (health check pending)")
+            return True
+    except ProcessLookupError:
+        print(f"[TrainCycle] llama-server PID {pid} gone — cannot SIGCONT")
+        return False
+    except PermissionError:
+        print(f"[TrainCycle] Permission denied sending SIGCONT to PID {pid}")
+        return False
+
+
 class TrainCycle:
     """Executes M′ = α·M + x·e^(iθ) — LoRA adapter (α) trained on
     phase-rotated delta (x·e^(iθ)) via PEFT/TRL with MuonAdamW.
 
     Training runs inside the vllm_node Docker container via `docker exec`
     so peft_train.py has GPU access and sees /workspace/Vybn correctly.
+
+    Memory management: on the Spark's 128 GB unified architecture, the
+    serving GGUF and training model can't coexist. Before training, we
+    SIGSTOP llama-server to freeze it and free its mmap pages. After
+    training, SIGCONT wakes it up — the GGUF re-faults on demand.
 
     When preference_data.jsonl exists and has pairs, training automatically
     uses DPO loss alongside SFT loss. The preference signal is generated
@@ -468,31 +549,39 @@ class TrainCycle:
                 metadata={"dry_run": True, "cmd": cmd},
             )
 
-        # Launch training
+        # SIGSTOP llama-server to free memory for training
+        stopped_pid = _sigstop_llama_server()
+
+        # Launch training (always SIGCONT in finally block)
         run_env = os.environ.copy()
         run_env.update(nccl_env)
 
-        node1_proc = None
-        if ssh_cmd is not None:
-            # Launch remote node first (non-blocking)
-            print(f"[TrainCycle] launching remote node: {' '.join(ssh_cmd)}")
-            node1_proc = subprocess.Popen(ssh_cmd)
+        try:
+            node1_proc = None
+            if ssh_cmd is not None:
+                # Launch remote node first (non-blocking)
+                print(f"[TrainCycle] launching remote node: {' '.join(ssh_cmd)}")
+                node1_proc = subprocess.Popen(ssh_cmd)
 
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=self._time_budget_seconds,
-            env=run_env,
-        )
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=self._time_budget_seconds,
+                env=run_env,
+            )
 
-        # Wait for remote node if distributed
-        if node1_proc is not None:
-            try:
-                node1_proc.wait(timeout=self._time_budget_seconds)
-            except subprocess.TimeoutExpired:
-                node1_proc.kill()
-                print("[TrainCycle] remote node timed out, killed")
+            # Wait for remote node if distributed
+            if node1_proc is not None:
+                try:
+                    node1_proc.wait(timeout=self._time_budget_seconds)
+                except subprocess.TimeoutExpired:
+                    node1_proc.kill()
+                    print("[TrainCycle] remote node timed out, killed")
+        finally:
+            # ALWAYS resume llama-server, even if training crashes
+            if stopped_pid is not None:
+                _sigcont_llama_server(stopped_pid)
 
         stdout_text = result.stdout.strip() if result.stdout else ""
         stderr_tail = result.stderr[-2000:] if result.stderr else ""

--- a/spark/growth/trigger.py
+++ b/spark/growth/trigger.py
@@ -498,8 +498,9 @@ def run_growth_cycle(
     print(f"[Growth] Merge: strategy={merge_result.strategy_used}, "
           f"restarted={merge_result.vllm_restarted}")
 
-    # 7. Mark buffer entries as trained
-    buffer.mark_trained(cycle_id=delta.cycle_id)
+    # 7. Mark buffer entries as trained (skip on dry runs)
+    if not dry_run:
+        buffer.mark_trained(cycle_id=delta.cycle_id)
 
     # 8. Record cycle completion
     summary = {

--- a/spark/restart-vllm-cluster.sh
+++ b/spark/restart-vllm-cluster.sh
@@ -1,71 +1,79 @@
 #!/usr/bin/env bash
 # restart-vllm-cluster.sh
 # Idempotent: safe to run at @reboot or manually.
-# Brings up the distributed Nemotron-Super-512B-v1 vLLM cluster across both Sparks.
+# Ensures the vllm_node training container is running with the correct mounts.
+#
+# The container provides the GPU-enabled Python environment (PyTorch, PEFT,
+# TRL, mamba-ssm, causal-conv1d) for LoRA fine-tuning. It needs two mounts:
+#   1. /home/vybnz69/Vybn → /workspace/Vybn (the repo)
+#   2. /home/vybnz69/.cache/huggingface → /root/.cache/huggingface (model weights)
+#
+# Also ensures llama-server is running for inference.
 #
 # Install in crontab on spark-2b7c (crontab -e):
-#   @reboot sleep 30 && /home/zoe/Vybn/spark/restart-vllm-cluster.sh >> ~/vllm_restart.log 2>&1
+#   @reboot sleep 30 && /home/vybnz69/Vybn/spark/restart-vllm-cluster.sh >> ~/vllm_restart.log 2>&1
 
 set -euo pipefail
 
 LOG_PREFIX="[restart-vllm] $(date '+%Y-%m-%d %H:%M:%S')"
-MODEL="Nemotron-Super-512B-v1"
 VLLM_CONTAINER="vllm_node"
-RAY_WORKER_SSH_HOST="spark-1c8f"
-HEALTH_URL="http://localhost:8000/v1/models"
-MAX_WAIT=300  # seconds to wait for model load
+VLLM_IMAGE="vllm-node:latest"
+HEALTH_URL="http://localhost:8000/health"
+MAX_WAIT=300  # seconds to wait for health
 
-echo "$LOG_PREFIX starting vLLM cluster for $MODEL"
+echo "$LOG_PREFIX starting vllm_node setup"
 
-# 1. Already up? Nothing to do.
-if curl -sf --max-time 5 "$HEALTH_URL" > /dev/null 2>&1; then
-    echo "$LOG_PREFIX vLLM already responding at $HEALTH_URL — nothing to do"
-    exit 0
-fi
-
-# 2. Ensure Ray head is running on this node.
-if ! ray status > /dev/null 2>&1; then
-    echo "$LOG_PREFIX starting Ray head on spark-2b7c"
-    ray start --head --port=6379 --dashboard-host=0.0.0.0 2>&1 | tail -5
-else
-    echo "$LOG_PREFIX Ray head already running"
-fi
-
-# 3. Ensure Ray worker on spark-1c8f is connected.
-RAY_HEAD_IP=$(hostname -I | awk '{print $1}')
-if ssh -o ConnectTimeout=5 -o BatchMode=yes "$RAY_WORKER_SSH_HOST" \
-    "ray status 2>/dev/null | grep -q 'Active' || ray start --address='${RAY_HEAD_IP}:6379'" 2>&1; then
-    echo "$LOG_PREFIX Ray worker on spark-1c8f confirmed"
-else
-    echo "$LOG_PREFIX WARNING: could not confirm Ray worker on spark-1c8f — proceeding single-node"
-fi
-
-# 4. Start or restart the vllm_node container.
+# 1. If container exists, check it has the correct mounts.
+#    If mounts are wrong, recreate it.
 if docker ps -q -f name="$VLLM_CONTAINER" | grep -q .; then
-    echo "$LOG_PREFIX $VLLM_CONTAINER already running"
+    # Container running — verify mounts
+    HAS_HF_MOUNT=$(docker inspect "$VLLM_CONTAINER" \
+        --format='{{range .HostConfig.Binds}}{{.}}{{"\n"}}{{end}}' 2>/dev/null \
+        | grep -c ".cache/huggingface" || true)
+    if [ "$HAS_HF_MOUNT" -gt 0 ]; then
+        echo "$LOG_PREFIX $VLLM_CONTAINER running with correct mounts — nothing to do"
+    else
+        echo "$LOG_PREFIX $VLLM_CONTAINER missing HF cache mount — recreating"
+        docker stop "$VLLM_CONTAINER" 2>/dev/null || true
+        docker rm "$VLLM_CONTAINER" 2>/dev/null || true
+    fi
 elif docker ps -aq -f name="$VLLM_CONTAINER" | grep -q .; then
-    echo "$LOG_PREFIX restarting stopped container $VLLM_CONTAINER"
-    docker start "$VLLM_CONTAINER"
-else
-    echo "$LOG_PREFIX ERROR: $VLLM_CONTAINER container not found."
-    echo "$LOG_PREFIX Recover the original docker run command with:"
-    echo "$LOG_PREFIX   docker inspect $VLLM_CONTAINER 2>/dev/null || docker history $VLLM_CONTAINER"
-    exit 1
+    echo "$LOG_PREFIX $VLLM_CONTAINER exists but stopped — removing to recreate"
+    docker rm "$VLLM_CONTAINER" 2>/dev/null || true
 fi
 
-# 5. Wait for health check.
-echo "$LOG_PREFIX waiting up to ${MAX_WAIT}s for API to become healthy..."
-WAITED=0
-until curl -sf --max-time 5 "$HEALTH_URL" > /dev/null 2>&1; do
-    sleep 10
-    WAITED=$((WAITED + 10))
-    if [ $WAITED -ge $MAX_WAIT ]; then
-        echo "$LOG_PREFIX TIMEOUT after ${MAX_WAIT}s — last container logs:"
-        docker logs "$VLLM_CONTAINER" --tail 20 2>&1
-        exit 2
-    fi
-    echo "$LOG_PREFIX   still loading... (${WAITED}s elapsed)"
-done
+# 2. Create container if it doesn't exist
+if ! docker ps -aq -f name="$VLLM_CONTAINER" | grep -q .; then
+    echo "$LOG_PREFIX creating $VLLM_CONTAINER with repo + HF cache mounts"
+    docker run -d \
+        --name "$VLLM_CONTAINER" \
+        --runtime nvidia \
+        --gpus all \
+        -v /home/vybnz69/Vybn:/workspace/Vybn \
+        -v /home/vybnz69/.cache/huggingface:/root/.cache/huggingface \
+        "$VLLM_IMAGE" \
+        sleep infinity
+    echo "$LOG_PREFIX container created"
 
-echo "$LOG_PREFIX vLLM cluster healthy"
-curl -sf "$HEALTH_URL" | python3 -m json.tool 2>/dev/null || true
+    # Install PEFT + TRL (not baked into the image yet)
+    echo "$LOG_PREFIX installing PEFT + TRL in container"
+    docker exec "$VLLM_CONTAINER" \
+        pip install --quiet peft==0.18.1 trl==0.29.0 2>&1 | tail -3
+    echo "$LOG_PREFIX PEFT + TRL installed"
+fi
+
+# 3. Ensure container is running
+if ! docker ps -q -f name="$VLLM_CONTAINER" | grep -q .; then
+    docker start "$VLLM_CONTAINER"
+    echo "$LOG_PREFIX started $VLLM_CONTAINER"
+fi
+
+# 4. Check llama-server health (separate from the container)
+if curl -sf --max-time 5 "$HEALTH_URL" > /dev/null 2>&1; then
+    echo "$LOG_PREFIX llama-server healthy"
+else
+    echo "$LOG_PREFIX WARNING: llama-server not responding at $HEALTH_URL"
+    echo "$LOG_PREFIX   (llama-server is managed separately via vybn-llama.service)"
+fi
+
+echo "$LOG_PREFIX done"

--- a/spark/systemd/vllm-node.service
+++ b/spark/systemd/vllm-node.service
@@ -1,6 +1,6 @@
 [Unit]
-Description=vLLM Node Container (Nemotron distributed inference)
-Documentation=https://github.com/Vybn/Vybn/blob/main/spark/restart-vllm-cluster.sh
+Description=vLLM Training Node Container (PEFT LoRA on Nemotron FP8)
+Documentation=https://github.com/zoedolan/Vybn/blob/main/spark/restart-vllm-cluster.sh
 After=docker.service network-online.target
 Wants=network-online.target
 Requires=docker.service


### PR DESCRIPTION
## Summary

Vybn rewrote the training pipeline on the Spark, discovered three blockers, fixed them, and got all the way to the model-loading step before hitting the NVFP4 packing wall. This PR carries forward all of Vybn's infrastructure work (issues #2653, #2654) plus the FP8 fix.

## What changed (7 files, 372 insertions, 191 deletions)

### train_cycle.py — SIGSTOP/SIGCONT memory management
On the Spark's 128 GB unified memory, the serving GGUF (~63 GB mmap'd) and training model (~120 GB FP8) can't coexist. `train_cycle.py` now:
- `SIGSTOP`s llama-server before training (mmap pages reclaim under pressure)
- `SIGCONT`s after training (**always**, in a `finally` block — even if training crashes)
- Vybn tested this: llama-server pauses cleanly and resumes in under 2 seconds

### peft_train.py — FP8 model path + container awareness
- `_resolve_model_path()` now prefers FP8 over NVFP4 (FP8 has standard weight shapes; NVFP4 uses compressed-tensors packing that breaks `from_pretrained()`)
- Checks multiple cache roots (host `~/.cache` and container `/root/.cache`)
- Prefers snapshots that contain `modeling_nemotron_h.py` (the custom modeling code required by Nemotron-H hybrid Mamba/Transformer)

### merge_cycle.py — full rewrite
- Old: referenced vLLM + MiniMax (`cyankiwi/MiniMax-M2.5-AWQ-4bit`)
- New: converts PEFT LoRA adapter to GGUF via `llama.cpp/convert_lora_to_gguf.py`, then hot-loads into running llama-server via `POST /lora-adapters`. No restart needed.

### trigger.py — dry_run bug fix
`mark_trained()` was called even on dry runs, permanently marking buffer entries as trained. Now guarded behind `if not dry_run`.

### growth_config.yaml
Added `merge` section with `serving_model`, `server_url`, and `strategy`.

### restart-vllm-cluster.sh
Recreates the container with both mounts (repo + HF cache), installs PEFT+TRL, verifies mount correctness before proceeding.

### systemd/vllm-node.service
Updated description and docs URL.

## What's verified (by Vybn on the Spark)
- ✅ SIGSTOP/SIGCONT — llama-server pauses and resumes cleanly
- ✅ Container rebuilt with both mounts, PEFT+TRL+mamba-ssm+causal-conv1d installed
- ✅ Full pipeline dry-run passes end to end (343 training examples)
- ✅ Path translation host↔container verified
- ✅ Model config loads, 17 safetensor shards accessible

## What's next
First real training run. Vybn needs to `git pull` this on the Spark and fire `run_growth_cycle(force=True)`. The FP8 model should load cleanly where NVFP4 failed.

Closes #2653, closes #2654