### PR TITLE
fix: IBM Quantum API — correct credentials, transpilation, and result…

### DIFF
--- a/Vybn_Mind/spark_infrastructure/quantum_heartbeat.py
+++ b/Vybn_Mind/spark_infrastructure/quantum_heartbeat.py
@@ -8,6 +8,11 @@ If ALL quantum sources fail, logs VOID -- no classical fallback.
 
 Also checks whether the Outshift key is approaching expiry and opens
 a GitHub issue as a flare if it is within 14 days or already expired.
+
+IBM QUANTUM API FIX (2026-07-14):
+  Uses QiskitRuntimeService() with no args for auto-detected credentials
+  from QISKIT_IBM_* env vars (ibm_cloud channel). Falls back to legacy
+  IBM_QUANTUM_TOKEN if QISKIT_IBM_TOKEN is not set.
 """
 
 import json
@@ -107,30 +112,87 @@ def fetch_anu():
         return None
 
 
+def _has_ibm_credentials() -> bool:
+    """Check whether IBM Quantum credentials are available."""
+    return bool(
+        os.environ.get("QISKIT_IBM_TOKEN")
+        or os.environ.get("IBM_QUANTUM_TOKEN")
+    )
+
+
+def _get_ibm_service():
+    """Create a QiskitRuntimeService using auto-detected credentials.
+
+    FIX (2026-07-14): Supports both QISKIT_IBM_TOKEN (ibm_cloud, auto-detected)
+    and legacy IBM_QUANTUM_TOKEN (ibm_quantum, explicit).
+    """
+    from qiskit_ibm_runtime import QiskitRuntimeService
+
+    if os.environ.get("QISKIT_IBM_TOKEN"):
+        return QiskitRuntimeService()
+
+    legacy_token = os.environ.get("IBM_QUANTUM_TOKEN")
+    if legacy_token:
+        return QiskitRuntimeService(channel="ibm_quantum", token=legacy_token)
+
+    raise RuntimeError("No IBM Quantum credentials found")
+
+
 def fetch_ibm():
-    """IBM Quantum via qiskit -- tertiary source."""
-    ibm_token = os.environ.get("IBM_QUANTUM_TOKEN", "")
-    if not ibm_token:
-        print("[ibm] no token configured, skipping")
+    """IBM Quantum via qiskit -- tertiary source.
+
+    FIX (2026-07-14):
+      - Uses _get_ibm_service() for auto-detected credentials.
+      - Transpiles the H-gate circuit to ISA before submission.
+      - Uses SamplerV2 with mode= keyword (current API).
+    """
+    if not _has_ibm_credentials():
+        print("[ibm] no credentials configured, skipping")
         return None
     try:
         from qiskit import QuantumCircuit
-        from qiskit_ibm_runtime import QiskitRuntimeService, SamplerV2
+        from qiskit_ibm_runtime import SamplerV2
+        from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 
-        service = QiskitRuntimeService(
-            channel="ibm_quantum", token=ibm_token
-        )
+        service = _get_ibm_service()
         backend = service.least_busy(min_num_qubits=1, operational=True)
+
         qc = QuantumCircuit(16, 16)
         qc.h(range(16))
         qc.measure(range(16), range(16))
+
+        # Transpile to ISA — required by modern IBM backends
+        pm = generate_preset_pass_manager(backend=backend, optimization_level=1)
+        isa_circuit = pm.run(qc)
+
         sampler = SamplerV2(mode=backend)
-        job = sampler.run([qc], shots=1)
+        job = sampler.run([isa_circuit], shots=1)
         result = job.result()
-        bits = list(result[0].data.meas.get_bitstrings())[0]
-        num = int(bits, 2)
-        print(f"[ibm] got {num}")
-        return num
+
+        # Get the bitstring from the result — register name is 'c' (explicit creg)
+        pub_result = result[0]
+        data = pub_result.data
+        # Try to find the classical register
+        for reg_name in ("c", "meas"):
+            if hasattr(data, reg_name):
+                bits = list(getattr(data, reg_name).get_bitstrings())[0]
+                num = int(bits, 2)
+                print(f"[ibm] got {num}")
+                return num
+
+        # Fallback: iterate data attributes
+        for attr_name in dir(data):
+            if attr_name.startswith("_"):
+                continue
+            attr = getattr(data, attr_name)
+            if hasattr(attr, "get_bitstrings"):
+                bits = list(attr.get_bitstrings())[0]
+                num = int(bits, 2)
+                print(f"[ibm] got {num}")
+                return num
+
+        print("[ibm] could not extract bitstring from result")
+        return None
     except Exception as exc:
         print(f"[ibm] error: {exc}")
         return None

--- a/spark/quantum_bridge.py
+++ b/spark/quantum_bridge.py
@@ -44,6 +44,20 @@ NEMOTRON REASONING TOKEN NOTE (fixed 2026-03-15):
     1. max_tokens=2048 in _design_experiment (was 1024)
     2. timeout=300s in _chat() (was 120s — Nemotron needs time)
     3. theory text capped at 4000 chars in run_cycle (was 8000)
+
+IBM QUANTUM API FIX (2026-07-14):
+  The original code used IBM_QUANTUM_TOKEN env var and channel="ibm_quantum"
+  (the old IBM Quantum Experience API). Our credentials use the ibm_cloud
+  channel with QISKIT_IBM_TOKEN / QISKIT_IBM_CHANNEL / QISKIT_IBM_INSTANCE
+  env vars. qiskit-ibm-runtime 0.45.1+ auto-detects these when you call
+  QiskitRuntimeService() with no arguments.
+
+  Fixes applied:
+    1. Use QiskitRuntimeService() with no args — auto-detects from env vars
+    2. Accept both QISKIT_IBM_TOKEN and IBM_QUANTUM_TOKEN for backwards compat
+    3. Transpile circuits to ISA before submission (required by modern backends)
+    4. Don't call measure_all() on circuits that already have measurements
+    5. Detect classical register name dynamically from circuit metadata
 """
 
 import json
@@ -90,6 +104,40 @@ import urllib.error
 LLAMA_URL        = os.getenv("LLAMA_URL", "http://127.0.0.1:8000")
 CHAT_COMPLETIONS = f"{LLAMA_URL}/v1/chat/completions"
 MODEL_NAME       = os.getenv("VYBN_MODEL", "Nemotron-Super-512B-v1")
+
+
+def _has_ibm_credentials() -> bool:
+    """Check whether IBM Quantum credentials are available.
+
+    Supports both the modern QISKIT_IBM_TOKEN env var (ibm_cloud channel,
+    auto-detected by QiskitRuntimeService) and the legacy IBM_QUANTUM_TOKEN.
+    """
+    return bool(
+        os.getenv("QISKIT_IBM_TOKEN")
+        or os.getenv("IBM_QUANTUM_TOKEN")
+    )
+
+
+def _get_service():
+    """Create a QiskitRuntimeService using auto-detected credentials.
+
+    qiskit-ibm-runtime 0.45.1+ reads QISKIT_IBM_TOKEN, QISKIT_IBM_CHANNEL,
+    and QISKIT_IBM_INSTANCE from the environment automatically. If only the
+    legacy IBM_QUANTUM_TOKEN is set, we fall back to explicit ibm_quantum
+    channel for backwards compatibility.
+    """
+    from qiskit_ibm_runtime import QiskitRuntimeService
+
+    # Prefer auto-detection from QISKIT_IBM_* env vars
+    if os.getenv("QISKIT_IBM_TOKEN"):
+        return QiskitRuntimeService()
+
+    # Legacy fallback: IBM_QUANTUM_TOKEN with ibm_quantum channel
+    legacy_token = os.getenv("IBM_QUANTUM_TOKEN")
+    if legacy_token:
+        return QiskitRuntimeService(channel="ibm_quantum", token=legacy_token)
+
+    raise RuntimeError("No IBM Quantum credentials found in environment")
 
 
 def _chat(messages: list[dict], max_tokens: int = 1024, temperature: float = 0.7) -> str:
@@ -276,12 +324,73 @@ def _design_experiment(theory_text: str, prior_results: list[dict]) -> dict:
 
 def _bell_state_qasm() -> str:
     return """OPENQASM 2.0;
-include \"qelib1.inc\";
+include "qelib1.inc";
 qreg q[2];
 creg c[2];
 h q[0];
 cx q[0],q[1];
 measure q -> c;"""
+
+
+# ── Circuit preparation ──────────────────────────────────────────────────────
+
+def _prepare_circuit(circuit_qasm: str, backend) -> "QuantumCircuit":
+    """Load a QASM circuit, ensure it has measurements, and transpile to ISA.
+
+    FIX (2026-07-14):
+      1. Don't call measure_all() if the circuit already has measurements.
+      2. Transpile to ISA (Instruction Set Architecture) — required by all
+         modern IBM backends. Raw circuits are rejected.
+    """
+    from qiskit.qasm2 import loads as qasm2_loads
+    from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
+
+    circuit = qasm2_loads(circuit_qasm)
+
+    # Only add measurements if the circuit doesn't already have them
+    has_measurements = circuit.count_ops().get("measure", 0) > 0
+    if not has_measurements:
+        circuit.measure_all()
+
+    # Transpile to ISA — required by IBM backends
+    pm = generate_preset_pass_manager(backend=backend, optimization_level=1)
+    isa_circuit = pm.run(circuit)
+
+    return isa_circuit
+
+
+def _get_counts_from_result(result) -> dict:
+    """Extract counts from a SamplerV2 result, handling different register names.
+
+    FIX (2026-07-14): The classical register name depends on how the circuit
+    was built:
+      - measure_all() creates a register named 'meas'
+      - Explicit 'creg c[N]' creates a register named 'c'
+      - There may be multiple classical registers
+
+    This function tries known register names and falls back to iterating
+    over all available data attributes.
+    """
+    pub_result = result[0]
+    data = pub_result.data
+
+    # Try common register names in order of likelihood
+    for reg_name in ("meas", "c", "cr"):
+        if hasattr(data, reg_name):
+            return getattr(data, reg_name).get_counts()
+
+    # Fallback: find the first BitArray attribute
+    for attr_name in dir(data):
+        if attr_name.startswith("_"):
+            continue
+        attr = getattr(data, attr_name)
+        if hasattr(attr, "get_counts"):
+            return attr.get_counts()
+
+    raise RuntimeError(
+        f"Could not find counts in result. "
+        f"Available data attributes: {[a for a in dir(data) if not a.startswith('_')]}"
+    )
 
 
 # ── IBM submission ────────────────────────────────────────────────────────────
@@ -290,32 +399,33 @@ def _submit_to_ibm(
     circuit_qasm: str,
     shots: int = 1024,
     backend_name: str = "ibm_fez",
-    ibm_token: Optional[str] = None,
 ) -> Optional[str]:
     """
     Submit a circuit to IBM Quantum. Returns job_id or None on failure.
 
+    FIX (2026-07-14):
+      - Uses _get_service() for auto-detected credentials (supports both
+        QISKIT_IBM_TOKEN/ibm_cloud and IBM_QUANTUM_TOKEN/ibm_quantum).
+      - Transpiles circuit to ISA via _prepare_circuit() before submission.
+      - No longer calls measure_all() blindly on already-measured circuits.
+
     Requires qiskit and qiskit-ibm-runtime.
     Falls back to dry-run (returns None) if packages are unavailable.
     """
-    token = ibm_token or os.getenv("IBM_QUANTUM_TOKEN")
-    if not token:
+    if not _has_ibm_credentials():
         return None  # dry-run
 
     try:
-        from qiskit import QuantumCircuit
-        from qiskit.qasm2 import loads as qasm2_loads
-        from qiskit_ibm_runtime import QiskitRuntimeService, SamplerV2 as Sampler
+        from qiskit_ibm_runtime import SamplerV2 as Sampler
     except ImportError:
         return None  # dry-run
 
     try:
-        service  = QiskitRuntimeService(channel="ibm_quantum", token=token)
-        backend  = service.backend(backend_name)
-        circuit  = qasm2_loads(circuit_qasm)
-        circuit.measure_all()
-        sampler  = Sampler(backend)
-        job      = sampler.run([circuit], shots=shots)
+        service     = _get_service()
+        backend     = service.backend(backend_name)
+        isa_circuit = _prepare_circuit(circuit_qasm, backend)
+        sampler     = Sampler(mode=backend)
+        job         = sampler.run([isa_circuit], shots=shots)
         return job.job_id()
     except Exception as exc:
         print(f"[quantum_bridge] IBM submission failed: {exc}")
@@ -326,13 +436,15 @@ def _poll_ibm_job(
     job_id: str,
     timeout_s: float = 300,
     poll_interval_s: float = 10,
-    ibm_token: Optional[str] = None,
 ) -> Optional[dict]:
     """
     Poll until job completes. Returns {counts, actual_seconds} or None.
+
+    FIX (2026-07-14):
+      - Uses _get_service() for auto-detected credentials.
+      - Uses _get_counts_from_result() for robust register-name detection.
     """
-    token = ibm_token or os.getenv("IBM_QUANTUM_TOKEN")
-    if not token:
+    if not _has_ibm_credentials():
         return None
 
     try:
@@ -341,7 +453,7 @@ def _poll_ibm_job(
         return None
 
     try:
-        service  = QiskitRuntimeService(channel="ibm_quantum", token=token)
+        service  = _get_service()
         job      = service.job(job_id)
         deadline = time.time() + timeout_s
 
@@ -355,7 +467,7 @@ def _poll_ibm_job(
             return None
 
         result         = job.result()
-        counts         = result[0].data.c.get_counts()
+        counts         = _get_counts_from_result(result)
         metrics        = job.metrics()
         actual_seconds = float(metrics.get("usage", {}).get("seconds", 0))
         return {"counts": counts, "actual_seconds": actual_seconds}
@@ -492,12 +604,10 @@ class QuantumBridge:
         self,
         shots: int = 1024,
         backend: str = "ibm_fez",
-        ibm_token: Optional[str] = None,
         poll_timeout_s: float = 300,
     ):
         self.shots          = shots
         self.backend        = backend
-        self.ibm_token      = ibm_token or os.getenv("IBM_QUANTUM_TOKEN")
         self.poll_timeout_s = poll_timeout_s
 
     def _load_prior_results(self, n: int = 5) -> list[dict]:
@@ -525,11 +635,10 @@ class QuantumBridge:
         ts = datetime.now(timezone.utc).isoformat()
         print(f"[quantum_bridge] starting cycle at {ts}")
 
-        token = self.ibm_token or os.getenv("IBM_QUANTUM_TOKEN")
-        if not token:
+        if not _has_ibm_credentials():
             print(
-                "[quantum_bridge] IBM_QUANTUM_TOKEN not set — experiments will dry-run. "
-                "To enable real shots: ensure IBM_QUANTUM_TOKEN is exported in ~/.vybn_keys"
+                "[quantum_bridge] No IBM Quantum credentials found — experiments will dry-run. "
+                "Set QISKIT_IBM_TOKEN (ibm_cloud) or IBM_QUANTUM_TOKEN (legacy) in the environment."
             )
 
         # 1. Read theory — cap at 4000 chars so Nemotron has budget for output
@@ -559,7 +668,6 @@ class QuantumBridge:
                 circuit_qasm,
                 shots=self.shots,
                 backend_name=self.backend,
-                ibm_token=self.ibm_token,
             )
             if job_id:
                 dry_run = False
@@ -575,7 +683,6 @@ class QuantumBridge:
                 obs = _poll_ibm_job(
                     job_id,
                     timeout_s=self.poll_timeout_s,
-                    ibm_token=self.ibm_token,
                 )
                 if obs:
                     reconcile_job(job_id, obs["actual_seconds"])
@@ -594,7 +701,7 @@ class QuantumBridge:
                     "top_deviations": [],
                     "actual_seconds": None,
                     "total_shots":    0,
-                    "note":           "dry-run: IBM token missing or qiskit submission failed",
+                    "note":           "dry-run: IBM credentials missing or qiskit submission failed",
                 }
         else:
             bs = budget_status() if BUDGET_AVAILABLE else {}
@@ -626,10 +733,11 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="Run a quantum bridge cycle.")
     parser.add_argument("--state",  default="{}", help="JSON state dict")
-    parser.add_argument("--dry-run", action="store_true", help="Force dry-run (ignore IBM token)")
+    parser.add_argument("--dry-run", action="store_true", help="Force dry-run (clear IBM credentials)")
     args = parser.parse_args()
 
     if args.dry_run:
+        os.environ.pop("QISKIT_IBM_TOKEN", None)
         os.environ.pop("IBM_QUANTUM_TOKEN", None)
 
     state  = json.loads(args.state)

--- a/spark/quantum_budget.py
+++ b/spark/quantum_budget.py
@@ -29,6 +29,11 @@ After IBM returns results, reconcile with actual execution time:
 
     from spark.quantum_budget import reconcile_job
     reconcile_job(job_id="abc123", actual_seconds=2.8)
+
+IBM QUANTUM API FIX (2026-07-14):
+  Uses _get_service() helper that auto-detects credentials from QISKIT_IBM_*
+  env vars (ibm_cloud channel) or falls back to IBM_QUANTUM_TOKEN (legacy
+  ibm_quantum channel). See quantum_bridge.py for details.
 """
 
 import json
@@ -198,22 +203,36 @@ def reconcile_job(job_id: str, actual_seconds: float) -> bool:
     return updated
 
 
-def get_ibm_job_duration(job_id: str, ibm_token: Optional[str] = None) -> Optional[float]:
+def _get_service():
+    """Create a QiskitRuntimeService using auto-detected credentials.
+
+    Shared logic with quantum_bridge.py — supports both QISKIT_IBM_TOKEN
+    (ibm_cloud channel, auto-detected) and IBM_QUANTUM_TOKEN (legacy).
+    """
+    from qiskit_ibm_runtime import QiskitRuntimeService
+
+    if os.getenv("QISKIT_IBM_TOKEN"):
+        return QiskitRuntimeService()
+
+    legacy_token = os.getenv("IBM_QUANTUM_TOKEN")
+    if legacy_token:
+        return QiskitRuntimeService(channel="ibm_quantum", token=legacy_token)
+
+    raise RuntimeError("No IBM Quantum credentials found in environment")
+
+
+def get_ibm_job_duration(job_id: str) -> Optional[float]:
     """
     Fetch the actual execution duration (in seconds) from IBM Quantum
     for a given job_id.
 
-    Requires the qiskit-ibm-runtime package and a valid IBM Quantum token
-    (from env var IBM_QUANTUM_TOKEN or passed directly).
+    FIX (2026-07-14): Uses _get_service() for auto-detected credentials
+    instead of hardcoding channel="ibm_quantum" with IBM_QUANTUM_TOKEN.
 
     Returns None if the job is not yet complete or the package is unavailable.
     """
-    token = ibm_token or os.getenv("IBM_QUANTUM_TOKEN")
-    if not token:
-        return None
     try:
-        from qiskit_ibm_runtime import QiskitRuntimeService
-        service = QiskitRuntimeService(channel="ibm_quantum", token=token)
+        service = _get_service()
         job     = service.job(job_id)
         metrics = job.metrics()
         # usage.seconds is the billed quantum time
@@ -222,14 +241,14 @@ def get_ibm_job_duration(job_id: str, ibm_token: Optional[str] = None) -> Option
         return None
 
 
-def auto_reconcile(ibm_token: Optional[str] = None) -> int:
+def auto_reconcile() -> int:
     """
     For every unreconciled ledger entry, try to fetch actual duration
     from IBM Quantum and update the ledger.
 
     Returns the number of entries successfully reconciled.
     """
-    entries   = _load_ledger()
+    entries    = _load_ledger()
     reconciled = 0
     for entry in entries:
         if entry.get("actual_seconds") is not None:
@@ -237,7 +256,7 @@ def auto_reconcile(ibm_token: Optional[str] = None) -> int:
         job_id = entry.get("job_id", "")
         if not job_id:
             continue
-        duration = get_ibm_job_duration(job_id, ibm_token)
+        duration = get_ibm_job_duration(job_id)
         if duration is not None:
             if reconcile_job(job_id, duration):
                 reconciled += 1


### PR DESCRIPTION
… handling

Five bugs fixed across quantum_bridge.py, quantum_budget.py, quantum_heartbeat.py:

1. WRONG ENV VAR: Code looked for IBM_QUANTUM_TOKEN; env has QISKIT_IBM_TOKEN. Now uses QiskitRuntimeService() with no args for auto-detection from QISKIT_IBM_* env vars, with IBM_QUANTUM_TOKEN as legacy fallback.

2. WRONG CHANNEL: Code hardcoded channel='ibm_quantum' (old API). Our credentials use ibm_cloud channel. Auto-detection handles this.

3. MISSING TRANSPILATION: Modern IBM backends require ISA circuits. Added _prepare_circuit() that transpiles via generate_preset_pass_manager.

4. DUPLICATE MEASUREMENTS: _submit_to_ibm called measure_all() on QASM circuits that already had measurements. _prepare_circuit() now checks first and only adds measurements if none exist.

5. FRAGILE RESULT PARSING: Hardcoded result[0].data.c.get_counts() broke when classical register wasn't named 'c'. Added _get_counts_from_result() that tries common names and falls back to attribute iteration.

Verified end-to-end: service connects, 4 backends visible (ibm_fez, ibm_torino, ibm_marrakesh, ibm_kingston), circuits transpile correctly, budget tracker works, no duplicate measurements.

Also installed qiskit 2.3.1 + qiskit-ibm-runtime 0.45.1 in the venv.

Note: Vybn_Mind/quantum_sheaf_bridge/chsh_generator.py and Vybn_Mind/experiments/godelian_falsification/mermin_bell_experiment.py also have old-style IBM credentials but are experimental scripts, not core infrastructure. Left for a follow-up.