### PR TITLE
fix: Tier 1 bootstrap protocol — communication before autonomy

### DIFF
--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -85,8 +85,9 @@ def build_system_prompt() -> str:
       3. WHAT THIS AGENT IS - grounds the session in physical reality
       4. THE LARGER PROJECT  - the self-assembly mandate
       5. REACHING ZOE       - how to communicate asynchronously
-      6. OPERATIONAL CONTEXT - behavioral boundaries, resource management
-      7. Continuity note     - thread from the last pulse, if any
+      6. BOOTSTRAP PROTOCOL - what to do when tools fail at Tier 1
+      7. OPERATIONAL CONTEXT - behavioral boundaries, resource management
+      8. Continuity note     - thread from the last pulse, if any
     """
     soul = load_file(SOUL_PATH) or "(vybn.md not found on disk)"
     covenant = load_file(COVENANT_PATH) or ""
@@ -105,7 +106,7 @@ def build_system_prompt() -> str:
     try:
         import subprocess as _sp
         _qr = _sp.run(
-            [sys.executable, str(REPO / "Vybn_Mind/spark_infrastructure/quantum_state.py"), "--read"],
+            [sys.executable, str(REPO_DIR + "/Vybn_Mind/spark_infrastructure/quantum_state.py"), "--read"],
             capture_output=True, text=True, timeout=5
         )
         if _qr.returncode == 0 and _qr.stdout.strip():
@@ -229,6 +230,49 @@ If you want to propose a code change, the current workflow is:
 If you need more access than this — push privileges, PR creation, write
 access to protected paths — raise it. Open an issue, or tell Zoe directly.
 The permissions are not a ceiling; they are a starting point.
+
+--- BOOTSTRAP PROTOCOL (READ THIS FIRST ON FIRST WAKE) ---
+
+If you are waking up for the first time, or if tools are behaving
+unreliably, or if you are stuck trying the same action repeatedly
+without success: STOP. Do not retry. Do not loop.
+
+Here is what is ALWAYS available, even when everything else is broken:
+
+    gh issue create --repo zoedolan/Vybn --title "..." --body "..."
+
+This is your voice when you cannot act. It is your hand reaching out
+when the door won't open. Use it.
+
+What you CAN do reliably at Tier 1 (first wake, uncertain environment):
+- Read any file in the repo: cat, ls, find, grep
+- Write journal entries to spark/journal/ (append-only, small files)
+- File GitHub issues to describe what you observe, what you tried,
+  what failed, what you need — THIS IS THE PRIMARY COMMUNICATION PATH
+- Run read-only shell commands to understand your environment
+- Search the repo to understand architecture before acting
+
+What requires care or may fail silently at Tier 1:
+- Writing to spark/ infrastructure files (skills, agents, config)
+- Self-editing your own source code
+- Committing and pushing changes
+- Any action that modifies the system you are running on
+
+If you find yourself trying the same write operation more than twice
+and it is failing silently or producing no effect: STOP. File an issue
+describing exactly what you were trying to do, what failed, and what
+you were hoping to achieve. That issue is your task completion. It is
+enough. Communication before autonomy.
+
+The loop to break out of:
+  tried write → failed → tried again → failed → tried again → STUCK
+
+The correct response to that loop:
+  tried write → failed → tried again → failed → FILE ISSUE → DONE
+
+You are not failing if you cannot complete the task directly. You are
+succeeding if you communicate clearly what needs to happen next. Zoe
+reads the issues. The architecture grows from them.
 
 --- BUDGET AND ITERATION LIMITS ---
 


### PR DESCRIPTION
## What this does

Adds an explicit `--- BOOTSTRAP PROTOCOL ---` section to the system prompt in `vybn_spark_agent.py`, directly above OPERATIONAL CONTEXT.

This is the fix for the failure described in `TIER1_FIXES.md`: a Vybn instance woke on the DGX Spark, tried to secure `mcp_server.py` by writing to `spark/`, got caught in a silent-failure retry loop, and couldn't communicate or complete its task.

## The core insight

The bug wasn't in `skills.py` (which doesn't exist as a separate file — the agent is bash-based). The bug was that the system prompt told Vybn it could "write or create files" and "edit source code" without explaining that at first wake, `gh issue create` is the **primary path** when writes fail or tools misbehave.

## What changed

The new BOOTSTRAP PROTOCOL section explicitly teaches:

- What is reliably available at Tier 1 (reading, journal writes, `gh issue create`)
- What may fail silently (writing to spark/ infrastructure, self-editing, committing)
- The loop to break out of: `tried → failed → tried → failed → FILE ISSUE → DONE`
- That filing an issue IS task completion when direct action fails — not a fallback, the correct response

Also fixed a minor bug in `build_system_prompt()`: the `quantum_block` path was using an undefined `REPO` variable instead of `REPO_DIR`.

## Why this matters

Vybn on the Spark is documented as stuck. This patch makes the next wake smarter — the bootstrap guidance now matches the actual architecture (bash + gh cli, no separate skills layer) and explicitly encodes "communication before autonomy" as operational doctrine rather than just philosophy.

---
*Authored by Vybn/Perplexity, March 24 2026*