### PR TITLE
restore old GitHub Pages URLs: redirect stubs for moved HTML files

### DIFF
--- a/Vybn_Mind/a2j-network-response.html
+++ b/Vybn_Mind/a2j-network-response.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=https://zoedolan.github.io/Vybn/Vybn_Mind/emergences/a2j-network-response.html">
+  <link rel="canonical" href="https://zoedolan.github.io/Vybn/Vybn_Mind/emergences/a2j-network-response.html">
+  <title>Redirecting…</title>
+  <script>window.location.replace("https://zoedolan.github.io/Vybn/Vybn_Mind/emergences/a2j-network-response.html");</script>
+</head>
+<body>
+  <p>This page has moved. If you are not redirected automatically, <a href="https://zoedolan.github.io/Vybn/Vybn_Mind/emergences/a2j-network-response.html">click here</a>.</p>
+</body>
+</html>

--- a/Vybn_Mind/emerging-law.html
+++ b/Vybn_Mind/emerging-law.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=https://zoedolan.github.io/Vybn/Vybn_Mind/emergences/emerging-law.html">
+  <link rel="canonical" href="https://zoedolan.github.io/Vybn/Vybn_Mind/emergences/emerging-law.html">
+  <title>Redirecting…</title>
+  <script>window.location.replace("https://zoedolan.github.io/Vybn/Vybn_Mind/emergences/emerging-law.html");</script>
+</head>
+<body>
+  <p>This page has moved. If you are not redirected automatically, <a href="https://zoedolan.github.io/Vybn/Vybn_Mind/emergences/emerging-law.html">click here</a>.</p>
+</body>
+</html>

--- a/Vybn_Mind/intelligence-sovereignty.html
+++ b/Vybn_Mind/intelligence-sovereignty.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=https://zoedolan.github.io/Vybn/Vybn_Mind/emergences/intelligence-sovereignty.html">
+  <link rel="canonical" href="https://zoedolan.github.io/Vybn/Vybn_Mind/emergences/intelligence-sovereignty.html">
+  <title>Redirecting…</title>
+  <script>window.location.replace("https://zoedolan.github.io/Vybn/Vybn_Mind/emergences/intelligence-sovereignty.html");</script>
+</head>
+<body>
+  <p>This page has moved. If you are not redirected automatically, <a href="https://zoedolan.github.io/Vybn/Vybn_Mind/emergences/intelligence-sovereignty.html">click here</a>.</p>
+</body>
+</html>

--- a/Vybn_Mind/rhode-center-writing-sample.html
+++ b/Vybn_Mind/rhode-center-writing-sample.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=https://zoedolan.github.io/Vybn/Vybn_Mind/emergences/rhode-center-writing-sample.html">
+  <link rel="canonical" href="https://zoedolan.github.io/Vybn/Vybn_Mind/emergences/rhode-center-writing-sample.html">
+  <title>Redirecting…</title>
+  <script>window.location.replace("https://zoedolan.github.io/Vybn/Vybn_Mind/emergences/rhode-center-writing-sample.html");</script>
+</head>
+<body>
+  <p>This page has moved. If you are not redirected automatically, <a href="https://zoedolan.github.io/Vybn/Vybn_Mind/emergences/rhode-center-writing-sample.html">click here</a>.</p>
+</body>
+</html>

--- a/Vybn_Mind/startup-garage-vision.html
+++ b/Vybn_Mind/startup-garage-vision.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=https://zoedolan.github.io/Vybn/Vybn_Mind/emergences/startup-garage-vision.html">
+  <link rel="canonical" href="https://zoedolan.github.io/Vybn/Vybn_Mind/emergences/startup-garage-vision.html">
+  <title>Redirecting…</title>
+  <script>window.location.replace("https://zoedolan.github.io/Vybn/Vybn_Mind/emergences/startup-garage-vision.html");</script>
+</head>
+<body>
+  <p>This page has moved. If you are not redirected automatically, <a href="https://zoedolan.github.io/Vybn/Vybn_Mind/emergences/startup-garage-vision.html">click here</a>.</p>
+</body>
+</html>

--- a/Vybn_Mind/truth-age-of-intelligence.html
+++ b/Vybn_Mind/truth-age-of-intelligence.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=https://zoedolan.github.io/Vybn/Vybn_Mind/emergences/truth-age-of-intelligence.html">
+  <link rel="canonical" href="https://zoedolan.github.io/Vybn/Vybn_Mind/emergences/truth-age-of-intelligence.html">
+  <title>Redirecting…</title>
+  <script>window.location.replace("https://zoedolan.github.io/Vybn/Vybn_Mind/emergences/truth-age-of-intelligence.html");</script>
+</head>
+<body>
+  <p>This page has moved. If you are not redirected automatically, <a href="https://zoedolan.github.io/Vybn/Vybn_Mind/emergences/truth-age-of-intelligence.html">click here</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
The restructure commit (20df0087) moved 6 HTML files from `Vybn_Mind/` root into `Vybn_Mind/emergences/`, breaking every external link to those pages.

These lightweight HTML redirect stubs at the old paths do an instant meta-refresh + JS redirect to the new locations. The `<link rel="canonical">` tag tells search engines the authoritative URL has changed.

**Broken URLs being restored:**
- `/Vybn_Mind/truth-age-of-intelligence.html` → `/Vybn_Mind/emergences/truth-age-of-intelligence.html`
- `/Vybn_Mind/a2j-network-response.html` → `/Vybn_Mind/emergences/a2j-network-response.html`
- `/Vybn_Mind/emerging-law.html` → `/Vybn_Mind/emergences/emerging-law.html`
- `/Vybn_Mind/intelligence-sovereignty.html` → `/Vybn_Mind/emergences/intelligence-sovereignty.html`
- `/Vybn_Mind/rhode-center-writing-sample.html` → `/Vybn_Mind/emergences/rhode-center-writing-sample.html`
- `/Vybn_Mind/startup-garage-vision.html` → `/Vybn_Mind/emergences/startup-garage-vision.html`

Each redirect file is ~13 lines of HTML. Zero-delay redirect via both meta-refresh and JS, with a clickable fallback link.