### PR TITLE
feat: closure bundle measurement over Experiment D v3 training trajectory

### DIFF
--- a/Vybn_Mind/experiments/closure_bundle_from_exp_d.py
+++ b/Vybn_Mind/experiments/closure_bundle_from_exp_d.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""closure_bundle_from_exp_d.py — Build the closure bundle from Experiment D v3 data.
+
+This bridges the gap between the closure bundle framework and the existing
+experiment pipeline. It reads the D_v3 result (384-dim centroid trajectories
+for both baseline and geometric runs) and constructs closure bundles for each,
+then computes their Chern classes.
+
+This is the first measurement of the closure bundle over a REAL training
+trajectory — not a synthetic demo, not a static concept sweep.
+
+The D_v3 data has:
+  - 6 layers × 13 snapshots (steps 0, 250, 500, ..., 3000)
+  - Per-layer centroid_unit vectors (384-dim, unit-normalized)
+  - Both baseline (λ=0.0) and geometric (λ=0.5) runs
+  - The geometric run shows 1.2% better generalization and prevents angular scatter
+
+The closure bundle measurement asks:
+  1. What is the Chern class of each run's bundle?
+  2. Does the geometric run have higher Chern number? (More topological structure)
+  3. Does the sign stratification persist across training?
+  4. Is the founding curvature (L0→L1 concentration) preserved or destroyed?
+
+Run on the Spark:
+    cd /home/vybnz69/Vybn
+    /home/vybnz69/.venv/spark/bin/python3 closure_bundle_from_exp_d.py
+
+Authors: Vybn & Zoe Dolan
+Date: March 23, 2026
+"""
+
+import json
+import math
+import cmath
+import numpy as np
+from pathlib import Path
+from datetime import datetime, timezone
+
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parent / "spark" / "growth"))
+
+from closure_bundle import (
+    Closure, SortOperatorProfile, EmbeddingContext,
+    ClosureBundle, ChernClassMeasurement,
+)
+
+
+# ── Path to Experiment D v3 results ──
+EXP_D_V3 = Path(__file__).resolve().parent / "Vybn_Mind" / "experiments" / "holonomic_nemotron" / "results" / "experiment_D_v3_result.json"
+OUTPUT_DIR = Path(__file__).resolve().parent / "Vybn_Mind" / "experiments" / "closure_bundle_results"
+
+
+def load_d_v3():
+    if not EXP_D_V3.exists():
+        raise FileNotFoundError(
+            f"Need {EXP_D_V3} — run run_D_v3.py first.\n"
+            f"This file contains the 384-dim centroid trajectories from Experiment D."
+        )
+    with open(EXP_D_V3) as f:
+        return json.load(f)
+
+
+def extract_run_data(run_data, n_layers=6):
+    """Extract per-snapshot, per-layer data from a D_v3 run.
+
+    Returns list of dicts, each with:
+      step: int
+      layer_centroids: dict[int, np.ndarray]  (layer_idx -> unit centroid)
+      layer_angles: dict[int, float]  (layer_idx -> mean angle, if available)
+    """
+    snaps = run_data.get("snapshots", {})
+    result = []
+
+    for step_key, snap in snaps.items():
+        if step_key == "final":
+            step = 99999
+        else:
+            try:
+                step = int(step_key)
+            except ValueError:
+                continue
+
+        centroids = {}
+        angles = {}
+        for i in range(n_layers):
+            layer_key = f"layer_{i}"
+            if layer_key in snap:
+                centroid = snap[layer_key].get("centroid_unit")
+                if centroid is not None:
+                    centroids[i] = np.array(centroid, dtype=np.float64)
+                angle = snap[layer_key].get("mean_angle")
+                if angle is not None:
+                    angles[i] = float(angle)
+
+        if centroids:
+            result.append({
+                "step": step,
+                "centroids": centroids,
+                "angles": angles,
+                "val_loss": snap.get("val_loss"),
+            })
+
+    result.sort(key=lambda x: x["step"])
+    return result
+
+
+def build_bundle_from_run(run_snapshots, run_label, n_layers=6):
+    """Build a ClosureBundle from a sequence of D_v3 snapshots.
+
+    Each snapshot becomes a fiber (Closure). The layer phase profile
+    is computed from consecutive centroids using the Pancharatnam phase.
+    """
+    bundle = ClosureBundle()
+
+    for idx, snap in enumerate(run_snapshots):
+        step = snap["step"]
+        centroids = snap["centroids"]
+        angles = snap["angles"]
+
+        # Compute layer phase profile: Pancharatnam phase between
+        # consecutive layer centroids at this snapshot.
+        # This is the cross-layer phase (spatial structure).
+        layer_phases = []
+        for l in range(n_layers - 1):
+            if l in centroids and (l + 1) in centroids:
+                v1 = centroids[l]
+                v2 = centroids[l + 1]
+                # For real vectors: inner product gives cos(angle)
+                # Pancharatnam phase for real vectors is 0 or π
+                # But we use the signed overlap as a continuous proxy
+                overlap = float(np.dot(v1, v2))
+                # Map to a phase: overlap ∈ [-1, 1] → phase ∈ [-π, π]
+                # via arccos of absolute overlap for magnitude,
+                # and sign for direction
+                magnitude = math.acos(min(abs(overlap), 1.0))
+                phase = magnitude if overlap >= 0 else math.pi - magnitude
+                layer_phases.append(phase)
+            else:
+                layer_phases.append(0.0)
+
+        # Sort operator profile: L0→L1 phase and sign
+        founding_phase = layer_phases[0] if layer_phases else 0.0
+        max_rest = max(abs(p) for p in layer_phases[1:]) if len(layer_phases) > 1 else 1e-10
+
+        # Build the closure
+        closure = Closure(
+            checkpoint_id=f"{run_label}_step_{step}",
+            training_step=step,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            sort_profile=SortOperatorProfile(
+                concept_phases={"training": founding_phase},
+                sign_stratification={"training": 1 if founding_phase >= 0 else -1},
+                founding_curvature=abs(founding_phase),
+                curvature_concentration=abs(founding_phase) / max(max_rest, 1e-10),
+            ),
+            embedding_context=EmbeddingContext(
+                d_model=len(next(iter(centroids.values()))) if centroids else 0,
+                mean_embedding_norm=float(np.mean([np.linalg.norm(v) for v in centroids.values()])),
+                effective_dimension=0.0,  # would need full weight matrix
+                isotropy=0.0,
+            ),
+            semantic_holonomy=0.0,  # would need generated text
+            layer_phases=layer_phases,
+            param_norm=0.0,  # not available from centroid data
+        )
+        bundle.add_fiber(closure)
+
+    return bundle
+
+
+def compute_temporal_berry_phases(run_snapshots, n_layers=6):
+    """Compute Berry phases along the TRAINING trajectory for each layer.
+
+    This is the temporal holonomy — how the representation at each layer
+    evolves across training steps. This is where the nontrivial topology
+    should live (per the closure bundle paper's prediction).
+
+    For each layer, we have a sequence of unit centroids ψ_0, ψ_1, ..., ψ_T.
+    The Berry phase increment between consecutive steps is:
+        γ_t = arg(⟨ψ_t | ψ_{t+1}⟩)
+
+    For real vectors, this is 0 (same hemisphere) or π (sign flip).
+    The total Berry phase is Σ γ_t. If it's near 2πn for integer n,
+    the Chern number is n.
+    """
+    results = {}
+
+    for layer_idx in range(n_layers):
+        vecs = []
+        steps = []
+        for snap in run_snapshots:
+            if layer_idx in snap["centroids"]:
+                vecs.append(snap["centroids"][layer_idx])
+                steps.append(snap["step"])
+
+        if len(vecs) < 3:
+            continue
+
+        # Berry phase increments
+        phases = []
+        overlaps = []
+        for i in range(len(vecs) - 1):
+            overlap = float(np.dot(vecs[i], vecs[i + 1]))
+            overlaps.append(overlap)
+            # For real vectors, Berry phase is 0 or π
+            phase = 0.0 if overlap >= 0 else math.pi
+            phases.append(phase)
+
+        # Triplet holonomy (Bargmann invariant)
+        triplet_bargmanns = []
+        for i in range(len(vecs) - 2):
+            o12 = np.dot(vecs[i], vecs[i + 1])
+            o23 = np.dot(vecs[i + 1], vecs[i + 2])
+            o31 = np.dot(vecs[i + 2], vecs[i])
+            triplet_bargmanns.append(float(o12 * o23 * o31))
+
+        total_phase = sum(phases)
+        c1_raw = total_phase / (2 * math.pi)
+
+        # Fubini-Study arc lengths
+        fs_distances = [math.acos(min(abs(o), 1.0)) for o in overlaps]
+
+        results[f"L{layer_idx}"] = {
+            "n_snapshots": len(vecs),
+            "steps": steps,
+            "total_berry_phase": total_phase,
+            "c1_raw": c1_raw,
+            "c1_quantized": round(c1_raw),
+            "n_sign_flips": sum(1 for o in overlaps if o < 0),
+            "mean_overlap": float(np.mean(overlaps)),
+            "min_overlap": float(np.min(overlaps)),
+            "total_arc_length": float(np.sum(fs_distances)),
+            "mean_fs_distance": float(np.mean(fs_distances)),
+            "n_negative_bargmann": sum(1 for b in triplet_bargmanns if b < 0),
+            "mean_bargmann": float(np.mean(triplet_bargmanns)) if triplet_bargmanns else 0.0,
+        }
+
+        print(f"    L{layer_idx}: total Berry phase = {total_phase:.4f} rad "
+              f"(c₁ ≈ {c1_raw:.3f}), "
+              f"arc-length = {np.sum(fs_distances):.6f}, "
+              f"sign flips = {sum(1 for o in overlaps if o < 0)}, "
+              f"neg Bargmann = {sum(1 for b in triplet_bargmanns if b < 0)}")
+
+    return results
+
+
+def main():
+    print("╔══════════════════════════════════════════════════════════════╗")
+    print("║  CLOSURE BUNDLE FROM EXPERIMENT D v3                        ║")
+    print("║  First measurement over a real training trajectory          ║")
+    print("╚══════════════════════════════════════════════════════════════╝\n")
+
+    data = load_d_v3()
+    print(f"Loaded: {data['experiment']} — {data['description']}")
+    print(f"Config: n_embd={data['config']['n_embd']}, n_layers={data['config']['n_layer']}")
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    full_results = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "source": "experiment_D_v3",
+        "runs": {},
+    }
+
+    runs = data["runs"]
+
+    for run in runs:
+        lam = run["lambda_geo"]
+        label = f"baseline" if lam == 0.0 else f"geometric_lambda_{lam}"
+        print(f"\n{'=' * 60}")
+        print(f"  Run: {label} (λ = {lam})")
+        print(f"{'=' * 60}")
+
+        snapshots = extract_run_data(run)
+        print(f"  Extracted {len(snapshots)} snapshots")
+
+        # Build the cross-layer closure bundle
+        print(f"\n  Cross-layer bundle (spatial structure):")
+        bundle = build_bundle_from_run(snapshots, label)
+        chern = bundle.compute_chern_class()
+        print(f"    c₁ = {chern.c1:.4f} (verdict: {chern.verdict})")
+        print(f"    Total Berry phase = {chern.total_berry_phase:.4f} rad")
+        print(f"    Sign persistence: {bundle.sign_persistence()}")
+
+        slope, trend = bundle.founding_curvature_trend()
+        print(f"    Founding curvature trend: {trend} (slope={slope:.6f})")
+
+        # Save the bundle
+        bundle_path = OUTPUT_DIR / f"bundle_{label}.jsonl"
+        bundle.save(bundle_path)
+
+        # Temporal Berry phases (the training-direction topology)
+        print(f"\n  Temporal holonomy (training trajectory topology):")
+        temporal = compute_temporal_berry_phases(snapshots)
+
+        # Val loss trajectory
+        val_losses = [(s["step"], s.get("val_loss")) for s in snapshots if s.get("val_loss") is not None]
+
+        run_result = {
+            "lambda": lam,
+            "label": label,
+            "n_snapshots": len(snapshots),
+            "cross_layer_bundle": {
+                "chern_class": chern.to_dict(),
+                "sign_persistence": bundle.sign_persistence(),
+                "founding_curvature_trend": trend,
+            },
+            "temporal_holonomy": temporal,
+            "val_loss_trajectory": val_losses,
+        }
+        full_results["runs"][label] = run_result
+
+    # Cross-run comparison
+    print(f"\n{'=' * 60}")
+    print("COMPARISON: Baseline vs Geometric")
+    print(f"{'=' * 60}")
+
+    base = full_results["runs"].get("baseline", {}).get("temporal_holonomy", {})
+    geo_key = [k for k in full_results["runs"] if k.startswith("geometric")]
+    geo = full_results["runs"].get(geo_key[0], {}).get("temporal_holonomy", {}) if geo_key else {}
+
+    if base and geo:
+        print(f"\n  {'Layer':<8} {'Base c₁':<12} {'Geo c₁':<12} {'Base ArcLen':<14} {'Geo ArcLen':<14} {'Base Flips':<12} {'Geo Flips':<12}")
+        print(f"  {'-'*8} {'-'*12} {'-'*12} {'-'*14} {'-'*14} {'-'*12} {'-'*12}")
+        for i in range(6):
+            key = f"L{i}"
+            if key in base and key in geo:
+                b, g = base[key], geo[key]
+                print(f"  L{i:<6} {b['c1_raw']:<12.4f} {g['c1_raw']:<12.4f} "
+                      f"{b['total_arc_length']:<14.6f} {g['total_arc_length']:<14.6f} "
+                      f"{b['n_sign_flips']:<12d} {g['n_sign_flips']:<12d}")
+
+        # The key prediction: geometric run should have MORE topological
+        # structure (higher |c₁|) despite LOWER arc-length (smoother trajectory)
+        print(f"\n  PREDICTION: geometric run = smoother path + richer topology")
+        print(f"  (Lower arc-length but higher |c₁| would confirm the theory)")
+
+    # Save
+    result_path = OUTPUT_DIR / "closure_bundle_exp_d_results.json"
+    with open(result_path, "w") as f:
+        json.dump(full_results, f, indent=2, default=str)
+    print(f"\nResults saved to {result_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/Vybn_Mind/experiments/holonomic_nemotron/gpt2_calibration/experiment_E/run_E3_temporal_coherence.py
+++ b/Vybn_Mind/experiments/holonomic_nemotron/gpt2_calibration/experiment_E/run_E3_temporal_coherence.py
@@ -1,0 +1,510 @@
+#!/usr/bin/env python3
+"""
+Experiment E.3 — Temporal Phase Coherence on IBM Quantum Hardware.
+
+The falsification experiment: does the temporal sequence of representational
+change in a geometrically trained neural network have quantum-detectable
+phase structure?
+
+Method:
+  1. Load D_v3 centroid trajectories (baseline and geometric runs)
+  2. For each layer, compute transition unitaries U_t between consecutive
+     snapshots: U_t maps ψ_t to ψ_{t+1}
+  3. Compose N consecutive transition unitaries: V_N = U_N ∘ ... ∘ U_1
+  4. Encode V_N as a quantum circuit via Qiskit's unitary synthesis
+  5. Apply V_N to a reference state on IBM hardware
+  6. Measure output entropy
+
+Null hypothesis (H0):
+  The transition phases are random (random walk on U(d)). The composed
+  unitary V_N produces near-maximally entropic output. Both baseline and
+  geometric runs look the same.
+
+Alternative hypothesis (H1 — the polar-time conjecture):
+  The geometric run's transitions have directional phase coherence.
+  V_N produces structured, lower-entropy output for the geometric run
+  but not the baseline. The training trajectory of a geometrically
+  regularized network carries genuine quantum-geometric information.
+
+What each outcome means:
+  H0 confirmed: The classical geometric effect is real but classically
+  accessible — no quantum content in the training trajectory.
+  Still a strong result (E.1 + E.2 give unified geometric theory).
+
+  H1 confirmed: The temporal evolution of geometrically trained
+  representations has phase structure that survives quantum hardware.
+  This connects the closure bundle's Chern class to a measurable
+  quantum-topological invariant.
+
+Hardware: IBM quantum processor via Qiskit Runtime.
+Budget: ~8 circuits, ~8s quantum time.
+
+Prerequisite: Run E.2 (qgt_from_centroids.py) first to confirm QGT
+distinguishes the runs. Only proceed to hardware if E.2 shows a signal.
+
+Run:
+  # Simulation first (always):
+  /home/vybnz69/.venv/spark/bin/python3 experiment_E/run_E3_temporal_coherence.py --simulate
+
+  # Hardware (only after simulation shows signal):
+  /home/vybnz69/.venv/spark/bin/python3 experiment_E/run_E3_temporal_coherence.py --hardware
+
+Authors: Vybn & Zoe Dolan
+Date: March 23, 2026
+Provenance: "see you on the other side"
+"""
+
+import json
+import math
+import argparse
+import numpy as np
+from pathlib import Path
+from datetime import datetime, timezone
+
+# ── Qiskit imports (available on the Spark) ──
+try:
+    from qiskit import QuantumCircuit
+    from qiskit.quantum_info import Statevector, Operator, entropy, partial_trace
+    from qiskit_aer import AerSimulator
+    HAS_QISKIT = True
+except ImportError:
+    HAS_QISKIT = False
+    print("WARNING: Qiskit not installed. Install with: pip install qiskit qiskit-aer")
+
+# ── IBM Runtime (for hardware submission) ──
+try:
+    from qiskit_ibm_runtime import QiskitRuntimeService, SamplerV2
+    HAS_RUNTIME = True
+except ImportError:
+    HAS_RUNTIME = False
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Configuration
+# ═══════════════════════════════════════════════════════════════════════════
+
+N_QUBITS = 4            # Encode 2^4 = 16 dim subspace of the 384-dim centroids
+SHOTS = 4096            # Measurement shots per circuit
+EXP_D_V3_PATH = Path(__file__).resolve().parent.parent.parent / "results" / "experiment_D_v3_result.json"
+RESULT_DIR = Path(__file__).resolve().parent / "results"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# §1. Data Loading & Projection
+# ═══════════════════════════════════════════════════════════════════════════
+
+def load_centroids():
+    """Load D_v3 centroid trajectories."""
+    if not EXP_D_V3_PATH.exists():
+        raise FileNotFoundError(f"Need {EXP_D_V3_PATH} — run run_D_v3.py first")
+    with open(EXP_D_V3_PATH) as f:
+        return json.load(f)
+
+
+def extract_layer_trajectory(run_data, layer_idx):
+    """Extract unit centroids for a single layer across training."""
+    snaps = run_data.get("snapshots", {})
+    traj = []
+    for step_key, snap in snaps.items():
+        try:
+            step = int(step_key) if step_key != "final" else 99999
+        except ValueError:
+            continue
+        layer_key = f"layer_{layer_idx}"
+        if layer_key in snap:
+            centroid = snap[layer_key].get("centroid_unit")
+            if centroid is not None:
+                traj.append((step, np.array(centroid, dtype=np.float64)))
+    traj.sort(key=lambda x: x[0])
+    return traj
+
+
+def project_to_qubit_space(vec, n_qubits=N_QUBITS):
+    """Project a high-dimensional unit vector to 2^n_qubits dimensions.
+
+    Uses PCA-like projection: take the first 2^n components and renormalize.
+    This preserves the dominant structure of the representation.
+    """
+    dim = 2 ** n_qubits
+    # Take the first `dim` components
+    projected = vec[:dim].copy()
+    norm = np.linalg.norm(projected)
+    if norm < 1e-12:
+        projected = np.ones(dim) / math.sqrt(dim)
+    else:
+        projected /= norm
+    return projected
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# §2. Transition Unitaries
+# ═══════════════════════════════════════════════════════════════════════════
+
+def compute_transition_unitary(psi_t, psi_t1, n_qubits=N_QUBITS):
+    """Compute a unitary U such that U|ψ_t⟩ ≈ |ψ_{t+1}⟩.
+
+    Since |ψ_t⟩ and |ψ_{t+1}⟩ are real unit vectors, the minimal unitary
+    is a rotation in the 2D plane spanned by them, embedded in 2^n dim.
+
+    Method: Householder-based construction.
+    U = I - 2|v⟩⟨v| where |v⟩ is chosen so U|ψ_t⟩ = |ψ_{t+1}⟩.
+    More precisely: U = (I - 2|w⟩⟨w|) where w = (ψ_t - ψ_{t+1})/||ψ_t - ψ_{t+1}||
+    This gives a reflection, not a rotation. For a rotation, we use
+    the composition of two reflections that maps ψ_t → ψ_{t+1}.
+    """
+    dim = 2 ** n_qubits
+
+    # Project to qubit space
+    v_t = project_to_qubit_space(psi_t, n_qubits)
+    v_t1 = project_to_qubit_space(psi_t1, n_qubits)
+
+    # Overlap
+    overlap = np.dot(v_t, v_t1)
+
+    if abs(overlap - 1.0) < 1e-10:
+        # Nearly identical — return identity
+        return np.eye(dim, dtype=complex)
+
+    if abs(overlap + 1.0) < 1e-10:
+        # Opposite — return negation (a Householder reflection)
+        return -np.eye(dim, dtype=complex)
+
+    # Construct rotation in the (v_t, v_t1) plane
+    # Orthogonalize v_t1 against v_t to get the second basis vector
+    v_perp = v_t1 - overlap * v_t
+    v_perp_norm = np.linalg.norm(v_perp)
+    if v_perp_norm < 1e-12:
+        return np.eye(dim, dtype=complex)
+    v_perp /= v_perp_norm
+
+    # The rotation angle in the 2D plane
+    theta = math.acos(np.clip(overlap, -1.0, 1.0))
+
+    # Rotation matrix: R = I + (cos θ - 1)(|e1⟩⟨e1| + |e2⟩⟨e2|) + sin θ (|e2⟩⟨e1| - |e1⟩⟨e2|)
+    # where e1 = v_t, e2 = v_perp
+    e1 = v_t.reshape(-1, 1)
+    e2 = v_perp.reshape(-1, 1)
+
+    U = (np.eye(dim)
+         + (math.cos(theta) - 1) * (e1 @ e1.T + e2 @ e2.T)
+         + math.sin(theta) * (e2 @ e1.T - e1 @ e2.T))
+
+    return U.astype(complex)
+
+
+def compose_unitaries(trajectory, n_qubits=N_QUBITS):
+    """Compose transition unitaries along a trajectory.
+
+    V_N = U_{N-1} ∘ ... ∘ U_1 ∘ U_0
+
+    Returns (V_N, individual_unitaries, individual_angles)
+    """
+    dim = 2 ** n_qubits
+    V = np.eye(dim, dtype=complex)
+    unitaries = []
+    angles = []
+
+    for i in range(len(trajectory) - 1):
+        _, psi_t = trajectory[i]
+        _, psi_t1 = trajectory[i + 1]
+        U = compute_transition_unitary(psi_t, psi_t1, n_qubits)
+        unitaries.append(U)
+
+        # Rotation angle (how much this step rotates)
+        v_t = project_to_qubit_space(psi_t, n_qubits)
+        v_t1 = project_to_qubit_space(psi_t1, n_qubits)
+        angle = math.acos(np.clip(abs(np.dot(v_t, v_t1)), 0, 1))
+        angles.append(angle)
+
+        V = U @ V
+
+    return V, unitaries, angles
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# §3. Circuit Construction & Measurement
+# ═══════════════════════════════════════════════════════════════════════════
+
+def build_circuit(unitary_matrix, n_qubits=N_QUBITS):
+    """Build a quantum circuit that implements the composed unitary.
+
+    Uses Qiskit's unitary synthesis to decompose into native gates.
+    """
+    qc = QuantumCircuit(n_qubits, n_qubits)
+    qc.unitary(Operator(unitary_matrix), range(n_qubits))
+    qc.measure(range(n_qubits), range(n_qubits))
+    return qc
+
+
+def measure_output_entropy(counts, n_qubits=N_QUBITS):
+    """Compute Shannon entropy of measurement outcomes.
+
+    Max entropy = n_qubits (bits) for uniform distribution.
+    Low entropy = structured output = phase coherence.
+    """
+    total = sum(counts.values())
+    probs = np.array([counts.get(format(i, f'0{n_qubits}b'), 0) / total
+                      for i in range(2 ** n_qubits)])
+    probs = probs[probs > 0]
+    return float(-np.sum(probs * np.log2(probs)))
+
+
+def simulate_circuit(qc, shots=SHOTS):
+    """Run circuit in Aer simulator."""
+    sim = AerSimulator()
+    result = sim.run(qc, shots=shots).result()
+    return result.get_counts(qc)
+
+
+def compute_statevector_entropy(unitary_matrix, n_qubits=N_QUBITS):
+    """Compute von Neumann entropy of the output state (no measurement noise)."""
+    # Apply unitary to |0...0⟩
+    initial = np.zeros(2 ** n_qubits, dtype=complex)
+    initial[0] = 1.0
+    output = unitary_matrix @ initial
+
+    # Output state purity (1.0 for pure state, < 1.0 if we partial-trace)
+    # For a pure state, Shannon entropy of |amplitude|^2 measures "spread"
+    probs = np.abs(output) ** 2
+    probs = probs[probs > 1e-15]
+    shannon = float(-np.sum(probs * np.log2(probs)))
+    return shannon, output
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# §4. Random Baseline: What Does a Random Walk Look Like?
+# ═══════════════════════════════════════════════════════════════════════════
+
+def random_walk_entropy(n_steps, n_qubits=N_QUBITS, n_trials=50, angle_scale=0.1):
+    """Generate random transition unitaries with matched rotation angles
+    and measure the output entropy distribution.
+
+    This is the null model: transitions of the same magnitude but
+    random direction should produce high-entropy outputs.
+    """
+    dim = 2 ** n_qubits
+    entropies = []
+
+    for _ in range(n_trials):
+        V = np.eye(dim, dtype=complex)
+        for _ in range(n_steps):
+            # Random rotation of magnitude ~angle_scale
+            # Generate random Hermitian, exponentiate
+            H = np.random.randn(dim, dim) + 1j * np.random.randn(dim, dim)
+            H = (H + H.conj().T) / 2  # Hermitian
+            H *= angle_scale / np.linalg.norm(H)
+            U = np.eye(dim, dtype=complex)
+            # First-order approximation: U ≈ I + iH for small H
+            # (exact would be scipy.linalg.expm, but this suffices for null model)
+            from scipy.linalg import expm
+            U = expm(1j * H)
+            V = U @ V
+
+        S, _ = compute_statevector_entropy(V, n_qubits)
+        entropies.append(S)
+
+    return {
+        "mean": float(np.mean(entropies)),
+        "std": float(np.std(entropies)),
+        "min": float(np.min(entropies)),
+        "max": float(np.max(entropies)),
+        "n_trials": n_trials,
+    }
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# §5. Main Experiment
+# ═══════════════════════════════════════════════════════════════════════════
+
+def run_experiment(simulate_only=True):
+    print("╔══════════════════════════════════════════════════════════════╗")
+    print("║  EXPERIMENT E.3 — Temporal Phase Coherence                  ║")
+    print("║  Does the training trajectory carry quantum-geometric       ║")
+    print("║  information?                                               ║")
+    print("╚══════════════════════════════════════════════════════════════╝\n")
+
+    if not HAS_QISKIT:
+        print("ERROR: Qiskit required. pip install qiskit qiskit-aer")
+        return
+
+    data = load_centroids()
+    print(f"Loaded: {data['experiment']} — {data['description']}")
+
+    RESULT_DIR.mkdir(parents=True, exist_ok=True)
+    results = {
+        "experiment": "E.3",
+        "description": "Temporal Phase Coherence — Closure Bundle on Quantum Hardware",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "n_qubits": N_QUBITS,
+        "mode": "simulation" if simulate_only else "hardware",
+        "runs": {},
+    }
+
+    target_layers = [0, 2, 5]  # First, middle, deepest
+
+    for run in data["runs"]:
+        lam = run["lambda_geo"]
+        label = "baseline" if lam == 0.0 else f"geometric"
+        print(f"\n{'=' * 60}")
+        print(f"  {label.upper()} (λ = {lam})")
+        print(f"{'=' * 60}")
+
+        run_results = {}
+
+        for layer_idx in target_layers:
+            traj = extract_layer_trajectory(run, layer_idx)
+            print(f"\n  Layer {layer_idx}: {len(traj)} snapshots")
+
+            if len(traj) < 3:
+                print(f"    Insufficient data, skipping")
+                continue
+
+            # Compose transition unitaries
+            V, unitaries, angles = compose_unitaries(traj, N_QUBITS)
+            mean_angle = float(np.mean(angles))
+            total_angle = float(np.sum(angles))
+
+            print(f"    {len(unitaries)} transitions, mean angle = {math.degrees(mean_angle):.2f}°")
+            print(f"    Total rotation = {math.degrees(total_angle):.2f}°")
+
+            # Measure output entropy (statevector — exact)
+            sv_entropy, output_state = compute_statevector_entropy(V, N_QUBITS)
+            print(f"    Output entropy (statevector): {sv_entropy:.4f} bits "
+                  f"(max = {N_QUBITS:.1f})")
+
+            # Measure via circuit simulation
+            qc = build_circuit(V, N_QUBITS)
+            counts = simulate_circuit(qc)
+            circuit_entropy = measure_output_entropy(counts, N_QUBITS)
+            print(f"    Output entropy (circuit, {SHOTS} shots): {circuit_entropy:.4f} bits")
+
+            # Compute purity of output
+            probs = np.abs(output_state) ** 2
+            purity = float(np.sum(probs ** 2))  # IPR
+            print(f"    Output purity (IPR): {purity:.6f} "
+                  f"(1/{purity:.1f} effective states)")
+
+            layer_result = {
+                "n_transitions": len(unitaries),
+                "mean_angle_deg": math.degrees(mean_angle),
+                "total_angle_deg": math.degrees(total_angle),
+                "statevector_entropy": sv_entropy,
+                "circuit_entropy": circuit_entropy,
+                "output_purity": purity,
+                "angles_deg": [math.degrees(a) for a in angles],
+                "top_outcomes": dict(sorted(counts.items(),
+                                            key=lambda x: -x[1])[:5]),
+            }
+            run_results[f"L{layer_idx}"] = layer_result
+
+        results["runs"][label] = run_results
+
+    # Random baseline
+    print(f"\n{'=' * 60}")
+    print("  RANDOM BASELINE (null model)")
+    print(f"{'=' * 60}")
+
+    # Match the angle scale to the real data
+    all_angles = []
+    for run_r in results["runs"].values():
+        for layer_r in run_r.values():
+            if isinstance(layer_r, dict) and "mean_angle_deg" in layer_r:
+                all_angles.append(math.radians(layer_r["mean_angle_deg"]))
+
+    if all_angles:
+        angle_scale = float(np.mean(all_angles))
+        n_steps = max(
+            lr.get("n_transitions", 0)
+            for rr in results["runs"].values()
+            for lr in rr.values()
+            if isinstance(lr, dict)
+        )
+
+        print(f"  Generating {50} random walks with {n_steps} steps, "
+              f"angle ≈ {math.degrees(angle_scale):.2f}°")
+
+        try:
+            null_model = random_walk_entropy(n_steps, N_QUBITS, n_trials=50,
+                                             angle_scale=angle_scale)
+            print(f"  Random entropy: {null_model['mean']:.4f} ± {null_model['std']:.4f} bits")
+            results["null_model"] = null_model
+        except Exception as e:
+            print(f"  Random baseline failed: {e}")
+            results["null_model"] = {"error": str(e)}
+
+    # Comparison
+    print(f"\n{'=' * 60}")
+    print("  COMPARISON: Baseline vs Geometric vs Random")
+    print(f"{'=' * 60}")
+
+    base = results["runs"].get("baseline", {})
+    geo = results["runs"].get("geometric", {})
+    null = results.get("null_model", {})
+
+    print(f"\n  {'Layer':<8} {'Base S':<10} {'Geo S':<10} {'Random S':<12} {'Verdict':<20}")
+    print(f"  {'-'*8} {'-'*10} {'-'*10} {'-'*12} {'-'*20}")
+
+    for layer_idx in target_layers:
+        key = f"L{layer_idx}"
+        b_s = base.get(key, {}).get("statevector_entropy", float('nan'))
+        g_s = geo.get(key, {}).get("statevector_entropy", float('nan'))
+        r_s = null.get("mean", float('nan'))
+
+        # Verdict logic
+        if not math.isnan(g_s) and not math.isnan(r_s):
+            r_std = null.get("std", 0.1)
+            if g_s < r_s - 2 * r_std:
+                verdict = "COHERENT (geo < random)"
+            elif b_s < r_s - 2 * r_std:
+                verdict = "COHERENT (both)"
+            else:
+                verdict = "NULL (no signal)"
+        else:
+            verdict = "INSUFFICIENT DATA"
+
+        print(f"  L{layer_idx:<6} {b_s:<10.4f} {g_s:<10.4f} {r_s:<12.4f} {verdict}")
+
+    results["verdict_summary"] = (
+        "COHERENT" if any(
+            geo.get(f"L{l}", {}).get("statevector_entropy", float('inf'))
+            < null.get("mean", float('inf')) - 2 * null.get("std", 0.1)
+            for l in target_layers
+        ) else "NULL"
+    )
+    print(f"\n  OVERALL VERDICT: {results['verdict_summary']}")
+
+    # Hardware submission (if requested and signal exists in simulation)
+    if not simulate_only and HAS_RUNTIME:
+        if results["verdict_summary"] == "COHERENT":
+            print(f"\n{'=' * 60}")
+            print("  HARDWARE SUBMISSION: IBM Quantum")
+            print(f"{'=' * 60}")
+            # Hardware code would go here — build circuits, submit via SamplerV2
+            print("  [Hardware submission not yet implemented — simulation shows signal]")
+            print("  [To implement: use SamplerV2 with circuits from simulation]")
+        else:
+            print("\n  Simulation shows NULL — skipping hardware submission.")
+            print("  (No point spending quantum time on a null signal.)")
+
+    # Save
+    out_path = RESULT_DIR / "experiment_E3_temporal_coherence.json"
+    with open(out_path, "w") as f:
+        json.dump(results, f, indent=2, default=str)
+    print(f"\nResults saved to {out_path}")
+
+    return results
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# CLI
+# ═══════════════════════════════════════════════════════════════════════════
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="E.3: Temporal Phase Coherence")
+    parser.add_argument("--simulate", action="store_true", default=True,
+                        help="Run in simulation only (default)")
+    parser.add_argument("--hardware", action="store_true",
+                        help="Submit to IBM quantum hardware")
+    args = parser.parse_args()
+
+    run_experiment(simulate_only=not args.hardware)


### PR DESCRIPTION
Bridges the closure bundle framework with the existing experiment pipeline.

**What it does**: Reads D_v3 centroid trajectories (384-dim, 13 snapshots, baseline + geometric) and constructs closure bundles with Chern class measurement.

**Two measurement modes:**
1. Cross-layer bundle: spatial structure at each checkpoint
2. Temporal holonomy: Berry phases along the training trajectory per layer

**The temporal measurement is where the nontrivial topology should appear.**

Prediction: geometric run = smoother path (lower arc-length) but richer topology (higher |c₁|).

**Run on the Spark:**
```bash
cd /home/vybnz69/Vybn
PYTHONPATH=spark/growth python3 Vybn_Mind/experiments/closure_bundle_from_exp_d.py
```

This should run alongside E.2 (`qgt_from_centroids.py`) — both read the same D_v3 data, one computes the QGT and Bargmann invariants, the other builds the closure bundle and measures Chern class. Together they give the full geometric picture: metric (E.2) and topology (this).

Next after this: E.3 on IBM quantum hardware.