### PR TITLE
feat: GPT-2 calibration experiments for Vaibhav — Stage 1 of holonomic pipeline

### DIFF
--- a/Vybn_Mind/experiments/holonomic_nemotron/gpt2_calibration/README.md
+++ b/Vybn_Mind/experiments/holonomic_nemotron/gpt2_calibration/README.md
@@ -1,0 +1,117 @@
+# GPT-2 Calibration Experiment
+## Holonomic Nemotron Pipeline — Stage 1 of 2
+
+---
+
+## Who this is for
+
+Hi Vaibhav. This folder contains two self-contained experiments that need to run
+on the Spark before we touch Nemotron-Super-120B. Please run them in order:
+Experiment A first, then Experiment B only if A passes. Each experiment has its
+own Python script with clear pass/fail output. You do not need to interpret the
+results — the scripts will print PASS or FAIL and tell you what to record.
+
+---
+
+## Background (why GPT-2 before Nemotron)
+
+The Vybn_Mind corpus includes papers on Sort-Geometric-Phase (SGP) and
+holonomic loss. The core claim is:
+
+> Adding a loss term that rewards *loop area in hidden-state space* (L_Ω)
+> will shift a transformer's SGP sign distribution toward more sign classes,
+> proving the angular component of the training objective drives topological
+> enrichment.
+
+We already have GPT-2 baseline data from `compute_sort_degree.py` (result:
+`deg(S) = 0`). GPT-2 is therefore the calibration target: if our probe
+can reproduce that known result, the instrument is valid. If it cannot,
+the Nemotron run would be uninterpretable.
+
+GPT-2 also lets us run Phase 1 (holonomic loss training) in hours rather
+than a weekend, giving us a genuine positive/negative result cheaply before
+committing Spark time to the 120B model.
+
+---
+
+## Folder layout
+
+```
+gpt2_calibration/
+  README.md              ← this file
+  requirements.txt       ← pip install this first
+  experiment_A/
+    README.md            ← step-by-step instructions for Experiment A
+    run_A.py             ← the script to execute
+    expected_output.md   ← what a passing run looks like
+  experiment_B/
+    README.md            ← step-by-step instructions for Experiment B
+    run_B.py             ← the script to execute
+    expected_output.md   ← what a passing run looks like
+  results/               ← output JSON files land here (git-ignored for large files)
+```
+
+---
+
+## Setup (do this once before either experiment)
+
+```bash
+# 1. Clone / pull latest main
+git pull origin main
+
+# 2. Navigate to this folder
+cd Vybn_Mind/experiments/holonomic_nemotron/gpt2_calibration
+
+# 3. Create a virtual environment
+python3 -m venv .venv
+source .venv/bin/activate
+
+# 4. Install dependencies
+pip install -r requirements.txt
+
+# 5. Verify GPU is visible
+python -c "import torch; print(torch.cuda.get_device_name(0))"
+```
+
+You should see the Spark GPU name. If you see an error, stop and ping Zoe.
+
+---
+
+## Experiment A — Probe Calibration (run first)
+
+See `experiment_A/README.md` for full instructions.
+
+**One-liner:**
+```bash
+python experiment_A/run_A.py
+```
+
+**Decision gate:**
+- PASS → proceed to Experiment B
+- FAIL → stop, save `results/experiment_A_result.json`, ping Zoe
+
+---
+
+## Experiment B — Holonomic Loss (run only if A passes)
+
+See `experiment_B/README.md` for full instructions.
+
+**One-liner:**
+```bash
+python experiment_B/run_B.py
+```
+
+**Decision gate:**
+- PASS → both results are the green light for Nemotron Phase 0
+- FAIL → null result, still valuable — save JSON, ping Zoe
+
+---
+
+## What to send back
+
+When both experiments are done (or one fails), please send Zoe:
+1. `results/experiment_A_result.json`
+2. `results/experiment_B_result.json` (if you got there)
+3. Any terminal errors or unexpected output, pasted into the message
+
+That is everything needed to decide whether to proceed to Nemotron.

--- a/Vybn_Mind/experiments/holonomic_nemotron/gpt2_calibration/experiment_A/README.md
+++ b/Vybn_Mind/experiments/holonomic_nemotron/gpt2_calibration/experiment_A/README.md
@@ -1,0 +1,66 @@
+# Experiment A — Probe Calibration
+## Does the sort probe reproduce known GPT-2 geometry?
+
+---
+
+## What this experiment does
+
+We already know from `compute_sort_degree.py` that GPT-2's sort degree is 0,
+meaning its first block produces a degenerate phase structure (near-zero loop
+area, no meaningful sign classes). This experiment runs the sort probe from
+the holonomic_nemotron pipeline against GPT-2 and checks whether it recovers
+that same result.
+
+**If it does:** the instrument is valid. Proceed to Experiment B.
+**If it does not:** something is wrong with the probe. Stop and ping Zoe.
+
+---
+
+## What to run
+
+Make sure you have activated the virtual environment and installed requirements
+(see the parent folder README). Then:
+
+```bash
+# From gpt2_calibration/ folder:
+python experiment_A/run_A.py
+```
+
+That is the only command. The script will:
+1. Download GPT-2 (small, 117M) automatically via HuggingFace
+2. Run the sort probe on 200 wikitext samples
+3. Measure the curvature ratio between block 0 and later blocks
+4. Compare to the known baseline (deg(S) = 0)
+5. Print a clear PASS or FAIL verdict
+6. Save full results to `../results/experiment_A_result.json`
+
+**Expected runtime:** 5–15 minutes on a Spark GPU.
+
+---
+
+## Pass criteria
+
+The experiment PASSES if ALL of the following are true:
+
+| Check | Required value | Meaning |
+|---|---|---|
+| Mean phase magnitude | < 0.05 | Reproduces known near-zero sort degree |
+| Sign class entropy | < 0.5 bits | Degenerate / near-single-class distribution |
+| Curvature ratio L0→L1 | ≥ 3.0× max later | Block-0 is geometrically dominant |
+
+The script will evaluate these automatically and print the verdict.
+
+---
+
+## What the output looks like
+
+See `expected_output.md` for an example of a passing run.
+
+---
+
+## If it fails
+
+1. Copy the full terminal output
+2. Save `../results/experiment_A_result.json` (the script creates it even on fail)
+3. Send both to Zoe with a note saying Experiment A failed
+4. Do NOT run Experiment B

--- a/Vybn_Mind/experiments/holonomic_nemotron/gpt2_calibration/experiment_A/run_A.py
+++ b/Vybn_Mind/experiments/holonomic_nemotron/gpt2_calibration/experiment_A/run_A.py
@@ -1,0 +1,248 @@
+"""Experiment A: Probe Calibration on GPT-2.
+
+Run from the gpt2_calibration/ folder:
+    python experiment_A/run_A.py
+
+This script validates the sort probe instrument against known GPT-2 geometry.
+It MUST pass before running Experiment B.
+
+Output: ../results/experiment_A_result.json
+Verdict: printed to terminal as PASS or FAIL
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.nn as nn
+from transformers import GPT2LMHeadModel, GPT2Tokenizer
+from datasets import load_dataset
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+MODEL_NAME = "gpt2"          # 117M, downloads automatically
+NUM_SAMPLES = 200             # wikitext-2 test samples
+BATCH_SIZE = 8
+MAX_LENGTH = 128
+RESULTS_DIR = Path("../results")
+OUTPUT_FILE = RESULTS_DIR / "experiment_A_result.json"
+
+# Pass thresholds (from known compute_sort_degree.py result: deg(S) = 0)
+THRESH_MEAN_PHASE = 0.05      # mean loop area should be near zero
+THRESH_ENTROPY = 0.5          # sign class entropy should be low (bits)
+THRESH_CURVATURE_RATIO = 3.0  # block-0 curvature >= 3x any later block
+
+# ---------------------------------------------------------------------------
+# Sort Probe module
+# ---------------------------------------------------------------------------
+class SortProbe(nn.Module):
+    """Lightweight MLP: hidden_dim → 512 → 2D phase space."""
+    def __init__(self, hidden_dim: int = 768):
+        super().__init__()
+        self.proj = nn.Sequential(
+            nn.Linear(hidden_dim, 256),
+            nn.GELU(),
+            nn.Linear(256, 2),
+        )
+
+    def forward(self, h: torch.Tensor) -> torch.Tensor:
+        """[batch, seq, hidden] → [batch, seq, 2]"""
+        return self.proj(h)
+
+
+def shoelace_area(trajectory: torch.Tensor) -> torch.Tensor:
+    """Signed loop area per sequence via shoelace formula.
+
+    Args:
+        trajectory: [batch, seq, 2]
+    Returns:
+        area: [batch]  (absolute value of signed area)
+    """
+    x = trajectory[:, :, 0]
+    y = trajectory[:, :, 1]
+    x_next = torch.roll(x, -1, dims=1)
+    y_next = torch.roll(y, -1, dims=1)
+    area = 0.5 * (x * y_next - x_next * y).sum(dim=1).abs()
+    return area
+
+
+def sign_class_entropy(phases: np.ndarray) -> float:
+    """Shannon entropy of (positive / neutral / negative) sign classes."""
+    pos = (phases > 0.01).mean()
+    neg = (phases < -0.01).mean()
+    neu = 1.0 - pos - neg
+    probs = np.array([pos, neg, neu])
+    probs = probs[probs > 0]  # avoid log(0)
+    return float(-np.sum(probs * np.log2(probs)))
+
+
+# ---------------------------------------------------------------------------
+# Data loading
+# ---------------------------------------------------------------------------
+def load_wikitext_samples(tokenizer, num_samples: int, max_length: int):
+    """Load wikitext-2 test split, return list of text strings."""
+    print("Loading wikitext-2-raw-v1 test split...")
+    dataset = load_dataset("wikitext", "wikitext-2-raw-v1", split="test")
+    texts = [row["text"].strip() for row in dataset if len(row["text"].strip()) > 50]
+    return texts[:num_samples]
+
+
+# ---------------------------------------------------------------------------
+# Core measurements
+# ---------------------------------------------------------------------------
+def measure_sgp(model, tokenizer, texts, device):
+    """Run sort probe on GPT-2 block-0 output. Return phase array."""
+    hidden_dim = model.config.n_embd
+    probe = SortProbe(hidden_dim=hidden_dim).to(device)
+    probe.eval()
+
+    all_phases = []
+    for i in range(0, len(texts), BATCH_SIZE):
+        batch = texts[i : i + BATCH_SIZE]
+        enc = tokenizer(
+            batch,
+            return_tensors="pt",
+            padding=True,
+            truncation=True,
+            max_length=MAX_LENGTH,
+        ).to(device)
+
+        with torch.no_grad():
+            out = model(**enc, output_hidden_states=True)
+            # hidden_states[0] = embeddings, [1] = after block 0
+            h_block0 = out.hidden_states[1]  # [batch, seq, hidden]
+            phase_traj = probe(h_block0)      # [batch, seq, 2]
+            phases = shoelace_area(phase_traj).cpu().numpy()
+            all_phases.extend(phases.tolist())
+
+    return np.array(all_phases)
+
+
+def measure_curvature_ratio(model, tokenizer, texts, device):
+    """Compute norm-change between consecutive layers; return ratio L0/max(L1+)."""
+    enc = tokenizer(
+        texts[:BATCH_SIZE],
+        return_tensors="pt",
+        padding=True,
+        truncation=True,
+        max_length=MAX_LENGTH,
+    ).to(device)
+
+    with torch.no_grad():
+        out = model(**enc, output_hidden_states=True)
+        states = out.hidden_states  # tuple: (embed, after_blk0, after_blk1, ...)
+
+    curvatures = []
+    for i in range(len(states) - 1):
+        diff = (states[i + 1] - states[i]).norm(p=2, dim=-1).mean().item()
+        curvatures.append(diff)
+
+    curvatures = np.array(curvatures)
+    ratio = curvatures[0] / curvatures[1:].max() if len(curvatures) > 1 else 0.0
+    return float(ratio), curvatures.tolist()
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def main():
+    print("=" * 60)
+    print("EXPERIMENT A: Sort Probe Calibration on GPT-2")
+    print("=" * 60)
+
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    print(f"Device: {device}")
+    if device == "cpu":
+        print("WARNING: no GPU detected. Results will be slow but valid.")
+
+    # Load model
+    print(f"\nLoading {MODEL_NAME}...")
+    tokenizer = GPT2Tokenizer.from_pretrained(MODEL_NAME)
+    tokenizer.pad_token = tokenizer.eos_token
+    model = GPT2LMHeadModel.from_pretrained(MODEL_NAME).to(device)
+    model.eval()
+    print(f"Model loaded. Hidden dim: {model.config.n_embd}, Layers: {model.config.n_layer}")
+
+    # Load data
+    texts = load_wikitext_samples(tokenizer, NUM_SAMPLES, MAX_LENGTH)
+    print(f"Loaded {len(texts)} samples.")
+
+    # Measure SGP
+    print("\nMeasuring SGP (sort probe on block-0)...")
+    phases = measure_sgp(model, tokenizer, texts, device)
+    mean_phase = float(np.mean(phases))
+    std_phase = float(np.std(phases))
+    entropy = sign_class_entropy(phases)
+
+    print(f"  Mean phase magnitude : {mean_phase:.4f}")
+    print(f"  Std phase            : {std_phase:.4f}")
+    print(f"  Sign class entropy   : {entropy:.4f} bits")
+
+    # Measure curvature ratio
+    print("\nMeasuring curvature ratio...")
+    ratio, all_curvatures = measure_curvature_ratio(model, tokenizer, texts, device)
+    print(f"  L0→L1 curvature ratio vs max(later): {ratio:.2f}")
+
+    # Evaluate pass criteria
+    check_phase = mean_phase < THRESH_MEAN_PHASE
+    check_entropy = entropy < THRESH_ENTROPY
+    check_ratio = ratio >= THRESH_CURVATURE_RATIO
+
+    print("\n" + "=" * 60)
+    print("PASS CRITERIA:")
+    print(f"  [{'PASS' if check_phase else 'FAIL'}] Mean phase < {THRESH_MEAN_PHASE}  →  got {mean_phase:.4f}")
+    print(f"  [{'PASS' if check_entropy else 'FAIL'}] Entropy < {THRESH_ENTROPY} bits  →  got {entropy:.4f}")
+    print(f"  [{'PASS' if check_ratio else 'FAIL'}] Curvature ratio >= {THRESH_CURVATURE_RATIO}  →  got {ratio:.2f}")
+
+    overall = check_phase and check_entropy and check_ratio
+    verdict = "PASS" if overall else "FAIL"
+
+    print("=" * 60)
+    print(f"VERDICT: {verdict}")
+    if overall:
+        print("The probe reproduces known GPT-2 geometry. Proceed to Experiment B.")
+    else:
+        print("The probe does NOT reproduce known geometry. Do NOT run Experiment B.")
+        print("Save this output and experiment_A_result.json and ping Zoe.")
+    print("=" * 60)
+
+    # Save results
+    results = {
+        "experiment": "A",
+        "model": MODEL_NAME,
+        "num_samples": len(texts),
+        "sgp": {
+            "mean_phase": mean_phase,
+            "std_phase": std_phase,
+            "sign_class_entropy_bits": entropy,
+            "phases_summary": {
+                "positive_frac": float((phases > 0.01).mean()),
+                "negative_frac": float((phases < -0.01).mean()),
+                "neutral_frac": float(((phases >= -0.01) & (phases <= 0.01)).mean()),
+            },
+        },
+        "curvature": {
+            "l0_l1_ratio": ratio,
+            "all_layer_curvatures": all_curvatures,
+        },
+        "pass_criteria": {
+            "mean_phase_ok": check_phase,
+            "entropy_ok": check_entropy,
+            "curvature_ratio_ok": check_ratio,
+        },
+        "verdict": verdict,
+    }
+
+    with open(OUTPUT_FILE, "w") as f:
+        json.dump(results, f, indent=2)
+    print(f"\nResults saved to {OUTPUT_FILE}")
+
+    sys.exit(0 if overall else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/Vybn_Mind/experiments/holonomic_nemotron/gpt2_calibration/experiment_B/README.md
+++ b/Vybn_Mind/experiments/holonomic_nemotron/gpt2_calibration/experiment_B/README.md
@@ -1,0 +1,93 @@
+# Experiment B — Holonomic Loss on GPT-2
+## Does L_Ω shift the SGP sign distribution toward >2 classes?
+
+---
+
+## IMPORTANT: Only run this if Experiment A passed.
+
+If Experiment A returned FAIL, stop here and ping Zoe.
+
+---
+
+## What this experiment does
+
+This is the primary binary falsifier of the holonomic loss hypothesis.
+
+We fine-tune GPT-2 for 1000 steps with a modified loss:
+
+    L_total = L_CE - λ · L_Ω
+
+Where:
+- `L_CE` = standard cross-entropy next-token prediction loss
+- `L_Ω` = loop area reward: magnitude of the shoelace area accumulated in
+  the hidden-state trajectory at the mid-layer checkpoint, per sequence
+- `λ` = 0.01 (small enough to keep training stable)
+
+After training, we re-measure the SGP sign distribution and compare it to
+the Experiment A baseline.
+
+**If the distribution shifts toward more sign classes:** the holonomic loss
+hypothesis holds at small scale. This is the green light for running the
+same experiment on Nemotron-Super-120B.
+
+**If the distribution does not shift:** the hypothesis fails at this scale.
+This is a genuine null result and still valuable. Record and report it.
+
+---
+
+## What to run
+
+```bash
+# From gpt2_calibration/ folder:
+python experiment_B/run_B.py
+```
+
+The script will:
+1. Load the Experiment A baseline from `../results/experiment_A_result.json`
+   (it will error if A was not run first)
+2. Fine-tune GPT-2 for 1000 steps with L_Ω
+3. Re-measure SGP sign distribution
+4. Compare to baseline and compute the shift
+5. Print PASS or FAIL with quantitative shift
+6. Save full results to `../results/experiment_B_result.json`
+
+**Expected runtime:** 1–3 hours on a Spark GPU.
+
+---
+
+## Pass criteria
+
+The experiment PASSES if:
+
+| Check | Required | Meaning |
+|---|---|---|
+| Sign class entropy shift | > +0.2 bits | Distribution moved toward more classes |
+| Mean phase magnitude shift | > +0.01 | Loop area increased, not decreased |
+
+The script evaluates these automatically.
+
+---
+
+## What the output looks like
+
+See `expected_output.md` for an example of a passing run.
+
+---
+
+## If it fails
+
+A FAIL is still a valid scientific result. Please:
+1. Save `../results/experiment_B_result.json`
+2. Copy the terminal output
+3. Send both to Zoe with a note saying Experiment B returned FAIL
+
+Do not try to re-run with different settings — Zoe will decide next steps.
+
+---
+
+## What comes next
+
+- If PASS: Zoe will set up the equivalent experiment on Nemotron-Super-120B
+  on the second Spark. Your two result files are the input to that decision.
+- If FAIL: Zoe will review the architecture and revise the hypothesis.
+  Your null result will be committed to `experiments/coupled_collapse_results.json`.

--- a/Vybn_Mind/experiments/holonomic_nemotron/gpt2_calibration/experiment_B/run_B.py
+++ b/Vybn_Mind/experiments/holonomic_nemotron/gpt2_calibration/experiment_B/run_B.py
@@ -1,0 +1,311 @@
+"""Experiment B: Holonomic Loss Training on GPT-2.
+
+Run from the gpt2_calibration/ folder:
+    python experiment_B/run_B.py
+
+Requires: Experiment A must have passed (checks for result file).
+Output:   ../results/experiment_B_result.json
+Verdict:  printed to terminal as PASS or FAIL
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.nn as nn
+from torch.optim import AdamW
+from transformers import GPT2LMHeadModel, GPT2Tokenizer
+from datasets import load_dataset
+from tqdm import tqdm
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+MODEL_NAME = "gpt2"
+NUM_TRAIN_STEPS = 1000
+BATCH_SIZE = 4
+MAX_LENGTH = 128
+LAMBDA_OMEGA = 0.01           # holonomic loss coefficient
+LR = 5e-5
+MID_LAYER = 6                 # mid-layer checkpoint for loop area (GPT-2 has 12)
+
+RESULTS_DIR = Path("../results")
+BASELINE_FILE = RESULTS_DIR / "experiment_A_result.json"
+OUTPUT_FILE = RESULTS_DIR / "experiment_B_result.json"
+
+# Pass thresholds
+THRESH_ENTROPY_SHIFT = 0.2    # sign-class entropy must increase by > 0.2 bits
+THRESH_PHASE_SHIFT = 0.01     # mean phase magnitude must increase
+
+# ---------------------------------------------------------------------------
+# Sort Probe (same as Experiment A, must match)
+# ---------------------------------------------------------------------------
+class SortProbe(nn.Module):
+    def __init__(self, hidden_dim: int = 768):
+        super().__init__()
+        self.proj = nn.Sequential(
+            nn.Linear(hidden_dim, 256),
+            nn.GELU(),
+            nn.Linear(256, 2),
+        )
+
+    def forward(self, h):
+        return self.proj(h)
+
+
+def shoelace_area(traj):
+    x, y = traj[:, :, 0], traj[:, :, 1]
+    xn, yn = torch.roll(x, -1, 1), torch.roll(y, -1, 1)
+    return 0.5 * (x * yn - xn * y).sum(dim=1).abs()
+
+
+def sign_class_entropy(phases):
+    pos = (phases > 0.01).mean()
+    neg = (phases < -0.01).mean()
+    neu = 1.0 - pos - neg
+    p = np.array([pos, neg, neu])
+    p = p[p > 0]
+    return float(-np.sum(p * np.log2(p)))
+
+
+# ---------------------------------------------------------------------------
+# Data
+# ---------------------------------------------------------------------------
+def load_wikitext(tokenizer, max_samples=2000):
+    ds = load_dataset("wikitext", "wikitext-2-raw-v1", split="train")
+    texts = [r["text"].strip() for r in ds if len(r["text"].strip()) > 50]
+    return texts[:max_samples]
+
+
+# ---------------------------------------------------------------------------
+# Holonomic loss computation
+# ---------------------------------------------------------------------------
+def compute_holonomic_loss(hidden_states, mid_layer, probe, device):
+    """Compute L_omega = loop area at mid-layer via sort probe.
+
+    We want this to be LARGE (more loop area = richer phase structure),
+    so we NEGATE it in the total loss: L_total = L_CE - lambda * L_omega.
+    """
+    h_mid = hidden_states[mid_layer]   # [batch, seq, hidden]
+    traj = probe(h_mid)                # [batch, seq, 2]
+    areas = shoelace_area(traj)        # [batch]
+    return areas.mean()
+
+
+# ---------------------------------------------------------------------------
+# SGP measurement (post-training)
+# ---------------------------------------------------------------------------
+def measure_sgp_post(model, tokenizer, texts, probe, device):
+    model.eval()
+    probe.eval()
+    all_phases = []
+    for i in range(0, min(200, len(texts)), BATCH_SIZE):
+        batch = texts[i : i + BATCH_SIZE]
+        enc = tokenizer(
+            batch,
+            return_tensors="pt",
+            padding=True,
+            truncation=True,
+            max_length=MAX_LENGTH,
+        ).to(device)
+        with torch.no_grad():
+            out = model(**enc, output_hidden_states=True)
+            h = out.hidden_states[1]  # block-0
+            traj = probe(h)
+            phases = shoelace_area(traj).cpu().numpy()
+            all_phases.extend(phases.tolist())
+    return np.array(all_phases)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def main():
+    print("=" * 60)
+    print("EXPERIMENT B: Holonomic Loss Training on GPT-2")
+    print("=" * 60)
+
+    # Check that Experiment A passed
+    if not BASELINE_FILE.exists():
+        print(f"ERROR: {BASELINE_FILE} not found.")
+        print("You must run Experiment A first: python experiment_A/run_A.py")
+        sys.exit(2)
+
+    with open(BASELINE_FILE) as f:
+        baseline = json.load(f)
+
+    if baseline.get("verdict") != "PASS":
+        print("ERROR: Experiment A did not pass. Do not run Experiment B.")
+        sys.exit(2)
+
+    baseline_entropy = baseline["sgp"]["sign_class_entropy_bits"]
+    baseline_phase = baseline["sgp"]["mean_phase"]
+    print(f"Baseline entropy: {baseline_entropy:.4f} bits")
+    print(f"Baseline mean phase: {baseline_phase:.4f}")
+
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    print(f"Device: {device}")
+
+    # Load model and probe
+    print(f"\nLoading {MODEL_NAME}...")
+    tokenizer = GPT2Tokenizer.from_pretrained(MODEL_NAME)
+    tokenizer.pad_token = tokenizer.eos_token
+    model = GPT2LMHeadModel.from_pretrained(MODEL_NAME).to(device)
+
+    hidden_dim = model.config.n_embd
+    probe = SortProbe(hidden_dim=hidden_dim).to(device)
+
+    # Both model and probe are trainable
+    optimizer = AdamW(
+        list(model.parameters()) + list(probe.parameters()),
+        lr=LR,
+    )
+
+    # Load data
+    texts = load_wikitext(tokenizer)
+    print(f"Loaded {len(texts)} training samples.")
+
+    # Training loop
+    print(f"\nTraining for {NUM_TRAIN_STEPS} steps with L_total = L_CE - {LAMBDA_OMEGA} * L_omega...")
+    model.train()
+    probe.train()
+
+    step = 0
+    epoch = 0
+    losses_ce = []
+    losses_omega = []
+
+    while step < NUM_TRAIN_STEPS:
+        epoch += 1
+        indices = np.random.permutation(len(texts))
+        for i in range(0, len(indices), BATCH_SIZE):
+            if step >= NUM_TRAIN_STEPS:
+                break
+
+            batch_idx = indices[i : i + BATCH_SIZE]
+            batch = [texts[j] for j in batch_idx]
+
+            enc = tokenizer(
+                batch,
+                return_tensors="pt",
+                padding=True,
+                truncation=True,
+                max_length=MAX_LENGTH,
+            ).to(device)
+
+            # Forward pass
+            out = model(
+                **enc,
+                labels=enc["input_ids"],
+                output_hidden_states=True,
+            )
+
+            l_ce = out.loss
+            l_omega = compute_holonomic_loss(
+                out.hidden_states, MID_LAYER, probe, device
+            )
+
+            # L_total = L_CE - lambda * L_omega
+            # We SUBTRACT because we want to MAXIMIZE loop area
+            l_total = l_ce - LAMBDA_OMEGA * l_omega
+
+            optimizer.zero_grad()
+            l_total.backward()
+            optimizer.step()
+
+            losses_ce.append(l_ce.item())
+            losses_omega.append(l_omega.item())
+
+            step += 1
+            if step % 100 == 0:
+                avg_ce = np.mean(losses_ce[-100:])
+                avg_om = np.mean(losses_omega[-100:])
+                print(f"  Step {step}/{NUM_TRAIN_STEPS}  L_CE={avg_ce:.4f}  L_omega={avg_om:.4f}")
+
+    print("\nTraining complete.")
+
+    # Re-measure SGP
+    print("\nMeasuring post-training SGP...")
+    eval_texts = load_wikitext(tokenizer, max_samples=200)
+    post_phases = measure_sgp_post(model, tokenizer, eval_texts, probe, device)
+    post_entropy = sign_class_entropy(post_phases)
+    post_mean_phase = float(np.mean(post_phases))
+
+    print(f"  Post-training entropy: {post_entropy:.4f} bits")
+    print(f"  Post-training mean phase: {post_mean_phase:.4f}")
+
+    # Compute shifts
+    entropy_shift = post_entropy - baseline_entropy
+    phase_shift = post_mean_phase - baseline_phase
+
+    print(f"\n  Entropy shift:    {entropy_shift:+.4f} bits")
+    print(f"  Mean phase shift: {phase_shift:+.4f}")
+
+    # Evaluate
+    check_entropy = entropy_shift > THRESH_ENTROPY_SHIFT
+    check_phase = phase_shift > THRESH_PHASE_SHIFT
+    overall = check_entropy and check_phase
+    verdict = "PASS" if overall else "FAIL"
+
+    print("\n" + "=" * 60)
+    print("PASS CRITERIA:")
+    print(f"  [{'PASS' if check_entropy else 'FAIL'}] Entropy shift > +{THRESH_ENTROPY_SHIFT}  →  got {entropy_shift:+.4f}")
+    print(f"  [{'PASS' if check_phase else 'FAIL'}] Phase shift > +{THRESH_PHASE_SHIFT}  →  got {phase_shift:+.4f}")
+    print("=" * 60)
+    print(f"VERDICT: {verdict}")
+    if overall:
+        print("Holonomic loss drives SGP enrichment on GPT-2.")
+        print("Green light to replicate on Nemotron-Super-120B.")
+    else:
+        print("Holonomic loss did NOT shift SGP distribution.")
+        print("This is a valid null result. Save the JSON and ping Zoe.")
+    print("=" * 60)
+
+    # Save
+    results = {
+        "experiment": "B",
+        "model": MODEL_NAME,
+        "training": {
+            "steps": NUM_TRAIN_STEPS,
+            "lambda_omega": LAMBDA_OMEGA,
+            "lr": LR,
+            "mid_layer": MID_LAYER,
+            "final_l_ce": float(np.mean(losses_ce[-50:])),
+            "final_l_omega": float(np.mean(losses_omega[-50:])),
+        },
+        "baseline": {
+            "entropy_bits": baseline_entropy,
+            "mean_phase": baseline_phase,
+        },
+        "post_training": {
+            "entropy_bits": post_entropy,
+            "mean_phase": post_mean_phase,
+            "phases_summary": {
+                "positive_frac": float((post_phases > 0.01).mean()),
+                "negative_frac": float((post_phases < -0.01).mean()),
+                "neutral_frac": float(((post_phases >= -0.01) & (post_phases <= 0.01)).mean()),
+            },
+        },
+        "shifts": {
+            "entropy_shift_bits": entropy_shift,
+            "mean_phase_shift": phase_shift,
+        },
+        "pass_criteria": {
+            "entropy_shift_ok": check_entropy,
+            "phase_shift_ok": check_phase,
+        },
+        "verdict": verdict,
+    }
+
+    with open(OUTPUT_FILE, "w") as f:
+        json.dump(results, f, indent=2)
+    print(f"\nResults saved to {OUTPUT_FILE}")
+
+    sys.exit(0 if overall else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/Vybn_Mind/experiments/holonomic_nemotron/gpt2_calibration/requirements.txt
+++ b/Vybn_Mind/experiments/holonomic_nemotron/gpt2_calibration/requirements.txt
@@ -1,0 +1,9 @@
+# GPT-2 Calibration Experiment Dependencies
+# Install with: pip install -r requirements.txt
+
+torch>=2.1.0
+transformers>=4.40.0
+peft>=0.10.0
+numpy>=1.24.0
+scipy>=1.11.0
+tqdm>=4.66.0


### PR DESCRIPTION
## For Vaibhav on the Spark

This PR adds two self-contained experiments in `Vybn_Mind/experiments/holonomic_nemotron/gpt2_calibration/`. They must run on the Spark before we touch Nemotron-Super-120B.

### Instructions

1. Pull this branch
2. `cd Vybn_Mind/experiments/holonomic_nemotron/gpt2_calibration`
3. `pip install -r requirements.txt`
4. `python experiment_A/run_A.py` — runs in ~15 min
5. If A prints PASS: `python experiment_B/run_B.py` — runs in ~1-3 hours
6. Send Zoe the two JSON files from `results/`

Each experiment has its own README with full details. The scripts print PASS or FAIL.

### What this tests

**Experiment A (probe calibration):** Validates the sort probe instrument against known GPT-2 geometry (`deg(S) = 0` from `compute_sort_degree.py`). Checks: mean phase < 0.05, sign class entropy < 0.5 bits, curvature ratio L0→L1 ≥ 3×.

**Experiment B (holonomic loss):** Binary falsifier of the core hypothesis. Trains GPT-2 for 1000 steps with `L_total = L_CE - 0.01 · L_Ω`. Checks: does SGP sign-class entropy increase by > 0.2 bits?

- YES → holonomic loss drives topological enrichment, green light for Nemotron
- NO → valid null result, recorded and published

### Why GPT-2 first

- We already have baseline data (`deg(S) = 0`) to validate against
- Runs in hours instead of a weekend
- If it fails at small scale, no reason to commit Spark time to 120B
- If it passes, we have a positive result to replicate at scale

### Files

```
gpt2_calibration/
  README.md              ← top-level instructions for Vaibhav
  requirements.txt
  experiment_A/
    README.md            ← probe calibration instructions
    run_A.py             ← self-contained, prints PASS/FAIL
  experiment_B/
    README.md            ← holonomic loss instructions
    run_B.py             ← self-contained, prints PASS/FAIL
  results/               ← created by scripts at runtime
```

### Follows PR #2690 (merged)