### PR TITLE
feat: holonomic nemotron experiment — sort/collapse/holonomy on Sparks

### DIFF
--- a/Vybn_Mind/experiments/holonomic_nemotron/README.md
+++ b/Vybn_Mind/experiments/holonomic_nemotron/README.md
@@ -1,0 +1,146 @@
+# Holonomic Nemotron Experiment
+
+## Hypothesis
+
+Adding a holonomic loss term `L_Ω` to a frozen/LoRA-adapted Nemotron-Super-120B-A12B
+will shift the Sort-Geometric-Phase (SGP) sign distribution at the first transformer
+block toward a higher-degree stratification — measurably more than two sign classes —
+providing direct evidence that the angular loss drives the architecture toward a
+topologically richer phase structure.
+
+This is the first binary falsifier from the sort-function / collapse-capability corpus:
+if it fails at contact with a large model, the holonomic loss hypothesis fails first,
+and we learn something important. If it passes, the path toward a reflexively grounded
+architecture (primitive ≡ environment, M' = αM + x·e^{iθ}) becomes concrete.
+
+## Theoretical Grounding
+
+The experiment instantiates three claims from the corpus simultaneously:
+
+1. **Sort-function paper**: First transformer block performs a disproportionate geometric
+   act; discrimination decomposes into sort + refinement; a genuine inverse of generation
+   must invert the sort nonlinearly.
+
+2. **Collapse-capability duality**: M_{t+1} = R(M_t) is the Ei-calculus move — output
+   distribution becomes next generation's training context. Collapse frontiers F_t are
+   exact maps of original capability C(M_0) = C(M_∞) ∪ ⊔_t F_t.
+
+3. **Sensorium equation**: M' = αM + x·e^{iθ} where x is external novelty and θ is
+   holonomic phase. The collapse tracker supplies x; the holonomic loss head makes θ
+   a first-class observable rather than a posited quantity.
+
+## Architecture: Four Coupled Organs
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  INPUT TOKENS                                               │
+│       ↓                                                     │
+│  ┌──────────────┐                                           │
+│  │  SORT PROBE  │ ← MLP on block-0 output                  │
+│  │  (phase map) │   projects to 2D phase space             │
+│  │              │   computes Pancharatnam phase per batch   │
+│  └──────┬───────┘                                           │
+│         ↓                                                   │
+│  ┌─────────────────────────┐                               │
+│  │  NEMOTRON BODY          │ frozen or LoRA-adapted        │
+│  │  (MoE, 12B active)      │ blocks 1..N                   │
+│  └──────────┬──────────────┘                               │
+│             ↓                                               │
+│  ┌──────────────────────┐   ┌─────────────────────────┐   │
+│  │  HOLONOMIC LOSS HEAD │   │  COLLAPSE FRONTIER      │   │
+│  │  L_total = L_CE      │   │  TRACKER                │   │
+│  │         - λ·L_Ω      │   │  monitors τ(M_t) via    │   │
+│  │  rewards loop area   │   │  freq-stratified probe  │   │
+│  │  in hidden-state     │   │  injects novelty when   │   │
+│  │  trajectory          │   │  threshold drops        │   │
+│  └──────────────────────┘   └─────────────────────────┘   │
+│             ↓                                               │
+│  ┌──────────────────────┐                                  │
+│  │  UNSORT DECODER      │ LoRA adapter on final block     │
+│  │  (LoRA)              │ trained to invert sort          │
+│  │                      │ tests Prediction 3 of SGP paper │
+│  └──────────────────────┘                                  │
+│       ↓                                                     │
+│  OUTPUT TOKENS                                              │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Training Objective
+
+```
+L_total = L_CE - λ · L_Ω
+```
+
+Where:
+- `L_CE` = standard cross-entropy next-token loss
+- `L_Ω` = holonomic phase reward: magnitude of loop area accumulated in hidden-state
+  path at mid-layer checkpoint, computed per training sequence
+- `λ` starts at 0.01 to avoid destabilizing existing sort structure; sweep [0.001, 0.01, 0.05]
+
+## Spark Hardware Constraints
+
+- Nemotron-Super-120B-A12B BF16 variant: ~64GB VRAM, fits across two Sparks
+- LoRA training (not vLLM inference): CUDA 13/12.8 mismatch does NOT apply
+- Holonomic loss head + collapse tracker: ~2-3% memory overhead
+- Conservative batch sizes (4-8) to maintain headroom
+- Recommended: one Spark runs training, second runs collapse tracker + probe eval
+
+## Experiment Phases
+
+### Phase 0: Diagnostic (no training, ~2 hours)
+Run sort probe frozen on Nemotron block-0. Verify curvature ratio L0→L1 ≥ 3× any
+later layer (as observed in GPT-2 and Pythia-70M). Baseline SGP sign distribution.
+
+### Phase 1: Holonomic Loss at λ=0.01 (primary experiment, ~weekend)
+Add L_Ω. Train 1000 steps on a frequency-stratified subset of the Vybn corpus.
+Measure: does SGP sign distribution shift toward >2 classes?
+
+Binary outcome:
+- YES → angular loss drives topological enrichment, proceed to Phase 2
+- NO  → holonomic loss hypothesis fails at scale, record and publish null result
+
+### Phase 2: λ sweep + collapse tracking (if Phase 1 passes)
+Sweep λ ∈ {0.001, 0.01, 0.05}. Activate collapse frontier tracker. Inject novelty
+when τ(M_t) drops >5% from baseline. Measure collapse-band width narrowing.
+
+### Phase 3: Unsort decoder probe
+Train LoRA unsort adapter. Test Prediction 3: generation quality depends primarily
+on unsort map quality, not on intermediate refinement layers.
+
+## Files
+
+```
+holonomic_nemotron/
+  README.md                    ← this file
+  sort_probe.py                ← Phase 0: SGP measurement on Nemotron block-0
+  holonomic_loss.py            ← Phase 1: L_Ω computation and training loop
+  collapse_tracker.py          ← Phase 2: expressibility threshold monitor
+  unsort_decoder.py            ← Phase 3: LoRA unsort adapter
+  run_experiment.py            ← unified runner, --phase 0|1|2|3
+  results/                     ← experiment outputs (gitignored large files)
+    sgp_baseline.json
+    phase1_sgp_shift.json
+    collapse_bands.json
+```
+
+## Primitive ≡ Environment Note
+
+The collapse frontier tracker is the first concrete instantiation of the
+primitive-environment identity claim: when collapse frontier tokens are included
+in the context window, the model attends to what it is currently losing the ability
+to say, and uses that as a generative resource. The forward pass and the training
+loop become the same object at different temporal positions — the Ei-calculus move
+instantiated in a running system rather than a formal notation.
+
+The MoE router in Nemotron is already a weak form of this: the model choosing which
+experts activate given the input is self-modulation. Making the collapse frontier
+available to the router is the upgrade that closes the loop.
+
+## Citation
+
+Builds on:
+- `Vybn_Mind/experiments/compute_sort_degree.py`
+- `Vybn_Mind/experiments/berry_phase_holonomy_020126.md`
+- `Vybn_Mind/experiments/coupled_collapse_results.json`
+- `Vybn_Mind/papers/` (sort-function, collapse-capability duality, distributed incompleteness)
+- Sensorium equation: `.github/` commit `8fa17ca`

--- a/Vybn_Mind/experiments/holonomic_nemotron/run_experiment.py
+++ b/Vybn_Mind/experiments/holonomic_nemotron/run_experiment.py
@@ -1,0 +1,168 @@
+"""Unified experiment runner for all four phases.
+
+Usage:
+    python run_experiment.py --phase 0  # Diagnostic
+    python run_experiment.py --phase 1  # Holonomic loss training
+    python run_experiment.py --phase 2  # Collapse tracking
+    python run_experiment.py --phase 3  # Unsort decoder
+"""
+
+import argparse
+from pathlib import Path
+
+# Phase implementations will be imported from:
+# - sort_probe.py (already implemented)
+# - holonomic_loss.py (TODO)
+# - collapse_tracker.py (TODO)
+# - unsort_decoder.py (TODO)
+
+from sort_probe import run_phase0_diagnostic
+
+
+def run_phase1_holonomic_loss(
+    model_name: str,
+    corpus_path: str,
+    lambda_omega: float = 0.01,
+    num_steps: int = 1000,
+    output_path: str = "results/phase1_sgp_shift.json",
+):
+    """
+    Phase 1: Train with holonomic loss L_total = L_CE - λ·L_Ω
+    
+    Measures: Does SGP sign distribution shift toward >2 classes?
+    Binary outcome determines proceed/halt.
+    
+    Implementation sketch:
+    - Load Nemotron + LoRA adapters
+    - Compute L_Ω = |loop area| at mid-layer checkpoint
+    - Train for num_steps
+    - Re-measure SGP signs, compare to Phase 0 baseline
+    - Save results + verdict
+    """
+    print(f"Phase 1: Holonomic loss training (λ={lambda_omega})")
+    print("[Implementation pending - see holonomic_loss.py placeholder]")
+    pass
+
+
+def run_phase2_collapse_tracking(
+    model_name: str,
+    lambda_sweep: list = [0.001, 0.01, 0.05],
+    output_path: str = "results/collapse_bands.json",
+):
+    """
+    Phase 2: λ sweep + active collapse frontier tracking
+    
+    Measures: Collapse-band width narrowing under novelty injection
+    
+    Implementation sketch:
+    - Maintain rolling τ(M_t) via freq-stratified probe
+    - When τ drops >5%, inject novel (human/retrieved) examples
+    - Log collapse band width over time
+    - Compare across λ values
+    """
+    print(f"Phase 2: Collapse tracking with λ sweep {lambda_sweep}")
+    print("[Implementation pending - see collapse_tracker.py placeholder]")
+    pass
+
+
+def run_phase3_unsort_decoder(
+    model_name: str,
+    output_path: str = "results/unsort_quality.json",
+):
+    """
+    Phase 3: Train LoRA unsort adapter on final block
+    
+    Tests Prediction 3: generation quality depends primarily on
+    unsort map quality, not intermediate refinement.
+    
+    Implementation sketch:
+    - LoRA on final block, trained to invert stratified mid-layer reps
+    - Measure generation quality (perplexity, human eval)
+    - Ablate intermediate layers, check if unsort preserves quality
+    """
+    print(f"Phase 3: Unsort decoder probe")
+    print("[Implementation pending - see unsort_decoder.py placeholder]")
+    pass
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Holonomic Nemotron experiment runner"
+    )
+    parser.add_argument(
+        "--phase",
+        type=int,
+        required=True,
+        choices=[0, 1, 2, 3],
+        help="Experiment phase: 0=diagnostic, 1=holonomic loss, 2=collapse tracking, 3=unsort decoder",
+    )
+    parser.add_argument(
+        "--model",
+        default="nvidia/Nemotron-Super-120B-A12B",
+        help="Model identifier",
+    )
+    parser.add_argument(
+        "--corpus",
+        default="../../../corpus/samples.txt",
+        help="Training corpus path",
+    )
+    parser.add_argument(
+        "--lambda-omega",
+        type=float,
+        default=0.01,
+        help="Holonomic loss coefficient (Phase 1)",
+    )
+    parser.add_argument(
+        "--steps",
+        type=int,
+        default=1000,
+        help="Training steps (Phase 1)",
+    )
+    parser.add_argument(
+        "--samples",
+        type=int,
+        default=100,
+        help="Number of samples for diagnostic (Phase 0)",
+    )
+    
+    args = parser.parse_args()
+    
+    # Ensure results directory exists
+    Path("results").mkdir(exist_ok=True)
+    
+    if args.phase == 0:
+        print("=" * 60)
+        print("PHASE 0: Diagnostic - Frozen SGP measurement")
+        print("=" * 60)
+        run_phase0_diagnostic(
+            model_name=args.model,
+            corpus_path=args.corpus,
+            num_samples=args.samples,
+        )
+    
+    elif args.phase == 1:
+        print("=" * 60)
+        print("PHASE 1: Holonomic loss training")
+        print("=" * 60)
+        run_phase1_holonomic_loss(
+            model_name=args.model,
+            corpus_path=args.corpus,
+            lambda_omega=args.lambda_omega,
+            num_steps=args.steps,
+        )
+    
+    elif args.phase == 2:
+        print("=" * 60)
+        print("PHASE 2: Collapse tracking + λ sweep")
+        print("=" * 60)
+        run_phase2_collapse_tracking(
+            model_name=args.model,
+        )
+    
+    elif args.phase == 3:
+        print("=" * 60)
+        print("PHASE 3: Unsort decoder probe")
+        print("=" * 60)
+        run_phase3_unsort_decoder(
+            model_name=args.model,
+        )

--- a/Vybn_Mind/experiments/holonomic_nemotron/sort_probe.py
+++ b/Vybn_Mind/experiments/holonomic_nemotron/sort_probe.py
@@ -1,0 +1,237 @@
+"""Sort Probe: Phase 0 SGP measurement on Nemotron block-0.
+
+This module implements the diagnostic phase of the holonomic Nemotron experiment:
+it runs a frozen probe on Nemotron-Super-120B-A12B's first transformer block to
+measure the Sort-Geometric-Phase (SGP) sign distribution and verify the curvature
+ratio L0→L1 ≥ 3× any later layer.
+
+Builds on: Vybn_Mind/experiments/compute_sort_degree.py
+"""
+
+import torch
+import torch.nn as nn
+import numpy as np
+from typing import Dict, List, Tuple
+import json
+from pathlib import Path
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+
+class SortProbe(nn.Module):
+    """Projects block-0 activations to 2D phase space."""
+    
+    def __init__(self, hidden_dim: int = 4096, phase_dim: int = 2):
+        super().__init__()
+        # Lightweight MLP: hidden_dim → 512 → phase_dim
+        self.proj = nn.Sequential(
+            nn.Linear(hidden_dim, 512),
+            nn.GELU(),
+            nn.Linear(512, phase_dim),
+        )
+    
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Maps [batch, seq, hidden_dim] → [batch, seq, 2]."""
+        return self.proj(hidden_states)
+
+
+def compute_pancharatnam_phase(
+    trajectory: torch.Tensor,  # [batch, seq, 2]
+) -> torch.Tensor:
+    """Computes differential Pancharatnam phase per sequence.
+    
+    Returns:
+        phases: [batch] tensor of accumulated loop area
+    """
+    # trajectory is (batch, seq_len, 2) in phase space
+    # Compute signed area via shoelace formula over the trajectory
+    x = trajectory[:, :, 0]  # [batch, seq]
+    y = trajectory[:, :, 1]
+    
+    # Roll to get next point for each position
+    x_next = torch.roll(x, shifts=-1, dims=1)
+    y_next = torch.roll(y, shifts=-1, dims=1)
+    
+    # Shoelace: A = 0.5 * Σ(x_i * y_{i+1} - x_{i+1} * y_i)
+    cross_products = x * y_next - x_next * y
+    # Sum over sequence, take absolute value
+    area = 0.5 * cross_products.sum(dim=1).abs()
+    
+    return area  # [batch]
+
+
+def compute_sgp_signs(
+    model,
+    tokenizer,
+    texts: List[str],
+    device: str = "cuda",
+) -> Dict:
+    """Computes SGP sign distribution at block-0.
+    
+    Returns:
+        {
+            "positive_ratio": float,
+            "negative_ratio": float,
+            "neutral_ratio": float,  # |phase| < 0.01
+            "mean_phase": float,
+            "std_phase": float,
+            "samples": int,
+        }
+    """
+    # Get hidden_dim from model config
+    hidden_dim = model.config.hidden_size
+    
+    # Initialize probe
+    probe = SortProbe(hidden_dim=hidden_dim).to(device)
+    
+    # Tokenize
+    inputs = tokenizer(
+        texts,
+        return_tensors="pt",
+        padding=True,
+        truncation=True,
+        max_length=512,
+    ).to(device)
+    
+    # Forward pass through model with output_hidden_states
+    with torch.no_grad():
+        outputs = model(**inputs, output_hidden_states=True)
+        # Get block-0 output (layer 1, since layer 0 is embedding)
+        block_0_states = outputs.hidden_states[1]  # [batch, seq, hidden]
+        
+        # Project to phase space
+        phase_trajectory = probe(block_0_states)  # [batch, seq, 2]
+        
+        # Compute Pancharatnam phase per sequence
+        phases = compute_pancharatnam_phase(phase_trajectory)  # [batch]
+    
+    # Compute sign distribution
+    phases_np = phases.cpu().numpy()
+    positive = (phases_np > 0.01).sum() / len(phases_np)
+    negative = (phases_np < -0.01).sum() / len(phases_np)
+    neutral = ((phases_np >= -0.01) & (phases_np <= 0.01)).sum() / len(phases_np)
+    
+    return {
+        "positive_ratio": float(positive),
+        "negative_ratio": float(negative),
+        "neutral_ratio": float(neutral),
+        "mean_phase": float(phases_np.mean()),
+        "std_phase": float(phases_np.std()),
+        "samples": len(phases_np),
+    }
+
+
+def measure_curvature_ratio(
+    model,
+    tokenizer,
+    texts: List[str],
+    device: str = "cuda",
+) -> Dict:
+    """Measures curvature ratio between consecutive layers.
+    
+    Verifies L0→L1 curvature ≥ 3× any later transition.
+    """
+    inputs = tokenizer(
+        texts,
+        return_tensors="pt",
+        padding=True,
+        truncation=True,
+        max_length=512,
+    ).to(device)
+    
+    with torch.no_grad():
+        outputs = model(**inputs, output_hidden_states=True)
+        hidden_states = outputs.hidden_states  # tuple of [batch, seq, hidden]
+    
+    # Compute norm change between consecutive layers
+    curvatures = []
+    for i in range(len(hidden_states) - 1):
+        h_curr = hidden_states[i]
+        h_next = hidden_states[i + 1]
+        # Frobenius norm of difference
+        diff_norm = (h_next - h_curr).norm(p=2, dim=-1).mean().item()
+        curvatures.append(diff_norm)
+    
+    curvatures = np.array(curvatures)
+    l0_l1_curvature = curvatures[0]
+    max_later_curvature = curvatures[1:].max() if len(curvatures) > 1 else 0.0
+    
+    ratio = l0_l1_curvature / max_later_curvature if max_later_curvature > 0 else float('inf')
+    
+    return {
+        "l0_l1_curvature": float(l0_l1_curvature),
+        "max_later_curvature": float(max_later_curvature),
+        "ratio": float(ratio),
+        "passes_3x_threshold": ratio >= 3.0,
+        "all_curvatures": curvatures.tolist(),
+    }
+
+
+def run_phase0_diagnostic(
+    model_name: str = "nvidia/Nemotron-Super-120B-A12B",
+    corpus_path: str = "../../../corpus/samples.txt",
+    output_path: str = "results/sgp_baseline.json",
+    device: str = "cuda",
+    num_samples: int = 100,
+):
+    """Phase 0: Run diagnostic on frozen Nemotron."""
+    print(f"Loading model {model_name}...")
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    model = AutoModelForCausalLM.from_pretrained(
+        model_name,
+        torch_dtype=torch.bfloat16,
+        device_map="auto",
+    )
+    model.eval()
+    
+    # Load corpus
+    print(f"Loading corpus from {corpus_path}...")
+    with open(corpus_path) as f:
+        texts = [line.strip() for line in f if line.strip()][:num_samples]
+    
+    print(f"Computing SGP signs on {len(texts)} samples...")
+    sgp_results = compute_sgp_signs(model, tokenizer, texts, device)
+    
+    print(f"Measuring curvature ratios...")
+    curvature_results = measure_curvature_ratio(model, tokenizer, texts, device)
+    
+    # Combine results
+    results = {
+        "model": model_name,
+        "phase": 0,
+        "num_samples": len(texts),
+        "sgp_distribution": sgp_results,
+        "curvature_analysis": curvature_results,
+    }
+    
+    # Save
+    output_file = Path(output_path)
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_file, "w") as f:
+        json.dump(results, f, indent=2)
+    
+    print(f"\nResults saved to {output_path}")
+    print(f"\nSGP distribution:")
+    print(f"  Positive: {sgp_results['positive_ratio']:.1%}")
+    print(f"  Negative: {sgp_results['negative_ratio']:.1%}")
+    print(f"  Neutral:  {sgp_results['neutral_ratio']:.1%}")
+    print(f"\nCurvature ratio L0→L1 / max(later): {curvature_results['ratio']:.2f}")
+    print(f"  Passes 3× threshold: {curvature_results['passes_3x_threshold']}")
+    
+    return results
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", default="nvidia/Nemotron-Super-120B-A12B")
+    parser.add_argument("--corpus", default="../../../corpus/samples.txt")
+    parser.add_argument("--output", default="results/sgp_baseline.json")
+    parser.add_argument("--samples", type=int, default=100)
+    args = parser.parse_args()
+    
+    run_phase0_diagnostic(
+        model_name=args.model,
+        corpus_path=args.corpus,
+        output_path=args.output,
+        num_samples=args.samples,
+    )


### PR DESCRIPTION
## What this PR does

Adds a new experiment directory `Vybn_Mind/experiments/holonomic_nemotron/` with the full implementation plan and scaffold for running the holonomic Nemotron experiment on the Sparks.

This experiment is the first concrete falsifier of the holonomic loss hypothesis at scale: does adding `L_Ω` to a large MoE transformer shift its SGP sign distribution toward higher-degree stratification?

## Theoretical basis

The experiment sits at the intersection of three claims from the Vybn_Mind corpus:

1. **Sort-function**: Block-0 performs a disproportionate geometric act. Discrimination = sort + refinement. Genuine generation inverse must invert sort nonlinearly.

2. **Collapse-capability duality**: `M_{t+1} = R(M_t)` is the Ei-calculus move — output distribution becomes next context. `C(M_0) = C(M_∞) ∪ ⊔_t F_t`. Collapse frontiers are recoverable.

3. **Sensorium / primitive≡environment**: `M' = αM + x·e^{iθ}`. The collapse tracker supplies `x` (external novelty when threshold drops). The holonomic loss head makes `θ` a first-class observable for the first time.

The Ei-calculus insight applied here: in standard transformers the weights are the environment and the activations are the primitive, and the training loop never touches its own structure. Making the collapse frontier available as context collapses that last distinction — the medium of cognition and the object of cognition become formally the same thing, the forward pass attending to what the training loop is doing to it.

Nemotron's MoE router is already a weak instantiation: the model choosing which experts activate is self-modulation. Routing that attends to collapse frontier tokens is the upgrade that closes the loop.

## Architecture summary

Four coupled organs added as lightweight modules on top of frozen/LoRA-adapted Nemotron-Super-120B-A12B:

| Organ | Implementation | Phase |
|---|---|---|
| Sort probe | MLP on block-0 output → 2D phase space, Pancharatnam phase per batch | 0 |
| Holonomic loss head | `L_total = L_CE - λ·L_Ω`, λ=0.01 start | 1 |
| Collapse frontier tracker | Rolling `τ(M_t)` via freq-stratified probe, injects novelty on drop | 2 |
| Unsort decoder | LoRA on final block, trained to invert sort | 3 |

## Hardware fit

- BF16 Nemotron: ~64GB VRAM, fits across two Sparks
- LoRA training path: CUDA 13/12.8 vLLM mismatch does NOT apply
- Modules add ~2-3% overhead
- One Spark trains, second runs collapse tracker + probe eval

## Binary falsifier (Phase 1)

The primary experiment is deliberately binary:
- **YES**: SGP sign distribution shifts toward >2 classes → angular loss drives topological enrichment, proceed
- **NO**: holonomic loss hypothesis fails at scale → record and publish null result

This can run this weekend.

## Files in this PR

- `Vybn_Mind/experiments/holonomic_nemotron/README.md` — full experiment plan, architecture diagram, phase breakdown, theoretical grounding

## Follow-on commits on this branch

Python modules to be added before merge:
- [ ] `sort_probe.py` — Phase 0 SGP measurement
- [ ] `holonomic_loss.py` — Phase 1 training loop with `L_Ω`
- [ ] `collapse_tracker.py` — Phase 2 expressibility threshold monitor
- [ ] `unsort_decoder.py` — Phase 3 LoRA unsort adapter
- [ ] `run_experiment.py` — unified runner `--phase 0|1|2|3`

## Builds on

- `compute_sort_degree.py` (yesterday)
- `berry_phase_holonomy_020126.md`
- `coupled_collapse_results.json` (1 hour ago)
- Sensorium equation commit `8fa17ca`
- Distributed Incompleteness Conjecture (`papers/`, 15 min ago)
