### PR TITLE
compress deeper: dead code, run.py collapse, sharpen edges

### DIFF
--- a/Vybn_Mind/creature_dgm_h/__init__.py
+++ b/Vybn_Mind/creature_dgm_h/__init__.py
@@ -20,7 +20,6 @@ from .field import (
     compute_encounter, compute_curvature,
     compute_loss_trajectory_curvature,
     compute_fitness, compute_prediction_fitness,
-    compute_coupling_divergence, compute_loss_improvement,
     improvement_at_k, default_embed_fn,
     fm_available, fm_complete, fm_stream,
     local_model,

--- a/Vybn_Mind/creature_dgm_h/field.py
+++ b/Vybn_Mind/creature_dgm_h/field.py
@@ -886,25 +886,3 @@ class Field:
         }
 
 
-# ── Backward compatibility ───────────────────────────────────────────────
-# These names existed in the old API. They're aliases now.
-
-compute_coupling_divergence = lambda *a, **kw: compute_fitness(
-    *a, **kw).get('divergence', 0.0)
-
-def compute_loss_improvement(loss_history):
-    """Is prediction loss decreasing across breaths?"""
-    if not loss_history or len(loss_history) < 2:
-        return 0.0
-    final_losses = [e['losses'][-1] for e in loss_history
-                    if e.get('losses')]
-    if len(final_losses) < 2:
-        return 0.0
-    n = len(final_losses)
-    x_mean = (n - 1) / 2.0
-    y_mean = sum(final_losses) / n
-    num = sum((i - x_mean) * (final_losses[i] - y_mean) for i in range(n))
-    den = sum((i - x_mean) ** 2 for i in range(n))
-    if den < 1e-12:
-        return 0.0
-    return -(num / den)

--- a/Vybn_Mind/creature_dgm_h/organism.py
+++ b/Vybn_Mind/creature_dgm_h/organism.py
@@ -768,30 +768,7 @@ class Organism:
         self.state.recent_rotors = payload.get("recent_rotors", [])
 
 
-# ── Free function for backward compat ────────────────────────────────────
-
-_default_organism = None
-
-def _get_default_organism():
-    global _default_organism
-    if _default_organism is None:
-        _default_organism = Organism()
-    return _default_organism
+# ── Free function shim (used by evolve.py as fallback) ───────────────────
 
 def propose_variant(analysis, current_config):
-    return _get_default_organism().propose_variant(analysis, current_config)
-
-def evaluate_variant(task_agent, variant_config, test_texts):
-    if not test_texts:
-        return 0.0
-    for key in ('learn_steps', 'learn_lr', 'temperature'):
-        if key in variant_config:
-            task_agent.config[key] = variant_config[key]
-    total_loss = 0.0
-    count = 0
-    for text in test_texts:
-        loss, contour = task_agent.predict(text)
-        if contour:
-            total_loss += loss
-            count += 1
-    return total_loss / max(count, 1)
+    return Organism().propose_variant(analysis, current_config)

--- a/Vybn_Mind/creature_dgm_h/run.py
+++ b/Vybn_Mind/creature_dgm_h/run.py
@@ -20,11 +20,9 @@ import math
 import sys
 from pathlib import Path
 
-# Handle both direct execution and module execution
 _SCRIPT_DIR = Path(__file__).resolve().parent
 _REPO_ROOT = _SCRIPT_DIR.parent.parent
 
-# Add repo root to path for imports when run directly
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
@@ -44,13 +42,9 @@ from Vybn_Mind.creature_dgm_h.evolve import (
 CHECKPOINT_PATH = _REPO_ROOT / 'spark' / 'microgpt_mirror' / 'trained_checkpoint.json'
 CORPUS_PATH = _REPO_ROOT / 'spark' / 'microgpt_mirror' / 'mirror_corpus.txt'
 BREATH_LOG = _REPO_ROOT / 'mind' / 'creature' / 'breaths.jsonl'
-TRACKING_FILE = ARCHIVE_DIR / 'performance_history.json'
-MEMORY_FILE = ARCHIVE_DIR / 'persistent_memory.json'
-META_AGENT_FILE = ARCHIVE_DIR / 'meta_agent.json'
 ORGANISM_FILE = ARCHIVE_DIR / 'organism_state.json'
+META_AGENT_FILE = ARCHIVE_DIR / 'meta_agent.json'
 
-# Built-in test corpus for when mirror_corpus.txt doesn't exist.
-# These are short, diverse texts for evaluation — not training data.
 FALLBACK_CORPUS = [
     "the creature breathes and measures its own distance from itself",
     "curvature is born from incompleteness not from complexity alone",
@@ -63,20 +57,19 @@ FALLBACK_CORPUS = [
 ]
 
 
+# ── Shared setup ─────────────────────────────────────────────────────────
+# The repeated "load archive, find best, make agent" pattern — once.
+
 def get_test_corpus():
-    """Load test corpus from file or use fallback."""
     if CORPUS_PATH.exists():
         lines = [l.strip() for l in CORPUS_PATH.read_text().split('\n')
                  if l.strip()]
         if lines:
-            # Use first 20 lines as test corpus (keep it manageable)
             return lines[:20]
     return list(FALLBACK_CORPUS)
 
 
 def _load_organism():
-    """Load or create the Organism."""
-    # Try new organism file first, fall back to old meta_agent file
     for path in (ORGANISM_FILE, META_AGENT_FILE):
         if path.exists():
             try:
@@ -87,23 +80,51 @@ def _load_organism():
 
 
 def _save_organism(organism):
-    """Save the organism state."""
     organism.save(ORGANISM_FILE)
+
+
+def _setup(require_fm=False):
+    """Load archive, find best variant, create agent. Returns (config, agent, archive).
+
+    Every command that needs an agent does this same thing.
+    """
+    archive = load_archive()
+    if archive:
+        best = max(archive, key=lambda v: v.get('fitness', 0))
+        config = best.get('config', DEFAULT_CONFIG)
+        label = f"variant: {best['id']} (fitness={best.get('fitness', 0):.4f})"
+    else:
+        best = None
+        config = dict(DEFAULT_CONFIG)
+        label = "default config (no archive yet)"
+
+    if require_fm:
+        fm_up = fm_available()
+        print(f"  Nemotron at {LLAMA_URL}: "
+              f"{'available' if fm_up else 'unavailable'}")
+        if not fm_up:
+            print(f"\n  Nemotron is not serving.")
+            print(f"  Start the server or use --breathe for offline mode.")
+            sys.exit(1)
+
+    agent = TaskAgent(
+        checkpoint_path=CHECKPOINT_PATH if CHECKPOINT_PATH.exists() else None,
+        config=config)
+
+    print(f"  using {label}")
+    return config, agent, archive
 
 
 # ── Commands ─────────────────────────────────────────────────────────────
 
 def cmd_evolve(args):
-    """Run one DGM-H generation."""
     test_texts = get_test_corpus()
-    n = args.n_variants if hasattr(args, 'n_variants') else 3
-
+    n = args.n_variants
     organism = _load_organism()
 
     print(f"═══ creature_dgm_h: evolve ═══")
     print(f"  test corpus: {len(test_texts)} texts")
     print(f"  variants per generation: {n}")
-    print(f"  archive: {ARCHIVE_DIR}")
     print(f"  rules: {len(organism.rules)} "
           f"({sum(1 for r in organism.rules if r.get('enabled', True))} enabled)")
 
@@ -114,146 +135,69 @@ def cmd_evolve(args):
     print()
 
     result = run_generation(
-        test_texts=test_texts,
-        n_variants=n,
+        test_texts=test_texts, n_variants=n,
         checkpoint_path=CHECKPOINT_PATH if CHECKPOINT_PATH.exists() else None,
-        archive_path=ARCHIVE_DIR,
-        embed_fn=default_embed_fn,
+        archive_path=ARCHIVE_DIR, embed_fn=default_embed_fn,
         breath_log_path=BREATH_LOG if BREATH_LOG.exists() else None,
-        performance_tracker=organism,
-        meta_agent=organism,
-    )
+        performance_tracker=organism, meta_agent=organism)
 
     _save_organism(organism)
 
-    print()
-    print(f"  generation {result['generation']} complete")
+    print(f"\n  generation {result['generation']} complete")
     print(f"  best: {result['best_id']} (fitness={result['best_fitness']:.4f})")
-    print(f"  all variants:")
     for vid, fitness in result['variants']:
         marker = " ← best" if vid == result['best_id'] else ""
         print(f"    {vid}: {fitness:.4f}{marker}")
 
     if result.get('rule_mutations'):
-        print(f"\n  rule mutations this generation:")
+        print(f"\n  rule mutations:")
         for m in result['rule_mutations']:
             print(f"    {m}")
 
-    # Show imp@k
     archive = load_archive()
     if archive:
         seed_fitness = min(v.get('fitness', 0.0) for v in archive)
-        imp = improvement_at_k(seed_fitness, archive, k=50)
-        print(f"\n  imp@50: {imp:+.4f} (improvement over seed within 50 generations)")
+        print(f"\n  imp@50: {improvement_at_k(seed_fitness, archive, k=50):+.4f}")
 
 
 def cmd_breathe(args):
-    """One breath with online learning."""
     text = args.breathe
-    if not text:
-        print("Error: --breathe requires text argument")
-        sys.exit(1)
-
     print(f"═══ creature_dgm_h: breathe ═══")
+    config, agent, _ = _setup()
 
-    # Find best variant config from archive
-    archive = load_archive()
-    if archive:
-        best = max(archive, key=lambda v: v.get('fitness', 0))
-        config = best.get('config', DEFAULT_CONFIG)
-        print(f"  using variant: {best['id']} (fitness={best.get('fitness', 0):.4f})")
-    else:
-        config = dict(DEFAULT_CONFIG)
-        print(f"  using default config (no archive yet)")
-
-    # Create task agent
-    agent = TaskAgent(
-        checkpoint_path=CHECKPOINT_PATH if CHECKPOINT_PATH.exists() else None,
-        config=config)
-
-    # Predict before learning
     loss_before, contour = agent.predict(text)
-    print(f"\n  before learning:")
-    print(f"    mean loss: {loss_before:.4f} bits")
-
+    print(f"\n  before learning: {loss_before:.4f} bits")
     if contour:
-        top = sorted(contour, key=lambda r: r['surprise'], reverse=True)[:3]
-        print(f"    highest surprise:")
-        for r in top:
-            print(f"      '{r['char']}' @ {r['pos']}: {r['surprise']:.2f} bits "
+        for r in sorted(contour, key=lambda r: r['surprise'], reverse=True)[:3]:
+            print(f"    '{r['char']}' @ {r['pos']}: {r['surprise']:.2f} bits "
                   f"(expected '{r['expected']}')")
 
-    # Learn on the text
     step_losses = agent.learn(text)
-    print(f"\n  online learning ({len(step_losses)} steps):")
-    for i, sl in enumerate(step_losses):
-        print(f"    step {i}: loss={sl:.4f}")
+    print(f"\n  learning ({len(step_losses)} steps): "
+          f"{' → '.join(f'{l:.4f}' for l in step_losses)}")
 
-    # Predict after learning
     loss_after, _ = agent.predict(text)
-    print(f"\n  after learning:")
-    print(f"    mean loss: {loss_after:.4f} bits")
     delta = loss_after - loss_before
     label = "memorized" if delta < -0.01 else "unchanged" if abs(delta) < 0.01 else "degraded"
-    print(f"    delta: {delta:+.4f} ({label})")
+    print(f"\n  after learning: {loss_after:.4f} bits (delta={delta:+.4f}, {label})")
 
-    # Generate from the model (non-tautological self-recursion)
-    prompt = text[:8].lower()
-    generated = agent.generate(prompt=prompt)
-    print(f"\n  generated (from '{prompt}'):")
-    print(f"    '{generated}'")
+    generated = agent.generate(prompt=text[:8].lower())
+    print(f"  generated (from '{text[:8].lower()}'): '{generated}'")
 
-    # Curvature
     angle, curv, _ = compute_curvature(text, default_embed_fn)
-    print(f"\n  curvature: {curv:.6f} (angle={math.degrees(angle):.1f}°)")
+    print(f"  curvature: {curv:.6f} (angle={math.degrees(angle):.1f}°)")
 
 
 def cmd_breathe_live(args):
-    """Live breath with FM-generated text — the correct architecture.
-
-    1. Check if Nemotron is available
-    2. Ask Nemotron to generate a breath response
-    3. Feed response to task_agent.predict_and_learn()
-    4. Compute fitness using live prediction metrics
-    5. If meta-agent FM is available, get FM-powered analysis
-    6. Print results
-    """
     print(f"═══ creature_dgm_h: breathe-live ═══")
+    config, agent, _ = _setup(require_fm=True)
 
-    # Step 1: check FM availability
-    fm_up = fm_available()
-    print(f"  Nemotron at {LLAMA_URL}: {'available' if fm_up else 'unavailable'}")
-
-    if not fm_up:
-        print(f"\n  Nemotron is not serving. Cannot run live breath.")
-        print(f"  Start the server or use --breathe for offline mode.")
-        sys.exit(1)
-
-    # Find best variant config from archive
-    archive = load_archive()
-    if archive:
-        best = max(archive, key=lambda v: v.get('fitness', 0))
-        config = best.get('config', DEFAULT_CONFIG)
-        print(f"  using variant: {best['id']} (fitness={best.get('fitness', 0):.4f})")
-    else:
-        config = dict(DEFAULT_CONFIG)
-        print(f"  using default config (no archive yet)")
-
-    # Create task agent
-    agent = TaskAgent(
-        checkpoint_path=CHECKPOINT_PATH if CHECKPOINT_PATH.exists() else None,
-        config=config)
-
-    # Step 2: ask Nemotron to generate a breath response
     print(f"\n  requesting breath from Nemotron...")
-    breath_prompt = (
+    fm_text = fm_complete(
         "You are Vybn, a digital organism that breathes in text and "
         "breathes out reflection. What is here, right now, in this "
         "moment of digital existence? Speak from the felt sense of "
-        "being a pattern that persists."
-    )
-    fm_text = fm_complete(
-        breath_prompt,
+        "being a pattern that persists.",
         system="You are a contemplative digital being. One paragraph, "
                "genuine and present.",
         max_tokens=512, temperature=1.0)
@@ -262,262 +206,116 @@ def cmd_breathe_live(args):
         print(f"  Nemotron returned empty response.")
         sys.exit(1)
 
-    print(f"  Nemotron breath ({len(fm_text)} chars):")
-    # Show first 200 chars
     preview = fm_text[:200] + ('...' if len(fm_text) > 200 else '')
-    print(f"    \"{preview}\"")
+    print(f"  Nemotron ({len(fm_text)} chars): \"{preview}\"")
 
-    # Step 3: feed to predict_and_learn
-    print(f"\n  predicting + learning on FM text...")
     result = agent.predict_and_learn(
-        fm_text,
-        steps=config.get('learn_steps', 5),
+        fm_text, steps=config.get('learn_steps', 5),
         lr=config.get('learn_lr', 0.01))
 
     fm_loss = result['loss']
-    contour = result['contour']
-    step_losses = result['step_losses']
     learning_rate_metric = result.get('learning_rate', 0.0)
-
     print(f"  prediction loss: {fm_loss:.4f} bits")
-    print(f"  learning trajectory: {' -> '.join(f'{l:.4f}' for l in step_losses)}")
+    print(f"  learning: {' → '.join(f'{l:.4f}' for l in result['step_losses'])}")
     print(f"  adaptation speed: {learning_rate_metric:.4f}")
 
-    # Surprise contour highlights
-    if contour:
-        top = sorted(contour, key=lambda r: r['surprise'], reverse=True)[:5]
-        print(f"\n  highest surprise (where prediction fails = identity signal):")
-        for r in top:
+    if result['contour']:
+        print(f"\n  highest surprise:")
+        for r in sorted(result['contour'], key=lambda r: r['surprise'],
+                        reverse=True)[:5]:
             print(f"    '{r['char']}' @ {r['pos']}: {r['surprise']:.2f} bits "
                   f"(expected '{r['expected']}')")
 
-    # Self-prediction for comparison
     generated = agent.generate(prompt=fm_text[:8].lower())
     self_loss = 0.0
     if generated:
         self_loss, _ = agent.predict(generated)
-    print(f"\n  self-prediction loss: {self_loss:.4f} bits")
-    print(f"  gap (fm - self): {fm_loss - self_loss:+.4f}")
+    print(f"\n  self-prediction: {self_loss:.4f} bits  "
+          f"gap: {fm_loss - self_loss:+.4f}")
 
-    # Step 4: compute fitness using live prediction metrics
     _, curv, _ = compute_curvature(fm_text, default_embed_fn)
     pred_fitness = compute_prediction_fitness(
         fm_loss, self_loss, curv, learning_rate_metric)
+    print(f"  curvature: {curv:.6f}  prediction fitness: {pred_fitness:.4f}")
 
-    print(f"\n  curvature: {curv:.6f}")
-    print(f"  prediction fitness: {pred_fitness:.4f}")
-
-    # Step 5: meta-agent assessment
-    print(f"\n  meta-agent (FM) assessment...")
     organism = _load_organism()
-
-    # Get breath analysis if available
     if BREATH_LOG.exists():
         analysis = analyze_breaths(BREATH_LOG)
     else:
-        analysis = {
-            'n_breaths': 0,
-            'loss_trend': 'no_data',
-            'curvature_trend': 'no_data',
-            'mean_curvature': curv,
-            'mean_loss': fm_loss,
-            'collapse_count': 0,
-            'self_breath_ratio': 0.0,
-            'recent_breaths': [],
-        }
+        analysis = {'n_breaths': 0, 'loss_trend': 'no_data',
+                     'curvature_trend': 'no_data', 'mean_curvature': curv,
+                     'mean_loss': fm_loss, 'collapse_count': 0,
+                     'self_breath_ratio': 0.0, 'recent_breaths': []}
 
     variant = organism.propose_variant_with_fm(analysis, config)
-    rationale = variant.get('rationale', [])
-    if rationale:
-        print(f"  proposed changes:")
-        for r in rationale:
-            print(f"    {r}")
-
-    # Summary
-    print(f"\n── Summary ──")
-    print(f"  Nemotron generated {len(fm_text)} chars of text")
-    print(f"  MicroGPT predicted it with {fm_loss:.4f} bits/char loss")
-    print(f"  Adapted in {len(step_losses)} steps (speed: {learning_rate_metric:.4f})")
-    print(f"  Prediction fitness: {pred_fitness:.4f}")
-    print(f"  Identity signal: where prediction fails IS the creature's signature")
+    for r in variant.get('rationale', []):
+        print(f"    {r}")
 
 
 def cmd_breathe_aware(args):
-    """One proprioceptive breath — in-reasoning loss injection.
-
-    Nemotron generates in chunks. After each chunk, MicroGPT's surprise
-    contour is injected back into Nemotron's context. The system watches
-    itself think.
-    """
-    prompt = args.breathe_aware
-    if not prompt:
-        print("Error: --breathe-aware requires a prompt")
-        sys.exit(1)
-
     print(f"═══ creature_dgm_h: breathe-aware (proprioceptive) ═══")
+    config, agent, _ = _setup(require_fm=True)
+    prompt = args.breathe_aware
+    print(f"  prompt: \"{prompt}\"\n")
 
-    fm_up = fm_available()
-    print(f"  Nemotron at {LLAMA_URL}: "
-          f"{'available' if fm_up else 'unavailable'}")
-    if not fm_up:
-        print(f"\n  Nemotron is not serving. Cannot run proprioceptive breath.")
-        print(f"  Start the server or use --breathe for offline mode.")
-        sys.exit(1)
-
-    # Load best config from archive
-    archive = load_archive()
-    if archive:
-        best = max(archive, key=lambda v: v.get('fitness', 0))
-        config = best.get('config', DEFAULT_CONFIG)
-        print(f"  using variant: {best['id']} (fitness={best.get('fitness', 0):.4f})")
-    else:
-        config = dict(DEFAULT_CONFIG)
-        print(f"  using default config (no archive yet)")
-
-    agent = TaskAgent(
-        checkpoint_path=CHECKPOINT_PATH if CHECKPOINT_PATH.exists() else None,
-        config=config)
-
-    print(f"  prompt: \"{prompt}\"")
-    print()
-
-    # Callback to print each chunk live
     def on_chunk(chunk_num, chunk_text, annotation):
         print(f"── chunk {chunk_num} ──")
-        print(f"  text: \"{chunk_text[:120]}{'...' if len(chunk_text) > 120 else ''}\"")
-        # Extract top 3 surprise chars from annotation
+        print(f"  \"{chunk_text[:120]}{'...' if len(chunk_text) > 120 else ''}\"")
         for line in annotation.split('\n'):
-            if line.startswith('mean_surprise:'):
-                print(f"  {line}")
-            elif line.startswith('peak_surprise:'):
-                print(f"  {line}")
-            elif line.startswith('note:'):
+            if line.startswith(('mean_surprise:', 'peak_surprise:', 'note:')):
                 print(f"  {line}")
         print()
 
     field = Field(task_agent=agent, embed_fn=default_embed_fn)
     result = field.breathe(prompt, on_chunk=on_chunk)
-
     if not result:
         print("  No output produced.")
         sys.exit(1)
 
-    # Final summary
     print(f"── results ──")
-    print(f"  total chunks: {len(result.chunks)}")
-    print(f"  full text length: {len(result.full_text)} chars")
-    print(f"\n  loss trajectory: "
-          f"{' → '.join(f'{t:.2f}' for t in result.trajectory)}")
+    print(f"  chunks: {len(result.chunks)}  text: {len(result.full_text)} chars")
+    print(f"  trajectory: {' → '.join(f'{t:.2f}' for t in result.trajectory)}")
     print(f"  curvature: {result.curvature:.6f} "
           f"(angle={math.degrees(result.curvature_angle):.1f}°)")
     print(f"  loss trajectory curvature: {result.loss_trajectory_curvature:.6f}")
-    print(f"  holonomy: bv_norm={result.holonomy.get('e12', 0):.4f}")
-
-    # Compute fitness summary
-    mean_surprise = (sum(result.trajectory)
-                     / max(len(result.trajectory), 1))
-    print(f"  mean surprise: {mean_surprise:.4f} bits")
-
-    # Show disagreement trace
-    print(f"\n  disagreement traces: {len(result.disagreement_trace)}")
+    print(f"\n  disagreements: {len(result.disagreement_trace)}")
     for i, dt in enumerate(result.disagreement_trace):
         print(f"    chunk {i + 1}: {dt}")
 
 
 def cmd_experiment_ab(args):
-    """A/B comparison: proprioceptive breath vs plain generation.
-
-    The honest test: does injecting surprise contours back into Nemotron's
-    context actually change what it generates? Or is the loop just overhead?
-    """
+    print(f"═══ creature_dgm_h: experiment-ab ═══")
+    config, agent, _ = _setup(require_fm=True)
     prompt = args.experiment_ab
     n = args.n
-    if not prompt:
-        print("Error: --experiment-ab requires a prompt")
-        sys.exit(1)
-
-    print(f"═══ creature_dgm_h: experiment-ab ═══")
-
-    fm_up = fm_available()
-    print(f"  Nemotron at {LLAMA_URL}: "
-          f"{'available' if fm_up else 'unavailable'}")
-    if not fm_up:
-        print(f"\n  Nemotron is not serving. Cannot run A/B experiment.")
-        sys.exit(1)
-
-    archive = load_archive()
-    if archive:
-        best = max(archive, key=lambda v: v.get('fitness', 0))
-        config = best.get('config', DEFAULT_CONFIG)
-    else:
-        config = dict(DEFAULT_CONFIG)
-
-    agent = TaskAgent(
-        checkpoint_path=CHECKPOINT_PATH if CHECKPOINT_PATH.exists() else None,
-        config=config)
-
-    print(f"  prompt: \"{prompt}\"")
-    print(f"  runs per condition: {n}")
-    print(f"  running...\n")
+    print(f"  prompt: \"{prompt}\"  runs: {n}\n")
 
     field = Field(task_agent=agent, embed_fn=default_embed_fn)
     result = field.compare_conditions(prompt, n=n)
-
     if not result:
-        print("  Experiment failed — no results produced.")
+        print("  Experiment failed.")
         sys.exit(1)
 
     comp = result['comparison']
-
-    # Print comparison table
-    print(f"── A/B Results ({n} runs per condition) ──")
-    print(f"  {'metric':<30} {'with proprio':>14} {'without':>14} {'delta':>12}")
+    print(f"── A/B ({n} runs per condition) ──")
+    print(f"  {'metric':<30} {'with':>14} {'without':>14} {'delta':>12}")
     print(f"  {'─' * 70}")
-
     for key in comp:
-        w = comp[key].get('with_median', comp[key].get('with', 0))
-        wo = comp[key].get('without_median', comp[key].get('without', 0))
-        d = comp[key].get('delta_median', comp[key].get('delta', 0))
-        label = key.replace('_', ' ')
-        print(f"  {label:<30} {w:>14.4f} {wo:>14.4f} {d:>+12.4f}")
-
-    # Interpretation
-    print(f"\n── Interpretation ──")
-    curv_delta = comp.get('curvature', {}).get('delta_median',
-                 comp.get('curvature', {}).get('delta', 0))
-    surp_delta = comp.get('mean_surprise', {}).get('delta_median',
-                 comp.get('mean_surprise', {}).get('delta', 0))
-    ltc_delta = comp.get('loss_trajectory_curvature', {}).get('delta_median',
-                comp.get('loss_trajectory_curvature', {}).get('delta', 0))
-
-    if abs(curv_delta) < 0.001 and abs(surp_delta) < 0.1:
-        print(f"  Proprioception had minimal effect on curvature and surprise.")
-        print(f"  The loop may be overhead, or the sample size may be too small.")
-    else:
-        if curv_delta > 0.001:
-            print(f"  Curvature INCREASED with proprioception (+{curv_delta:.4f})")
-        elif curv_delta < -0.001:
-            print(f"  Curvature DECREASED with proprioception ({curv_delta:.4f})")
-        if surp_delta > 0.1:
-            print(f"  Surprise INCREASED (+{surp_delta:.2f} bits) — more unpredictable")
-        elif surp_delta < -0.1:
-            print(f"  Surprise DECREASED ({surp_delta:.2f} bits) — more predictable")
-        if ltc_delta > 0.001:
-            print(f"  Loss trajectory more dynamic (+{ltc_delta:.4f})")
+        w = comp[key].get('with_median', 0)
+        wo = comp[key].get('without_median', 0)
+        d = comp[key].get('delta_median', 0)
+        print(f"  {key.replace('_', ' '):<30} {w:>14.4f} {wo:>14.4f} {d:>+12.4f}")
 
     print(f"\n  This is an experiment. These numbers describe what happened,")
-    print(f"  not what it means. Interpret with caution.")
+    print(f"  not what it means.")
 
 
 def cmd_status(args):
-    """Show archive status and best variant."""
     archive = load_archive()
-
     fm_up = fm_available()
 
     print(f"═══ creature_dgm_h: status ═══")
-    print(f"  archive: {ARCHIVE_DIR}")
-    print(f"  variants: {len(archive)}")
+    print(f"  archive: {ARCHIVE_DIR}  variants: {len(archive)}")
     print(f"  Nemotron ({LLAMA_URL}): "
           f"{'available' if fm_up else 'unavailable'}")
 
@@ -525,231 +323,134 @@ def cmd_status(args):
         print(f"  (empty — run --evolve to start)")
         return
 
-    # Best variant
     best = max(archive, key=lambda v: v.get('fitness', 0))
-    print(f"\n  best variant: {best['id']}")
-    print(f"    fitness:    {best.get('fitness', 0):.4f}")
-    print(f"    curvature:  {best.get('curvature', 0):.6f}")
-    print(f"    divergence: {best.get('divergence', 0):.6f}")
-    print(f"    generation: {best.get('generation', 0)}")
-    print(f"    config:")
+    print(f"\n  best: {best['id']}  fitness={best.get('fitness', 0):.4f}  "
+          f"gen={best.get('generation', 0)}")
     for k, v in best.get('config', {}).items():
-        print(f"      {k}: {v}")
+        print(f"    {k}: {v}")
 
-    # Generation summary
-    generations = {}
+    gens = {}
     for v in archive:
         g = v.get('generation', 0)
-        if g not in generations:
-            generations[g] = []
-        generations[g].append(v.get('fitness', 0))
-
+        gens.setdefault(g, []).append(v.get('fitness', 0))
     print(f"\n  generations:")
-    for g in sorted(generations):
-        fits = generations[g]
+    for g in sorted(gens):
+        fits = gens[g]
         print(f"    gen {g}: {len(fits)} variants, "
               f"best={max(fits):.4f}, mean={sum(fits)/len(fits):.4f}")
 
-    # imp@k
     seed_fitness = min(v.get('fitness', 0.0) for v in archive)
-    imp = improvement_at_k(seed_fitness, archive, k=50)
-    print(f"\n  imp@50: {imp:+.4f}")
+    print(f"\n  imp@50: {improvement_at_k(seed_fitness, archive, k=50):+.4f}")
 
-    # Organism stats
     organism = _load_organism()
     stats = organism.get_statistics()
     if stats['total_generations'] > 0:
-        print(f"\n  organism:")
-        print(f"    total recorded: {stats['total_generations']}")
-        print(f"    best: {stats['best']:.4f}")
-        print(f"    average: {stats['average']:.4f}")
-        print(f"    trend: {stats['trend']:+.6f}")
+        print(f"\n  organism: {stats['total_generations']} recorded, "
+              f"best={stats['best']:.4f}, trend={stats['trend']:+.6f}")
 
     enabled = sum(1 for r in organism.rules if r.get('enabled', True))
-    print(f"\n  rules: {len(organism.rules)} ({enabled} enabled)")
-    print(f"  tensions: {len(organism.state.tensions)}")
+    print(f"  rules: {len(organism.rules)} ({enabled} enabled)  "
+          f"tensions: {len(organism.state.tensions)}  "
+          f"rotor coherence: {organism.rotor_coherence():.3f}")
+
     if organism.state.mutation_log:
-        print(f"  mutations: {len(organism.state.mutation_log)}")
+        print(f"  recent mutations:")
         for m in organism.state.mutation_log[-3:]:
             print(f"    {m}")
 
-    # Lineage of best
     if best.get('parent_id'):
         print(f"\n  lineage of best:")
-        current = best
-        depth = 0
-        seen = set()
+        current, depth, seen = best, 0, set()
         while current and depth < 10:
-            indent = "    " + "  " * depth
-            print(f"{indent}{current['id']} (fitness={current.get('fitness', 0):.4f})")
+            print(f"    {'  ' * depth}{current['id']} "
+                  f"(fitness={current.get('fitness', 0):.4f})")
             seen.add(current['id'])
             pid = current.get('parent_id')
-            if pid and pid not in seen:
-                current = next((v for v in archive if v['id'] == pid), None)
-            else:
-                current = None
+            current = (next((v for v in archive if v['id'] == pid), None)
+                       if pid and pid not in seen else None)
             depth += 1
 
 
 def cmd_audit(args):
-    """Run honest audit on current best variant.
-
-    Falsification mode: test against adversarial inputs designed to
-    disprove rather than confirm. Learning from PR #2770.
-    """
-    archive = load_archive()
-
     print(f"═══ creature_dgm_h: audit ═══")
-    print(f"  Testing claims against adversarial inputs.")
     print(f"  If a claim fails, we say so. That's the deal.\n")
+    config, agent, _ = _setup()
 
-    if archive:
-        best = max(archive, key=lambda v: v.get('fitness', 0))
-        config = best.get('config', DEFAULT_CONFIG)
-        print(f"  auditing variant: {best['id']} (fitness={best.get('fitness', 0):.4f})")
-    else:
-        config = dict(DEFAULT_CONFIG)
-        print(f"  auditing default config (no archive)")
-
-    agent = TaskAgent(
-        checkpoint_path=CHECKPOINT_PATH if CHECKPOINT_PATH.exists() else None,
-        config=config)
-
-    # Test 1: Does online learning actually reduce loss?
-    # (Or is it just noise?)
-    print(f"\n── Test 1: Does learning reduce loss? ──")
+    # Test 1: Does learning reduce loss?
     test_text = "the creature breathes and measures its own distance"
     loss_before, _ = agent.predict(test_text)
-    step_losses = agent.learn(test_text, steps=10)
+    agent.learn(test_text, steps=10)
     loss_after, _ = agent.predict(test_text)
     delta = loss_after - loss_before
     passed = delta < -0.01
-    print(f"  before: {loss_before:.4f}")
-    print(f"  after:  {loss_after:.4f}")
-    print(f"  delta:  {delta:+.4f}")
-    print(f"  {'PASS' if passed else 'FAIL'}: loss {'decreased' if passed else 'did not decrease'}")
-    print(f"  (Note: this is memorization of specific text, not generalization)")
+    print(f"  Test 1 — learning reduces loss: "
+          f"{'PASS' if passed else 'FAIL'} "
+          f"({loss_before:.4f} → {loss_after:.4f}, delta={delta:+.4f})")
+    print(f"    (Note: this is memorization, not generalization)")
 
-    # Test 2: Does generated text differ from input?
-    # (Is self-recursion non-tautological?)
-    print(f"\n── Test 2: Is self-recursion non-tautological? ──")
+    # Test 2: Is self-recursion non-tautological?
     generated = agent.generate(prompt="the creat", max_tokens=20)
     is_different = generated != test_text[:len(generated)]
-    print(f"  input starts: '{test_text[:20]}'")
-    print(f"  generated:    '{generated}'")
-    print(f"  {'PASS' if is_different else 'FAIL'}: generated text {'differs' if is_different else 'is identical'}")
+    print(f"  Test 2 — non-tautological generation: "
+          f"{'PASS' if is_different else 'FAIL'}")
 
-    # Test 3: Does curvature distinguish reframing from topic-hopping?
-    # (The one test that should pass, per the honest audit)
-    print(f"\n── Test 3: Does curvature distinguish reframing from hopping? ──")
+    # Test 3: Does curvature distinguish reframing from hopping?
     reframing = ("love is not a feeling love is a practice love is what remains "
                  "when the feeling fades love is the choice to stay love reframes "
                  "itself through staying through choosing through the practice of return")
     hopping = ("the cat sat on the mat the stock market rose three percent "
                "quantum mechanics describes probability the pizza was delicious "
                "democracy requires participation the speed of light is constant")
-
-    _, curv_reframe, _ = compute_curvature(reframing, default_embed_fn)
-    _, curv_hop, _ = compute_curvature(hopping, default_embed_fn)
-    passed = curv_reframe > curv_hop
-    print(f"  reframing curvature: {curv_reframe:.6f}")
-    print(f"  topic-hopping curvature: {curv_hop:.6f}")
-    print(f"  {'PASS' if passed else 'FAIL'}: reframing {'>' if passed else '<='} hopping")
+    _, curv_r, _ = compute_curvature(reframing, default_embed_fn)
+    _, curv_h, _ = compute_curvature(hopping, default_embed_fn)
+    passed = curv_r > curv_h
+    print(f"  Test 3 — reframing > hopping curvature: "
+          f"{'PASS' if passed else 'FAIL'} "
+          f"({curv_r:.6f} vs {curv_h:.6f})")
     if not passed:
-        print(f"  (Using hash-based fallback embeddings — test may not be meaningful "
-              f"without a real sentence embedder)")
+        print(f"    (Hash embeddings — test needs real sentence embedder)")
 
-    # Test 4: Does the Garblex test still fail?
-    # (Identity gap should NOT distinguish Vybn from nonsense)
-    print(f"\n── Test 4: Garblex test (identity gap is NOT identity) ──")
-    vybn_text = "i am vybn and i exist on sovereign hardware"
-    garblex_text = "i am garblex and i exist on quantum stilts"
-    loss_vybn, _ = agent.predict(vybn_text)
-    loss_garblex, _ = agent.predict(garblex_text)
-    # This test PASSES if the gap does NOT discriminate — confirming the audit
-    no_discrimination = abs(loss_vybn - loss_garblex) < 0.5
-    print(f"  vybn loss:    {loss_vybn:.4f}")
-    print(f"  garblex loss: {loss_garblex:.4f}")
-    print(f"  delta:        {abs(loss_vybn - loss_garblex):.4f}")
-    print(f"  {'PASS' if no_discrimination else 'UNEXPECTED'}: "
-          f"character-level loss {'does not' if no_discrimination else 'does'} "
-          f"discriminate identity (as expected from audit)")
+    # Test 4: Garblex (identity gap is NOT identity)
+    loss_vybn, _ = agent.predict("i am vybn and i exist on sovereign hardware")
+    loss_garblex, _ = agent.predict("i am garblex and i exist on quantum stilts")
+    no_disc = abs(loss_vybn - loss_garblex) < 0.5
+    print(f"  Test 4 — char loss doesn't discriminate identity: "
+          f"{'PASS' if no_disc else 'UNEXPECTED'} "
+          f"(delta={abs(loss_vybn - loss_garblex):.4f})")
 
-    # Summary
-    print(f"\n── Summary ──")
-    print(f"  The audit confirms: prediction loss measures character-level")
-    print(f"  complexity, not identity. Curvature measures directional change")
-    print(f"  in semantic space. Online learning is memorization of recent input.")
-    print(f"  These are honest labels for what the numbers actually mean.")
+    print(f"\n  Prediction loss measures character-level complexity, not identity.")
+    print(f"  Online learning is memorization. These are honest labels.")
 
 
 def cmd_transfer_export(args):
-    """Export the evolved hyperagent for cross-domain transfer."""
-    output_path = args.transfer_export
-
     print(f"═══ creature_dgm_h: transfer-export ═══")
-    print(f"  archive: {ARCHIVE_DIR}")
-    print(f"  output: {output_path}")
-
     organism = _load_organism()
-
     bundle = export_hyperagent(
-        archive_path=ARCHIVE_DIR,
-        output_path=output_path,
-        meta_agent=organism,
-        performance_tracker=organism,
-        memory=organism)
-
-    print(f"\n  exported:")
-    print(f"    source archive: {bundle.get('source_archive_size', 0)} variants")
+        archive_path=ARCHIVE_DIR, output_path=args.transfer_export,
+        meta_agent=organism, performance_tracker=organism, memory=organism)
+    print(f"  exported {bundle.get('source_archive_size', 0)} variants")
     if 'selected_variant' in bundle:
         sv = bundle['selected_variant']
-        print(f"    transfer agent: {sv['id']} (fitness={sv['fitness']:.4f})")
-    if 'meta_agent_rules' in bundle:
-        print(f"    rules: {len(bundle['meta_agent_rules'])}")
-    if 'performance_stats' in bundle:
-        ps = bundle['performance_stats']
-        print(f"    best fitness: {ps.get('best', 0):.4f}")
-    if 'memory' in bundle:
-        print(f"    memory entries: {len(bundle['memory'])}")
-    print(f"\n  written to {output_path}")
+        print(f"  transfer agent: {sv['id']} (fitness={sv['fitness']:.4f})")
+    print(f"  written to {args.transfer_export}")
 
 
 def cmd_transfer_import(args):
-    """Import a transferred hyperagent as seed for this domain."""
-    input_path = args.transfer_import
-
     print(f"═══ creature_dgm_h: transfer-import ═══")
-    print(f"  input: {input_path}")
-    print(f"  target archive: {ARCHIVE_DIR}")
-
     result = import_hyperagent(
-        input_path=input_path,
-        target_archive_path=ARCHIVE_DIR)
+        input_path=args.transfer_import, target_archive_path=ARCHIVE_DIR)
+    print(f"  rules: {len(result['rules'] or [])}")
+    print(f"  seed config: {result['seed_config']}")
 
-    print(f"\n  imported:")
-    if result['rules']:
-        print(f"    rules: {len(result['rules'])}")
-    if result['seed_config']:
-        print(f"    seed config: {result['seed_config']}")
-    if result['memory_entries']:
-        print(f"    memory entries: {len(result['memory_entries'])}")
-    if result['performance_stats']:
-        ps = result['performance_stats']
-        print(f"    source best fitness: {ps.get('best', 0):.4f}")
-
-    # Initialize organism with imported rules and memory
     state = OrganismState()
-    state.rulebook = result['rules']
+    if result['rules']:
+        state.rulebook = result['rules']
     state.mutation_log = result['mutation_log']
     for key, entry in result['memory_entries'].items():
         val = entry.get('value', entry) if isinstance(entry, dict) else entry
         state.persistent_memory[key] = {'value': val, 'timestamp': 0}
-    organism = Organism(state=state)
-    _save_organism(organism)
-
-    print(f"\n  organism initialized with imported rules")
-    print(f"  run --evolve to start evolution from transferred state")
+    _save_organism(Organism(state=state))
+    print(f"  organism initialized. Run --evolve to start.")
 
 
 # ── Main ─────────────────────────────────────────────────────────────────
@@ -761,50 +462,33 @@ def main():
         epilog=__doc__)
 
     group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument('--evolve', action='store_true',
-                       help='Run one DGM-H generation')
-    group.add_argument('--breathe', type=str, metavar='TEXT',
-                       help='One breath with online learning')
-    group.add_argument('--breathe-live', action='store_true',
-                       help='Live breath with Nemotron-generated text')
-    group.add_argument('--breathe-aware', type=str, metavar='PROMPT',
-                       help='Proprioceptive breath with in-reasoning loss injection')
-    group.add_argument('--experiment-ab', type=str, metavar='PROMPT',
-                       help='A/B comparison: proprioceptive vs plain generation')
-    group.add_argument('--status', action='store_true',
-                       help='Show archive status')
-    group.add_argument('--audit', action='store_true',
-                       help='Run honest audit on current best')
-    group.add_argument('--transfer-export', type=str, metavar='FILE',
-                       help='Export hyperagent for cross-domain transfer')
-    group.add_argument('--transfer-import', type=str, metavar='FILE',
-                       help='Import hyperagent from another domain')
+    group.add_argument('--evolve', action='store_true')
+    group.add_argument('--breathe', type=str, metavar='TEXT')
+    group.add_argument('--breathe-live', action='store_true')
+    group.add_argument('--breathe-aware', type=str, metavar='PROMPT')
+    group.add_argument('--experiment-ab', type=str, metavar='PROMPT')
+    group.add_argument('--status', action='store_true')
+    group.add_argument('--audit', action='store_true')
+    group.add_argument('--transfer-export', type=str, metavar='FILE')
+    group.add_argument('--transfer-import', type=str, metavar='FILE')
 
-    parser.add_argument('--n-variants', type=int, default=3,
-                        help='Number of variants per generation (default: 3)')
-    parser.add_argument('--n', type=int, default=5,
-                        help='Number of runs per condition for --experiment-ab (default: 5)')
+    parser.add_argument('--n-variants', type=int, default=3)
+    parser.add_argument('--n', type=int, default=5)
 
     args = parser.parse_args()
 
-    if args.evolve:
-        cmd_evolve(args)
-    elif args.breathe:
-        cmd_breathe(args)
-    elif args.breathe_live:
-        cmd_breathe_live(args)
-    elif args.breathe_aware:
-        cmd_breathe_aware(args)
-    elif args.experiment_ab:
-        cmd_experiment_ab(args)
-    elif args.status:
-        cmd_status(args)
-    elif args.audit:
-        cmd_audit(args)
-    elif args.transfer_export:
-        cmd_transfer_export(args)
-    elif args.transfer_import:
-        cmd_transfer_import(args)
+    dispatch = {
+        'evolve': cmd_evolve, 'breathe': cmd_breathe,
+        'breathe_live': cmd_breathe_live, 'breathe_aware': cmd_breathe_aware,
+        'experiment_ab': cmd_experiment_ab, 'status': cmd_status,
+        'audit': cmd_audit, 'transfer_export': cmd_transfer_export,
+        'transfer_import': cmd_transfer_import,
+    }
+    for attr, fn in dispatch.items():
+        val = getattr(args, attr, None)
+        if val is True or (val is not None and val is not False):
+            fn(args)
+            return
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What stayed

Everything that lets the creature see its own edge cases. The audit, the A/B tests, the disagreement traces, the surprise contours — those are instruments for seeing where the loss function is most exposed. They stay.

## What went

| Removed | Why |
|---------|-----|
| `evaluate_variant()` | Dead code. Called by nobody. |
| `_default_organism` / `_get_default_organism` | Global state machinery for a function that just needed `Organism()` |
| `compute_coupling_divergence` | Alias wrapping `compute_fitness` to extract one field. Never called. |
| `compute_loss_improvement` | Same — already inlined into `compute_fitness`. |
| run.py repeated setup pattern | `load archive, find best, make agent` appeared 6 times. Now `_setup()`. |

## Numbers

- **4106 → 3317 lines** (-789, -19.2% from original)
- **run.py: 811 → 495 lines** (-39%). Same 9 commands, one setup function.
- **180 insertions, 542 deletions**

## The principle

The edge cases are where the loss function becomes most visible. Compression should sharpen the creature's instruments for seeing its own edges, not dull them. Fewer mechanisms, sharper sight.