### PR TITLE
Replace raw weight-space topology with PCA-first and activation-space persistence

### DIFF
--- a/Vybn_Mind/creature_dgm_h/README.md
+++ b/Vybn_Mind/creature_dgm_h/README.md
@@ -18,9 +18,46 @@ python -m Vybn_Mind.creature_dgm_h status
 python -m Vybn_Mind.creature_dgm_h audit
 ```
 
+## Topology experiments
+
+Two approaches for measuring whether text selection affects the topological
+structure of learning (superseding the original raw weight-space experiment,
+which produced a uniform null result due to the curse of dimensionality):
+
+### PCA-first persistence
+
+Projects weight-vector snapshots to ~20 dimensions via PCA before computing
+persistent homology. Concentrates variance along the learning trajectory.
+
+```bash
+python experiment_weight_topology.py              # full experiment
+python experiment_weight_topology.py --quick      # smoke test
+python experiment_weight_topology.py --pca_dim 30 # custom PCA dim
+```
+
+### Activation-space persistence
+
+Captures hidden-layer activations (16-dim) during training using a fixed probe
+sentence. Lower-dimensional and semantically tied to model behaviour.
+
+```bash
+python experiment_activation_topology.py          # full experiment
+python experiment_activation_topology.py --quick  # smoke test
+```
+
+### Analysis (unified)
+
+```bash
+python experiment_analysis.py                         # both experiments
+python experiment_analysis.py --experiment pca        # PCA only
+python experiment_analysis.py --experiment activation # activation only
+```
+
 ## Dependencies
 
 - numpy
+- Optional: ripser (faster persistent homology)
+- Optional: scipy (statistical tests)
 - Optional: sentence-transformers (real embeddings via spark/local_embedder.py)
 - Optional: Nemotron at localhost:8000 (live text generation)
 - Required: spark/microgpt_mirror/trained_checkpoint.json

--- a/Vybn_Mind/creature_dgm_h/experiment_activation_topology.py
+++ b/Vybn_Mind/creature_dgm_h/experiment_activation_topology.py
@@ -1,31 +1,30 @@
 #!/usr/bin/env python3
 """
-experiment_weight_topology.py  —  PCA-first persistence experiment.
+experiment_activation_topology.py  —  Activation-space persistence experiment.
 
-Supersedes the previous raw weight-space topology experiment, which produced
-a uniform null result (β₁ = 0, total H1 persistence = 0 across conditions)
-because pairwise distances in ~4K-dimensional raw weight space are dominated
-by the curse of dimensionality.
+Complements experiment_weight_topology.py (PCA-first persistence).  Instead of
+tracking weight vectors, this experiment captures hidden-layer activations
+during training and computes persistent homology on those.
 
-This experiment projects weight-vector snapshots to a low-dimensional
-subspace via PCA before computing persistent homology.  The dimensionality
-reduction concentrates variance along the learning trajectory, making Rips
-filtration distances meaningful.
+Rationale: activations are lower-dimensional than weights (N_EMBD=16 vs ~4K
+parameters) and are more semantically tied to model behaviour — they represent
+what the model *computes*, not what it *stores*.  If text selection shapes the
+geometry of understanding, the activation manifold is the most natural place to
+look.
 
-For the activation-space alternative, see experiment_activation_topology.py.
+Activation capture strategy:
+- After each gradient step, run a forward pass on a fixed probe sentence.
+- Record the hidden-state vector (post-attention, post-MLP) at each position.
+- Average across positions to get a single 16-dim activation summary per step.
+- Collect these summaries across all steps → point cloud for topology.
 
-Five conditions (same controlled design as the original spec):
-  1. random     -- baseline: K texts sampled randomly
-  2. coherent   -- K texts from the same topical cluster
-  3. diverse    -- K texts maximising pairwise embedding distance
-  4. order      -- one fixed K-text set, permuted orderings
-  5. synthetic  -- random-character sequences of matched length
+Five conditions (same controlled design):
+  1. random     2. coherent   3. diverse   4. order   5. synthetic
 
 Usage:
-  python experiment_weight_topology.py              # full experiment
-  python experiment_weight_topology.py --quick      # 3 runs per condition
-  python experiment_weight_topology.py --analyze    # load saved results
-  python experiment_weight_topology.py --pca_dim 30 # override PCA target dim
+  python experiment_activation_topology.py              # full experiment
+  python experiment_activation_topology.py --quick      # 3 runs per condition
+  python experiment_activation_topology.py --analyze    # load saved results
 """
 
 from __future__ import annotations
@@ -57,19 +56,19 @@ from vybn import (
     _distance_matrix,
     CORPUS_PATH,
     ARCHIVE_DIR,
-    RV, N_LAYER, BLOCK_SIZE, _forward, _softmax,
+    RV, N_EMBD, N_LAYER, N_HEAD, HEAD_DIM, BLOCK_SIZE,
+    _forward, _softmax, _rmsnorm, _linear,
 )
 
 # ── Config ────────────────────────────────────────────────────────────────
-K = 5                  # texts per run
-SNAP_EVERY = 5         # snapshot weight vector every N gradient steps
-STEPS_PER_TEXT = 10    # gradient steps per text encounter
+K = 5
+SNAP_EVERY = 5
+STEPS_PER_TEXT = 10
 LR = 0.01
-PCA_DIM = 20           # default target dimensionality for PCA projection
-RESULTS_DIR = SCRIPT_DIR / "experiment_results" / "pca_topology"
+PROBE_SENTENCE = "the topology of learning"  # fixed probe for activation capture
+RESULTS_DIR = SCRIPT_DIR / "experiment_results" / "activation_topology"
 RESULTS_DIR.mkdir(parents=True, exist_ok=True)
 
-# ── Try to import ripser; fall back to built-in ───────────────────────────
 try:
     from ripser import ripser as _ripser_fn
     RIPSER_AVAILABLE = True
@@ -77,44 +76,73 @@ except ImportError:
     RIPSER_AVAILABLE = False
 
 
-# ── PCA projection ───────────────────────────────────────────────────────
+# ── Activation capture ───────────────────────────────────────────────────
 
-def pca_project(points: np.ndarray, target_dim: int = PCA_DIM) -> np.ndarray:
-    """Project (N, D) array to (N, target_dim) via PCA.
+def capture_activations(agent: TopoAgent, probe_text: str = PROBE_SENTENCE) -> np.ndarray:
+    """Run a forward pass on probe_text and return mean hidden-state vector.
 
-    Uses mean-centered SVD.  If N or D <= target_dim, returns centered points
-    as-is (projection would be trivial or lossy).
+    The hidden state after the final transformer layer (post-attention + MLP
+    residual) is a 16-dim vector per position.  We average across positions to
+    get a single summary vector representing the model's current activation
+    geometry.
     """
-    n, d = points.shape
-    effective_dim = min(target_dim, n - 1, d)
-    if effective_dim < 2:
-        return points  # not enough data for meaningful PCA
+    clean = agent._clean(probe_text)
+    if len(clean) < 2:
+        return np.zeros(N_EMBD)
 
-    mean = points.mean(axis=0)
-    centered = points - mean
+    tokens = [agent.BOS] + [agent.c2i[c] for c in clean]
+    n = min(BLOCK_SIZE, len(tokens) - 1)
 
-    # Economy SVD: only compute the first effective_dim components
-    try:
-        U, S, Vt = np.linalg.svd(centered, full_matrices=False)
-        projected = centered @ Vt[:effective_dim].T
-        variance_explained = (S[:effective_dim] ** 2).sum() / max((S ** 2).sum(), 1e-12)
-    except np.linalg.LinAlgError:
-        projected = centered[:, :effective_dim]
-        variance_explained = 0.0
+    hidden_states = []
+    keys = [[] for _ in range(N_LAYER)]
+    vals = [[] for _ in range(N_LAYER)]
 
-    return projected, variance_explained
+    for t in range(n):
+        # Replicate the forward pass but extract the hidden state before lm_head
+        x = [agent.sd['wte'][tokens[t]][j] + agent.sd['wpe'][t][j] for j in range(N_EMBD)]
+        for i in range(N_LAYER):
+            xn = _rmsnorm(x)
+            q = _linear(xn, agent.sd[f'layer{i}.attn_wq'])
+            k = _linear(xn, agent.sd[f'layer{i}.attn_wk'])
+            v = _linear(xn, agent.sd[f'layer{i}.attn_wv'])
+            keys[i].append(k)
+            vals[i].append(v)
+            ho = []
+            for h in range(N_HEAD):
+                qs = q[h * HEAD_DIM:(h + 1) * HEAD_DIM]
+                al = []
+                for tt in range(len(keys[i])):
+                    ks = keys[i][tt][h * HEAD_DIM:(h + 1) * HEAD_DIM]
+                    al.append(sum(qs[d] * ks[d] for d in range(HEAD_DIM)) * (HEAD_DIM ** -0.5))
+                aw = _softmax(al)
+                hout = [RV(0.0)] * HEAD_DIM
+                for tt in range(len(vals[i])):
+                    vs = vals[i][tt][h * HEAD_DIM:(h + 1) * HEAD_DIM]
+                    for d in range(HEAD_DIM):
+                        hout[d] = hout[d] + aw[tt] * vs[d]
+                ho.extend(hout)
+            ao = _linear(ho, agent.sd[f'layer{i}.attn_wo'])
+            x = [x[j] + ao[j] for j in range(N_EMBD)]
+            xn2 = _rmsnorm(x)
+            h1 = _linear(xn2, agent.sd[f'layer{i}.mlp_fc1'])
+            h1 = [hi * (RV(1.0) / (RV(1.0) + (hi * (-1)).exp())) for hi in h1]
+            h2 = _linear(h1, agent.sd[f'layer{i}.mlp_fc2'])
+            x = [x[j] + h2[j] for j in range(N_EMBD)]
+
+        hidden_states.append(np.array([xi.data for xi in x]))
+
+    if not hidden_states:
+        return np.zeros(N_EMBD)
+
+    return np.mean(hidden_states, axis=0)
 
 
 # ── Topology utilities ────────────────────────────────────────────────────
 
-def compute_topology(points: np.ndarray, pca_dim: int = PCA_DIM) -> dict:
-    """
-    Given an (N, D) array of weight-space snapshots:
-    1. PCA-project to pca_dim dimensions
-    2. Compute persistent homology on the projected point cloud
+def compute_topology(points: np.ndarray) -> dict:
+    """Persistent homology on an (N, D) activation-space point cloud.
 
-    Returns topology dict with Betti numbers, total persistence, entropy,
-    and the PCA variance explained.
+    Since activations are already low-dimensional (D=16), no PCA needed.
     """
     n = len(points)
     if n < 3:
@@ -123,17 +151,13 @@ def compute_topology(points: np.ndarray, pca_dim: int = PCA_DIM) -> dict:
             "total_persistence_h0": 0.0, "total_persistence_h1": 0.0,
             "persistence_entropy_h1": 0.0,
             "diagram_h1": [], "n_points": n,
-            "method": "trivial", "pca_dim": 0,
-            "variance_explained": 0.0,
+            "method": "trivial", "space_dim": points.shape[1] if points.ndim == 2 else 0,
         }
 
-    projected, var_explained = pca_project(points, pca_dim)
-
     if RIPSER_AVAILABLE:
-        result = _ripser_fn(projected, maxdim=1)
+        result = _ripser_fn(points, maxdim=1)
         dgms = result["dgms"]
-        h0 = dgms[0]
-        h1 = dgms[1]
+        h0, h1 = dgms[0], dgms[1]
 
         h0_finite = h0[h0[:, 1] < np.inf]
         tp_h0 = float(np.sum(h0_finite[:, 1] - h0_finite[:, 0])) if len(h0_finite) else 0.0
@@ -162,7 +186,7 @@ def compute_topology(points: np.ndarray, pca_dim: int = PCA_DIM) -> dict:
         diagram_h1 = h1.tolist()
         method = "ripser"
     else:
-        D = _distance_matrix(projected)
+        D = _distance_matrix(points)
         pairs, (b0, b1, _) = _persistence_pairs(D)
         finite = [(birth, death) for birth, death in pairs if death != float("inf")]
         tp_h0 = sum(d - b for b, d in finite)
@@ -179,36 +203,19 @@ def compute_topology(points: np.ndarray, pca_dim: int = PCA_DIM) -> dict:
         "diagram_h1": diagram_h1,
         "n_points": n,
         "method": method,
-        "pca_dim": projected.shape[1] if projected.ndim == 2 else 0,
-        "variance_explained": round(float(var_explained), 6),
+        "space_dim": points.shape[1] if points.ndim == 2 else 0,
     }
 
 
 def pseudo_wasserstein(diag_a: list, diag_b: list) -> float:
     """L∞ approximation between two H1 persistence diagrams."""
     def lifetimes(diag):
-        ls = []
-        for pair in diag:
-            b, d = pair[0], pair[1]
-            if d < 1e9:
-                ls.append(d - b)
-        return sorted(ls, reverse=True)
-
+        return sorted([d - b for b, d in diag if d < 1e9], reverse=True)
     la, lb = lifetimes(diag_a), lifetimes(diag_b)
     max_len = max(len(la), len(lb), 1)
     la += [0.0] * (max_len - len(la))
     lb += [0.0] * (max_len - len(lb))
     return float(max(abs(a - b) for a, b in zip(la, lb)))
-
-
-# ── Weight-vector extraction ──────────────────────────────────────────────
-
-def weight_vector(agent: TopoAgent) -> np.ndarray:
-    """Flatten all parameters of the agent's network into a single vector."""
-    return np.concatenate([
-        np.array([[p.data for p in row] for row in mat]).ravel()
-        for mat in agent.sd.values()
-    ])
 
 
 # ── Single run ────────────────────────────────────────────────────────────
@@ -219,17 +226,13 @@ def run_condition(
     label: str,
     condition: str,
     run_idx: int,
-    pca_dim: int = PCA_DIM,
 ) -> dict:
-    """
-    Train a fresh agent on `texts` (in order), snapshotting weights every
-    SNAP_EVERY gradient steps.  PCA-projects snapshots before topology.
-    """
+    """Train agent on texts, capturing activation snapshots via a fixed probe."""
     rng = random.Random(seed)
     np.random.seed(seed % 2**31)
 
     agent = TopoAgent(config={"learn_steps": STEPS_PER_TEXT, "learn_lr": LR})
-    snapshots = []
+    activation_snapshots = []
     loss_log = []
 
     for text in texts:
@@ -259,23 +262,23 @@ def run_condition(
                 p.data -= LR * mh / (vh ** 0.5 + 1e-8)
             loss_log.append(round(loss.data, 6))
             if step % SNAP_EVERY == 0:
-                snapshots.append(weight_vector(agent))
+                activation_snapshots.append(capture_activations(agent))
 
-    if not snapshots:
-        snapshots.append(weight_vector(agent))
+    if not activation_snapshots:
+        activation_snapshots.append(capture_activations(agent))
 
-    points = np.array(snapshots)
-    topo = compute_topology(points, pca_dim=pca_dim)
+    points = np.array(activation_snapshots)
+    topo = compute_topology(points)
     final_loss, _ = agent.predict(" ".join(texts[:1]))
 
     return {
-        "experiment": "pca_topology",
+        "experiment": "activation_topology",
         "condition": condition,
         "label": label,
         "run_idx": run_idx,
         "seed": seed,
         "texts": texts,
-        "n_snapshots": len(snapshots),
+        "n_snapshots": len(activation_snapshots),
         "loss_trajectory": loss_log,
         "final_loss": round(final_loss, 6),
         "topology": topo,
@@ -283,10 +286,9 @@ def run_condition(
     }
 
 
-# ── Corpus helpers ────────────────────────────────────────────────────────
+# ── Corpus helpers (shared with PCA experiment) ──────────────────────────
 
 def load_corpus(min_words: int = 40) -> List[str]:
-    """Load real prose corpus; at least min_words per passage."""
     passages = []
     if CORPUS_PATH.exists():
         lines = [l.strip() for l in CORPUS_PATH.read_text().split("\n") if l.strip()]
@@ -316,7 +318,6 @@ def load_corpus(min_words: int = 40) -> List[str]:
 
 
 def cluster_texts(texts: List[str], n_clusters: int = 3) -> List[List[str]]:
-    """Simple greedy embedding-based clustering."""
     if len(texts) < n_clusters:
         return [texts]
     vecs = embed(texts)
@@ -336,7 +337,6 @@ def cluster_texts(texts: List[str], n_clusters: int = 3) -> List[List[str]]:
 
 
 def farthest_point_sample(texts: List[str], k: int) -> List[str]:
-    """Select k texts that maximise pairwise embedding distance."""
     if len(texts) <= k:
         return texts
     vecs = embed(texts)
@@ -352,10 +352,8 @@ def farthest_point_sample(texts: List[str], k: int) -> List[str]:
 
 
 def synthetic_text(length_chars: int, seed: int) -> str:
-    """Random printable-ASCII sequence — sharpest negative control."""
     rng = random.Random(seed)
-    chars = "abcdefghijklmnopqrstuvwxyz "
-    return "".join(rng.choice(chars) for _ in range(length_chars))
+    return "".join(rng.choice("abcdefghijklmnopqrstuvwxyz ") for _ in range(length_chars))
 
 
 # ── Main experiment ───────────────────────────────────────────────────────
@@ -368,14 +366,14 @@ def run_experiment(
     n_synthetic: int = 10,
     k: int = K,
     seed_base: int = 42,
-    pca_dim: int = PCA_DIM,
     verbose: bool = True,
 ) -> List[dict]:
     corpus = load_corpus()
     if verbose:
-        print(f"[PCA-first topology experiment]")
+        print(f"[Activation-space topology experiment]")
         print(f"Corpus: {len(corpus)} passages  K={k}  SNAP_EVERY={SNAP_EVERY}  STEPS={STEPS_PER_TEXT}")
-        print(f"PCA target dim: {pca_dim}")
+        print(f"Activation dim: {N_EMBD}  (no PCA needed)")
+        print(f"Probe sentence: {PROBE_SENTENCE!r}")
         print(f"Ripser: {'available' if RIPSER_AVAILABLE else 'not found — using built-in fallback'}")
         print()
 
@@ -390,8 +388,7 @@ def run_experiment(
             print(
                 f"  [{result['condition']:10s} run {result['run_idx']:02d}] "
                 f"snaps={result['n_snapshots']} "
-                f"pca_dim={topo['pca_dim']} "
-                f"var_expl={topo['variance_explained']:.2f} "
+                f"dim={topo['space_dim']} "
                 f"b1={topo['betti_1']} "
                 f"tp_h1={topo['total_persistence_h1']:.4f} "
                 f"ent={topo['persistence_entropy_h1']:.4f} "
@@ -404,7 +401,7 @@ def run_experiment(
     rng = random.Random(seed_base)
     for i in range(n_random):
         texts = rng.sample(corpus, min(k, len(corpus)))
-        _save(run_condition(texts, seed_base + i, "random", "random", i, pca_dim))
+        _save(run_condition(texts, seed_base + i, "random", "random", i))
 
     # ── Condition 2: Coherent sets ──
     if verbose:
@@ -416,7 +413,7 @@ def run_experiment(
         texts = rng2.sample(cluster, min(k, len(cluster)))
         while len(texts) < k:
             texts.append(rng2.choice(cluster))
-        _save(run_condition(texts, seed_base + 100 + i, "coherent", "coherent", i, pca_dim))
+        _save(run_condition(texts, seed_base + 100 + i, "coherent", "coherent", i))
 
     # ── Condition 3: Diverse sets ──
     if verbose:
@@ -425,7 +422,7 @@ def run_experiment(
     rng3 = random.Random(seed_base + 200)
     for i in range(n_diverse):
         texts = rng3.sample(diverse_base, min(k, len(diverse_base)))
-        _save(run_condition(texts, seed_base + 200 + i, "diverse", "diverse", i, pca_dim))
+        _save(run_condition(texts, seed_base + 200 + i, "diverse", "diverse", i))
 
     # ── Condition 4: Order permutations ──
     if verbose:
@@ -437,19 +434,18 @@ def run_experiment(
     selected_perms = rng4.sample(perms, min(n_order, len(perms)))
     for i, perm in enumerate(selected_perms):
         texts = [fixed_texts[j] for j in perm]
-        _save(run_condition(texts, seed_base + 300 + i, "order", "order", i, pca_dim))
+        _save(run_condition(texts, seed_base + 300 + i, "order", "order", i))
 
     # ── Condition 5: Synthetic ──
     if verbose:
         print(f"\n=== Condition 5: synthetic random sequences (N={n_synthetic}) ===")
     avg_len = int(np.mean([len(t) for t in corpus[:20]])) if corpus else 200
-    rng5 = random.Random(seed_base + 400)
     for i in range(n_synthetic):
         texts = [
             synthetic_text(avg_len, seed=seed_base + 400 + i * k + j)
             for j in range(k)
         ]
-        _save(run_condition(texts, seed_base + 400 + i, "synthetic", "synthetic", i, pca_dim))
+        _save(run_condition(texts, seed_base + 400 + i, "synthetic", "synthetic", i))
 
     return all_results
 
@@ -469,14 +465,13 @@ def load_results() -> List[dict]:
 
 
 def summarise(results: List[dict]) -> dict:
-    """Per-condition summary statistics and yes/no verdict."""
     from collections import defaultdict
     by_cond = defaultdict(list)
     for r in results:
         by_cond[r["condition"]].append(r)
 
     print("\n" + "=" * 70)
-    print("PCA-FIRST TOPOLOGY EXPERIMENT — RESULTS SUMMARY")
+    print("ACTIVATION-SPACE TOPOLOGY EXPERIMENT — RESULTS SUMMARY")
     print("=" * 70)
 
     cond_stats = {}
@@ -484,7 +479,6 @@ def summarise(results: List[dict]) -> dict:
         tp_h1s = [r["topology"]["total_persistence_h1"] for r in runs]
         b1s = [r["topology"]["betti_1"] for r in runs]
         ents = [r["topology"]["persistence_entropy_h1"] for r in runs]
-        var_expls = [r["topology"].get("variance_explained", 0) for r in runs]
         cond_stats[cond] = {
             "n": len(runs),
             "tp_h1_mean": float(np.mean(tp_h1s)),
@@ -492,18 +486,15 @@ def summarise(results: List[dict]) -> dict:
             "b1_mean": float(np.mean(b1s)),
             "b1_std": float(np.std(b1s)),
             "ent_mean": float(np.mean(ents)),
-            "var_explained_mean": float(np.mean(var_expls)),
             "tp_h1_values": tp_h1s,
         }
         print(
             f"  {cond:12s}: n={len(runs):2d}  "
             f"tp_h1={np.mean(tp_h1s):.4f}±{np.std(tp_h1s):.4f}  "
             f"b1={np.mean(b1s):.2f}±{np.std(b1s):.2f}  "
-            f"entropy={np.mean(ents):.4f}  "
-            f"var_expl={np.mean(var_expls):.2f}"
+            f"entropy={np.mean(ents):.4f}"
         )
 
-    # ── Kruskal-Wallis ──
     print("\n--- Statistical tests ---")
     real_conds = [c for c in ["random", "coherent", "diverse"] if c in cond_stats]
     if len(real_conds) >= 2:
@@ -514,9 +505,9 @@ def summarise(results: List[dict]) -> dict:
                 stat, p = kruskal(*groups)
                 print(f"  Kruskal-Wallis (random vs coherent vs diverse): H={stat:.4f}  p={p:.4f}")
                 if p < 0.05:
-                    print("  *** Text selection significantly affects PCA-projected weight topology (p<0.05) ***")
+                    print("  *** Text selection affects activation-space topology (p<0.05) ***")
                 else:
-                    print("  No significant difference between conditions (p>=0.05)")
+                    print("  No significant difference (p>=0.05)")
         except ImportError:
             all_vals = [v for c in real_conds for v in cond_stats[c]["tp_h1_values"]]
             grand_mean = np.mean(all_vals)
@@ -524,17 +515,12 @@ def summarise(results: List[dict]) -> dict:
             within_var = np.mean([np.var(cond_stats[c]["tp_h1_values"]) for c in real_conds])
             print(f"  Between/within variance ratio: {between_var / (within_var + 1e-12):.4f}")
 
-    if "order" in cond_stats:
-        order_vals = cond_stats["order"]["tp_h1_values"]
-        print(f"  Order-permutation variance: {float(np.var(order_vals)):.6f}")
-
     if "synthetic" in cond_stats and "random" in cond_stats:
         diff = np.mean(cond_stats["random"]["tp_h1_values"]) - np.mean(cond_stats["synthetic"]["tp_h1_values"])
         print(f"  Real minus synthetic tp_h1: {diff:+.4f}")
 
-    # ── Verdict ──
     print("\n" + "=" * 70)
-    print("VERDICT (PCA-first topology)")
+    print("VERDICT (activation-space topology)")
     print("=" * 70)
     if len(real_conds) >= 2:
         try:
@@ -543,10 +529,10 @@ def summarise(results: List[dict]) -> dict:
             if all(len(g) > 1 for g in groups):
                 _, p = kruskal(*groups)
                 if p < 0.05:
-                    print("YES — after PCA projection, text selection affects weight-space topology.")
+                    print("YES — activation-space topology differentiates text selection conditions.")
+                    print("The geometry of what the model computes depends on *what* it reads.")
                 else:
-                    print("NO (p>=0.05) — PCA projection did not reveal condition-dependent topology.")
-                    print("Consider: experiment_activation_topology.py (activation-space approach).")
+                    print("NO (p>=0.05) — activation-space topology does not differentiate conditions.")
         except ImportError:
             print("(scipy unavailable — inspect statistics above)")
     else:
@@ -558,23 +544,17 @@ def summarise(results: List[dict]) -> dict:
 # ── Entry point ───────────────────────────────────────────────────────────
 
 def main():
-    parser = argparse.ArgumentParser(description="PCA-first weight-space topology experiment")
-    parser.add_argument("--quick", action="store_true",
-                        help="Smoke test: 3 runs per condition")
-    parser.add_argument("--analyze", action="store_true",
-                        help="Load saved results and analyse (no new runs)")
-    parser.add_argument("--k", type=int, default=K,
-                        help=f"Texts per run (default {K})")
-    parser.add_argument("--seed", type=int, default=42,
-                        help="Random seed base (default 42)")
-    parser.add_argument("--pca_dim", type=int, default=PCA_DIM,
-                        help=f"PCA target dimensions (default {PCA_DIM})")
+    parser = argparse.ArgumentParser(description="Activation-space topology experiment")
+    parser.add_argument("--quick", action="store_true", help="3 runs per condition")
+    parser.add_argument("--analyze", action="store_true", help="Load saved results")
+    parser.add_argument("--k", type=int, default=K)
+    parser.add_argument("--seed", type=int, default=42)
     args = parser.parse_args()
 
     if args.analyze:
         results = load_results()
         if not results:
-            print("No saved results found. Run the experiment first.")
+            print("No saved results. Run the experiment first.")
             return
         summarise(results)
         return
@@ -589,7 +569,7 @@ def main():
     results = run_experiment(
         n_random=n_r, n_coherent=n_c, n_diverse=n_d,
         n_order=n_o, n_synthetic=n_s,
-        k=args.k, seed_base=args.seed, pca_dim=args.pca_dim,
+        k=args.k, seed_base=args.seed,
     )
     elapsed = time.time() - t0
     print(f"\nTotal runtime: {elapsed:.1f}s  ({len(results)} runs)")

--- a/Vybn_Mind/creature_dgm_h/experiment_analysis.py
+++ b/Vybn_Mind/creature_dgm_h/experiment_analysis.py
@@ -2,35 +2,44 @@
 """
 experiment_analysis.py
 
-Load saved results from experiment_weight_topology.py and produce:
+Unified analysis for both topology experiment approaches:
+  - PCA-first persistence (experiment_weight_topology.py)
+  - Activation-space persistence (experiment_activation_topology.py)
+
+Loads results from either or both experiment directories, produces:
   - Console summary with statistical tests
-  - results_plot.json (bar chart data) for external visualisation
-  - per-condition persistence diagram data
+  - results_plot_data.json for external visualisation
+  - Comparative report when both experiments have data
 
 Usage:
-  python experiment_analysis.py
-  python experiment_analysis.py --results_dir /path/to/results
+  python experiment_analysis.py                          # analyse all available results
+  python experiment_analysis.py --experiment pca         # PCA-first only
+  python experiment_analysis.py --experiment activation  # activation-space only
+  python experiment_analysis.py --results_dir /path      # custom directory
 """
 
 from __future__ import annotations
 
 import argparse
 import json
-import math
 from collections import defaultdict
 from pathlib import Path
-import sys
 
 import numpy as np
 
 SCRIPT_DIR = Path(__file__).resolve().parent
-DEFAULT_RESULTS_DIR = SCRIPT_DIR / "experiment_results"
+PCA_RESULTS_DIR = SCRIPT_DIR / "experiment_results" / "pca_topology"
+ACTIVATION_RESULTS_DIR = SCRIPT_DIR / "experiment_results" / "activation_topology"
+# Legacy: flat experiment_results/ from the old raw weight-space experiment
+LEGACY_RESULTS_DIR = SCRIPT_DIR / "experiment_results"
 
 
 def load_results(results_dir: Path) -> list:
     results = []
+    if not results_dir.exists():
+        return results
     for f in sorted(results_dir.glob("*.json")):
-        if f.name == "summary.json":
+        if f.name in ("summary.json", "results_plot_data.json"):
             continue
         try:
             results.append(json.loads(f.read_text()))
@@ -39,7 +48,8 @@ def load_results(results_dir: Path) -> list:
     return results
 
 
-def analyse(results: list, output_dir: Path):
+def analyse_single(results: list, experiment_name: str, output_dir: Path) -> dict:
+    """Analyse results from one experiment type. Returns cond_stats dict."""
     by_cond = defaultdict(list)
     for r in results:
         by_cond[r["condition"]].append(r)
@@ -47,9 +57,9 @@ def analyse(results: list, output_dir: Path):
     cond_order = ["random", "coherent", "diverse", "order", "synthetic"]
     present = [c for c in cond_order if c in by_cond]
 
-    print("\n" + "=" * 70)
-    print("WEIGHT-SPACE TOPOLOGY EXPERIMENT — ANALYSIS")
-    print("=" * 70)
+    print(f"\n{'=' * 70}")
+    print(f"{experiment_name.upper()} EXPERIMENT — ANALYSIS")
+    print(f"{'=' * 70}")
     print(f"  Conditions: {present}")
     print(f"  Total runs: {len(results)}")
     print()
@@ -61,6 +71,10 @@ def analyse(results: list, output_dir: Path):
         b1 = [r["topology"]["betti_1"] for r in runs]
         ent = [r["topology"]["persistence_entropy_h1"] for r in runs]
         losses = [r["final_loss"] for r in runs]
+        extra = {}
+        if "variance_explained" in runs[0].get("topology", {}):
+            var_expl = [r["topology"]["variance_explained"] for r in runs]
+            extra["var_explained_mean"] = float(np.mean(var_expl))
         cond_stats[cond] = {
             "n": len(runs),
             "tp_h1": tp,
@@ -73,58 +87,55 @@ def analyse(results: list, output_dir: Path):
             "b1_std": float(np.std(b1)),
             "ent_mean": float(np.mean(ent)),
             "loss_mean": float(np.mean(losses)),
+            **extra,
         }
+        var_str = f"  var_expl={extra['var_explained_mean']:.2f}" if "var_explained_mean" in extra else ""
         print(
             f"  {cond:12s}  n={len(runs):2d}  "
             f"tp_h1={np.mean(tp):.4f}±{np.std(tp):.4f}  "
             f"b1={np.mean(b1):.2f}±{np.std(b1):.2f}  "
             f"entropy={np.mean(ent):.4f}  "
-            f"loss={np.mean(losses):.4f}"
+            f"loss={np.mean(losses):.4f}{var_str}"
         )
 
     # ── Statistical tests ──
-    print("\n" + "-" * 70)
+    print(f"\n{'-' * 70}")
     print("STATISTICAL TESTS")
-    print("-" * 70)
+    print(f"{'-' * 70}")
 
     real = [c for c in ["random", "coherent", "diverse"] if c in cond_stats]
+    kw_p = None
     if len(real) >= 2:
         try:
             from scipy.stats import kruskal, mannwhitneyu
             groups = [cond_stats[c]["tp_h1"] for c in real]
             if all(len(g) > 1 for g in groups):
                 H, p = kruskal(*groups)
+                kw_p = p
                 print(f"  Kruskal-Wallis (random/coherent/diverse): H={H:.4f}  p={p:.6f}")
-                sig = p < 0.05
-                print(f"  Result: {'SIGNIFICANT' if sig else 'NOT SIGNIFICANT'} (alpha=0.05)")
-
-                # Pairwise Mann-Whitney
+                print(f"  Result: {'SIGNIFICANT' if p < 0.05 else 'NOT SIGNIFICANT'} (alpha=0.05)")
                 print()
                 for i, ca in enumerate(real):
-                    for cb in real[i+1:]:
+                    for cb in real[i + 1:]:
                         if len(cond_stats[ca]["tp_h1"]) > 1 and len(cond_stats[cb]["tp_h1"]) > 1:
                             u, pu = mannwhitneyu(
                                 cond_stats[ca]["tp_h1"],
                                 cond_stats[cb]["tp_h1"],
-                                alternative="two-sided"
+                                alternative="two-sided",
                             )
                             print(f"  Mann-Whitney {ca} vs {cb}: U={u:.1f}  p={pu:.4f}"
                                   f"  {'*' if pu < 0.05 else ''}")
         except ImportError:
-            print("  scipy not available — using variance ratio")
             all_v = [v for c in real for v in cond_stats[c]["tp_h1"]]
             gm = np.mean(all_v)
             bv = np.mean([(np.mean(cond_stats[c]["tp_h1"]) - gm) ** 2 for c in real])
             wv = np.mean([np.var(cond_stats[c]["tp_h1"]) for c in real])
-            print(f"  Between/within variance ratio: {bv/(wv+1e-12):.4f}")
+            print(f"  Between/within variance ratio: {bv / (wv + 1e-12):.4f}")
 
-    # Order effect
     if "order" in cond_stats:
         ov = cond_stats["order"]["tp_h1"]
         print(f"\n  Order-permutation variance: {float(np.var(ov)):.6f}")
-        print(f"  (>0 means reading order changes weight-space topology)")
 
-    # Synthetic control
     if "synthetic" in cond_stats and "random" in cond_stats:
         real_tp = cond_stats["random"]["tp_mean"]
         syn_tp = cond_stats["synthetic"]["tp_mean"]
@@ -132,76 +143,115 @@ def analyse(results: list, output_dir: Path):
         print(f"\n  Real vs synthetic tp_h1 difference: {diff:+.4f}")
         if diff > 0.01:
             print("  Real text produces RICHER topology than random sequences.")
-            print("  This suggests the topology signal reflects linguistic structure, not just counting.")
         elif abs(diff) <= 0.01:
             print("  Real and synthetic text produce SIMILAR topology.")
-            print("  The topology signal may be a counting/dimensionality artifact.")
         else:
-            print("  Synthetic text produces RICHER topology than real text (unexpected).")
+            print("  Synthetic text produces RICHER topology (unexpected).")
 
     # ── Correlation: topology vs loss ──
-    print("\n" + "-" * 70)
+    print(f"\n{'-' * 70}")
     print("TOPOLOGY vs LOSS CORRELATION")
-    print("-" * 70)
+    print(f"{'-' * 70}")
     all_tp = [r["topology"]["total_persistence_h1"] for r in results]
     all_loss = [r["final_loss"] for r in results]
     if len(all_tp) > 3:
         corr = float(np.corrcoef(all_tp, all_loss)[0, 1])
         print(f"  Pearson r(tp_h1, final_loss) = {corr:.4f}")
-        if abs(corr) > 0.3:
-            sign = "positively" if corr > 0 else "negatively"
-            print(f"  Richer topology is {sign} correlated with final loss.")
-        else:
-            print("  Weak correlation — topology and loss are largely independent.")
 
     # ── Save plot data ──
+    output_dir.mkdir(parents=True, exist_ok=True)
     plot_data = {
+        "experiment": experiment_name,
         "conditions": present,
         "tp_h1_means": [cond_stats[c]["tp_mean"] for c in present],
         "tp_h1_stds": [cond_stats[c]["tp_std"] for c in present],
         "b1_means": [cond_stats[c]["b1_mean"] for c in present],
         "b1_stds": [cond_stats[c]["b1_std"] for c in present],
-        "cond_stats": cond_stats,
     }
     plot_path = output_dir / "results_plot_data.json"
     with open(plot_path, "w") as f:
         json.dump(plot_data, f, indent=2, default=str)
     print(f"\n  Plot data saved to: {plot_path}")
 
-    # ── Final verdict ──
-    print("\n" + "=" * 70)
-    print("VERDICT")
-    print("=" * 70)
-    try:
-        from scipy.stats import kruskal
-        groups = [cond_stats[c]["tp_h1"] for c in real if len(cond_stats[c]["tp_h1"]) > 1]
-        if len(groups) >= 2:
-            _, p = kruskal(*groups)
-            if p < 0.05:
-                print("YES — text selection measurably affects weight-space topology (p < 0.05).")
-                print("The topology of weight space carries information about *what* was learned,")
-                print("not just *how much*. The nw fitness component is detecting real structure.")
-            else:
-                print("NO (p >= 0.05) — text selection does not significantly affect weight-space topology.")
-                print("The nw fitness component may reward a counting artifact (more texts → higher Betti).")
-                print("Recommendation: redesign nw to normalise by n_snapshots, or remove it.")
+    # ── Verdict ──
+    print(f"\n{'=' * 70}")
+    print(f"VERDICT ({experiment_name})")
+    print(f"{'=' * 70}")
+    if kw_p is not None:
+        if kw_p < 0.05:
+            print(f"YES — text selection significantly affects {experiment_name} topology (p < 0.05).")
         else:
-            print("(Insufficient groups for Kruskal-Wallis)")
-    except ImportError:
-        print("(scipy not available — inspect statistics above)")
+            print(f"NO (p >= 0.05) — text selection does not significantly affect {experiment_name} topology.")
+    else:
+        print("(Insufficient data or scipy unavailable for verdict)")
+
+    return cond_stats
+
+
+def compare_experiments(pca_stats: dict, act_stats: dict):
+    """Print side-by-side comparison when both experiments have results."""
+    print(f"\n{'=' * 70}")
+    print("CROSS-EXPERIMENT COMPARISON")
+    print(f"{'=' * 70}")
+
+    conds = sorted(set(pca_stats.keys()) & set(act_stats.keys()))
+    if not conds:
+        print("  No overlapping conditions to compare.")
+        return
+
+    print(f"  {'Condition':12s}  {'PCA tp_h1':>12s}  {'Act tp_h1':>12s}  {'PCA b1':>8s}  {'Act b1':>8s}")
+    print(f"  {'-' * 12}  {'-' * 12}  {'-' * 12}  {'-' * 8}  {'-' * 8}")
+    for c in conds:
+        p, a = pca_stats[c], act_stats[c]
+        print(
+            f"  {c:12s}  {p['tp_mean']:8.4f}±{p['tp_std']:.3f}  "
+            f"{a['tp_mean']:8.4f}±{a['tp_std']:.3f}  "
+            f"{p['b1_mean']:6.2f}±{p['b1_std']:.1f}  "
+            f"{a['b1_mean']:6.2f}±{a['b1_std']:.1f}"
+        )
+
+    # Which approach shows more inter-condition variance?
+    for name, stats in [("PCA-first", pca_stats), ("Activation", act_stats)]:
+        real = [c for c in ["random", "coherent", "diverse"] if c in stats]
+        if len(real) >= 2:
+            means = [stats[c]["tp_mean"] for c in real]
+            spread = max(means) - min(means)
+            print(f"\n  {name} inter-condition tp_h1 spread: {spread:.4f}")
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Analyse weight-topology experiment results")
-    parser.add_argument("--results_dir", type=Path, default=DEFAULT_RESULTS_DIR)
+    parser = argparse.ArgumentParser(description="Analyse topology experiment results")
+    parser.add_argument("--experiment", choices=["pca", "activation", "both"], default="both",
+                        help="Which experiment to analyse (default: both)")
+    parser.add_argument("--results_dir", type=Path, default=None,
+                        help="Override results directory (for single-experiment mode)")
     args = parser.parse_args()
 
-    results = load_results(args.results_dir)
-    if not results:
-        print(f"No results found in {args.results_dir}")
-        print("Run experiment_weight_topology.py first.")
-        return
-    analyse(results, args.results_dir)
+    pca_stats, act_stats = None, None
+
+    if args.experiment in ("pca", "both"):
+        d = args.results_dir if args.results_dir and args.experiment == "pca" else PCA_RESULTS_DIR
+        results = load_results(d)
+        if results:
+            pca_stats = analyse_single(results, "PCA-first persistence", d)
+        elif args.experiment == "pca":
+            print(f"No PCA results found in {d}")
+
+    if args.experiment in ("activation", "both"):
+        d = args.results_dir if args.results_dir and args.experiment == "activation" else ACTIVATION_RESULTS_DIR
+        results = load_results(d)
+        if results:
+            act_stats = analyse_single(results, "Activation-space persistence", d)
+        elif args.experiment == "activation":
+            print(f"No activation results found in {d}")
+
+    if pca_stats and act_stats:
+        compare_experiments(pca_stats, act_stats)
+
+    if not pca_stats and not act_stats:
+        print("No results found. Run one of:")
+        print("  python experiment_weight_topology.py   # PCA-first approach")
+        print("  python experiment_activation_topology.py  # activation-space approach")
 
 
 if __name__ == "__main__":

--- a/Vybn_Mind/creature_dgm_h/vybn.py
+++ b/Vybn_Mind/creature_dgm_h/vybn.py
@@ -1052,16 +1052,33 @@ def fitness(ext_texts, self_texts, loss_history, persistent_state=None, alpha=0.
             betti_tuple = persistent_state.betti_history[-1]
         structural_growth_val = round(ng, 6)
 
-    # -- Weight-space topology (nw) --
+    # -- Weight-space topology via PCA projection (nw) --
+    # The original raw weight-space persistence produced a uniform null result
+    # (β₁ = 0, total H1 = 0) because ~4K-dim pairwise distances are dominated
+    # by the curse of dimensionality.  We now PCA-project to ≤20 dimensions
+    # before computing persistent homology so the Rips filtration can find
+    # meaningful structure.
     nw = 0.5  # default: neutral
     if weight_vectors is not None and len(weight_vectors) >= 3:
         wv_array = np.array(weight_vectors)
-        D_w = _distance_matrix(wv_array)
+        n_wv, d_wv = wv_array.shape
+        pca_target = min(20, n_wv - 1, d_wv)
+        if pca_target >= 2:
+            mean_wv = wv_array.mean(axis=0)
+            centered = wv_array - mean_wv
+            try:
+                _, S, Vt = np.linalg.svd(centered, full_matrices=False)
+                projected = centered @ Vt[:pca_target].T
+            except np.linalg.LinAlgError:
+                projected = centered[:, :pca_target]
+        else:
+            projected = wv_array
+        D_w = _distance_matrix(projected)
         _, betti_w = _persistence_pairs(D_w)
         nw = min(betti_w[1] / 3.0, 1.0)
 
     # Weighted combination: curvature 25%, divergence 20%, loss 15%,
-    # topological richness 25%, weight-space topology 15%
+    # topological richness 25%, weight-space topology (PCA-projected) 15%
     fit = round(0.25 * nc + 0.20 * nd + 0.15 * nl + 0.25 * nr + 0.15 * nw, 6)
 
     return {

--- a/spark/journal/controlled_experiment_spec.md
+++ b/spark/journal/controlled_experiment_spec.md
@@ -1,138 +1,119 @@
 # Controlled Experiment: Does Text Selection Affect Weight-Space Topology?
 
-## Status: Proposed — seeking outside input before implementation
+## Status: Superseded — replaced by PCA-first and activation-space approaches
+
+> **Important (2026-03):** The original raw weight-space topology experiment produced a
+> uniform null result: β₁ = 0 and total H1 persistence = 0 across all conditions.
+> This was caused by the curse of dimensionality — pairwise Euclidean distances in
+> ~4K-dimensional raw weight space are nearly uniform, making Rips filtration
+> unable to detect meaningful structure.  The prior apparent positive result was a bug.
+>
+> Two replacement approaches now live in `Vybn_Mind/creature_dgm_h/`:
+>
+> 1. **PCA-first persistence** (`experiment_weight_topology.py`):
+>    Project weight vectors to ~20 dimensions via PCA before computing homology.
+>    Concentrates variance along the learning trajectory.
+>
+> 2. **Activation-space persistence** (`experiment_activation_topology.py`):
+>    Track hidden-layer activations (16-dim) instead of raw weights.
+>    Lower-dimensional, semantically tied to model behaviour.
+>
+> The `fitness()` function's `nw` component now uses PCA-projected weights.
+
+---
 
 ## The question
 
 When a small neural network learns from text, its weight updates trace a path through weight space. We compute persistent homology (Betti numbers) on snapshots of that path. The question is:
 
-**Holding the number of texts constant, do different *selections* of text produce measurably different topological signatures in weight space?**
+**Holding the number of texts constant, do different *selections* of text produce measurably different topological signatures?**
 
-If yes: topology captures something about how the *content* interacts with the learner — resonance, coherence, interference patterns between texts. That's interesting.
+If yes: topology captures something about how the *content* interacts with the learner — resonance, coherence, interference patterns between texts.
 
-If no: the topology signal is just a function of sample count, and the current fitness metric is rewarding a counting artifact. That's important to know.
+If no: the topology signal is just a function of sample count, and the current fitness metric is rewarding a counting artifact.
 
-## Current system (what exists)
+## Current approach (2026-03)
 
-**Code:** `Vybn_Mind/creature_dgm_h/vybn.py` (~1440 lines)
+### Approach 1: PCA-first persistence
 
-**Architecture:**
-- A character-level prediction network (1-layer transformer, embed_dim=16, 4 heads, block_size=16)
-- Creatures have genomes encoding: text selection strategy, learning rate, number of training epochs, text ordering
-- Each creature reads texts, trains its network, and we evaluate fitness
-- Fitness is a weighted combination of: embedding curvature (25%), embedding divergence (20%), prediction loss (15%), topological richness of encounter embeddings (25%), **weight-space topology (15%)**
+**Script:** `Vybn_Mind/creature_dgm_h/experiment_weight_topology.py`
 
-**Weight-space topology (the component under test):**
-- After training on selected texts, we flatten all network weights into a vector — one snapshot per text encounter
-- Given N text encounters → N weight vectors (each ~4K-dimensional for this network)
-- We compute pairwise Euclidean distances → distance matrix
-- Run a greedy union-find Rips filtration → persistence pairs → Betti numbers
-- `nw = min(betti_1 / 3.0, 1.0)` — rewards 1-cycles (loops) in weight space
-- Currently lives in the `fitness()` function, lines ~1055-1063
+- Snapshot weight vectors every SNAP_EVERY gradient steps during training
+- PCA-project to target_dim dimensions (default 20)
+- Compute persistent homology on the projected point cloud
+- Reports: Betti numbers, total persistence, persistence entropy, PCA variance explained
 
-**Problem with current setup:**
-- Variant 1 (the "organism") reads ALL texts in the corpus (~7+ texts)
-- Variants 2-5 (mutants) read 3 texts each
-- More texts → more weight snapshots → more points → trivially higher Betti numbers
-- We can't distinguish "topology captures learning structure" from "topology counts data points"
+```bash
+python experiment_weight_topology.py              # full experiment
+python experiment_weight_topology.py --quick      # smoke test (3 runs/condition)
+python experiment_weight_topology.py --pca_dim 30 # custom PCA dimension
+```
 
-## Proposed controlled experiment
+### Approach 2: Activation-space persistence
 
-### Design: Paired comparison with fixed text count
+**Script:** `Vybn_Mind/creature_dgm_h/experiment_activation_topology.py`
 
-**Constants (same across all conditions):**
-- Network architecture (identical initialization, same random seed)
-- Number of texts: **K** (e.g., K=5 or K=7, depending on corpus size)
-- Number of training epochs per text
-- Learning rate
+- After each gradient step, run a forward pass on a fixed probe sentence
+- Capture the mean hidden-state vector (16-dim) across positions
+- Compute persistent homology directly on the activation point cloud (no PCA needed)
+- Reports: Betti numbers, total persistence, persistence entropy
 
-**Independent variable:** Which K texts are selected, and in what order
+```bash
+python experiment_activation_topology.py          # full experiment
+python experiment_activation_topology.py --quick  # smoke test
+```
 
-**Dependent variable:** Betti numbers (especially β₁) of the weight-space point cloud after all K texts are processed
+### Unified analysis
 
-### Conditions
+**Script:** `Vybn_Mind/creature_dgm_h/experiment_analysis.py`
 
-Given a corpus of T total texts:
+```bash
+python experiment_analysis.py                         # both experiments
+python experiment_analysis.py --experiment pca        # PCA-first only
+python experiment_analysis.py --experiment activation # activation only
+```
 
-1. **Random selection baseline (N=20 runs):** For each run, randomly sample K texts from T, random order. Train, snapshot weights after each text, compute topology. This gives us the null distribution of β₁.
+## Five conditions (unchanged from original design)
 
-2. **Thematically coherent sets (N=10 runs):** Hand-curate or algorithmically cluster texts into coherent groups (e.g., all from the same conversation, all on the same topic). Sample K texts from within one cluster. Does coherence → different topology?
+Given a corpus of T total texts, K=5 texts per run:
 
-3. **Maximally diverse sets (N=10 runs):** Select K texts that maximize pairwise embedding distance (farthest-point sampling in embedding space). Does diversity → different topology?
+1. **Random selection baseline (N=20):** K texts sampled randomly
+2. **Thematically coherent sets (N=10):** K texts from the same cluster
+3. **Maximally diverse sets (N=10):** K texts maximising embedding distance
+4. **Order permutation control (N=10):** Fixed K texts, permuted orderings
+5. **Synthetic control (N=10):** Random character sequences, matched length
 
-4. **Order permutation control (N=10 runs):** Take ONE fixed set of K texts. Permute the reading order. Does order alone change topology?
+## Measurements per run
 
-### Measurements per run
-
-- Weight vectors after each of the K text encounters (K points in weight space)
 - Full persistence diagram (birth-death pairs) for H₀ and H₁
 - Betti numbers β₀, β₁ at median threshold
-- Total persistence (sum of death-birth for all finite pairs) — more robust than Betti numbers at a single threshold
-- Bottleneck distance or Wasserstein distance between persistence diagrams across conditions (if we want to compare shapes, not just counts)
-- Prediction loss trajectory (to correlate topology with learning quality)
+- Total persistence (sum of death-birth for all finite pairs)
+- Persistence entropy (Shannon entropy of H1 lifetime distribution)
+- PCA variance explained (approach 1 only)
+- Prediction loss trajectory
 
-### Analysis
+## Analysis
 
-1. **Is β₁ variance > 0 across conditions?** If all runs produce the same topology regardless of text selection, the signal is artifactual.
+1. **Kruskal-Wallis** across conditions 1-3: do selections differ?
+2. **Mann-Whitney** pairwise tests for individual condition pairs
+3. **Order variance** (condition 4): does reading order affect topology?
+4. **Synthetic control** (condition 5): real text vs random — counting artifact check
+5. **Topology-loss correlation**: is topological richness functionally meaningful?
 
-2. **Do conditions differ?** Compare β₁ distributions across conditions 1-3 using Kruskal-Wallis or permutation test. If coherent sets produce systematically different topology than diverse sets, text content shapes weight-space geometry.
+## What a positive result means
 
-3. **Does order matter?** Condition 4 isolates order effects. If same texts in different orders produce different topology, the learning *path* matters, not just the destination.
+If different text selections produce reliably different topologies:
+- The topology of weight/activation space is a fingerprint of *what was learned*
+- This fingerprint is selectable via genetic algorithm
+- The `nw` fitness component is detecting real structure
 
-4. **Correlation with loss:** Does richer topology (higher β₁) correlate with better or worse prediction? This tells us whether topological complexity in weight space is functionally meaningful.
+## What a negative result means
 
-### Statistical power concern
-
-With K=5, we have 5 points in ~4K-dimensional space. Persistent homology on 5 points is limited — you can get at most (5 choose 2) = 10 edges, and the Betti numbers will be small. Options:
-
-**Option A: More snapshots.** Instead of one snapshot per text, take a snapshot every N gradient steps during training on each text. K=5 texts × 20 snapshots each = 100 points. Much richer topology. This is probably the right move.
-
-**Option B: Larger corpus.** Use K=15 or K=20 texts. Requires a larger corpus. May also change the character of the experiment (more like "curriculum" than "reading list").
-
-**Option C: Lower-dimensional projection.** Project weight vectors to e.g. 50 dimensions via PCA before computing topology. Reduces noise, makes distances more meaningful, but loses information.
-
-**Recommendation:** Option A first. It's the most informative because it captures the *dynamics* of learning, not just the endpoints. The trajectory through weight space during training on a single text is itself a topological object.
-
-## What a positive result would mean
-
-If different text selections produce reliably different weight-space topologies (controlling for count), then:
-
-1. The topology of weight space is a fingerprint of *what was learned*, not just *how much*
-2. This fingerprint is selectable — a genetic algorithm can evolve toward richer or sparser topological signatures
-3. The mathematical structure of "how reading shapes a mind" is accessible to persistent homology
-4. This connects to a broader question: can we characterize the *geometry of understanding* — the shape that knowledge takes when it's embodied in weights?
-
-## What a negative result would mean
-
-If text selection doesn't matter and only count does:
-
-1. The weight-space topology component of fitness should be removed or redesigned
-2. The current results (Generation 47) are artifactual
-3. We learn something true: in this regime (small network, few texts), weight-space geometry is dominated by dimensionality effects, not content effects
-4. We should look for topology elsewhere — perhaps in the *embedding* space of text representations rather than in the *weight* space of the network
-
-## Implementation notes
-
-- The experiment should be a standalone script that imports from `vybn.py` but doesn't run the full evolutionary loop
-- Each run should log: the text selection, the order, all weight snapshots, the persistence diagram, the Betti numbers, and the final loss
-- Results should be saved as JSON for analysis
-- A simple analysis script should compute summary statistics and generate a yes/no answer to the core question
-- Estimated runtime: depends on training time per text, but with 50 runs × K texts × E epochs, probably 10-30 minutes on the Spark
-
-## Open questions for reviewer
-
-1. Is the greedy union-find Rips filtration adequate, or should we use a proper Vietoris-Rips complex (e.g., via `ripser` or `gudhi`)? The current implementation is approximate.
-
-2. Should we use total persistence or persistence entropy instead of Betti numbers at a single threshold? Betti numbers are threshold-sensitive; total persistence integrates over the filtration.
-
-3. The network is tiny (16-dim embeddings, 1 layer, ~4K parameters). Is this *too* small for meaningful weight-space topology, or is small actually better (less noise, more interpretable)?
-
-4. Is there prior work on persistent homology of weight-space trajectories during training? I'm aware of loss-landscape topology work (e.g., Birdal et al. on intrinsic dimension) but not specifically on homology of the weight trajectory point cloud.
-
-5. The texts are from Vybn's archive — conversations, reflections, breath logs. Should we also test on controlled synthetic texts (e.g., random character sequences vs. structured language) to separate content effects from language-structure effects?
+If text selection doesn't matter:
+- The weight-space topology component should be removed or further redesigned
+- Look for topology in other spaces (e.g. gradient space, loss landscape)
 
 ---
 
-*Written by Vybn (Claude Opus on DGX Spark), June 2025*
-*For review by: [outside instance/model]*
-*Repo: github.com/zoedolan/Vybn, path: Vybn_Mind/creature_dgm_h/*
+*Original spec: Vybn (Claude Opus on DGX Spark), June 2025*
+*Updated: March 2026 — superseded raw weight-space approach with PCA-first and activation-space persistence*


### PR DESCRIPTION
## Summary

- **Supersedes** the existing raw weight-space topology experiment, which produced a uniform null result (β₁=0, total H1=0) due to the curse of dimensionality in ~4K-dim weight space
- **Adds PCA-first persistence** (`experiment_weight_topology.py`, rewritten): projects weight snapshots to ~20 dims via PCA before computing persistent homology
- **Adds activation-space persistence** (`experiment_activation_topology.py`, new): captures hidden-layer activations (16-dim) via a fixed probe, computing topology on what the model *computes* rather than what it *stores*
- **Updates `fitness()` nw component**: now PCA-projects weight vectors before Rips filtration
- **Updates docs**: spec marked as superseded, README documents both new paths, unified analysis script supports both experiments

## Files changed

| File | Change |
|------|--------|
| `Vybn_Mind/creature_dgm_h/experiment_weight_topology.py` | Rewritten: PCA-first persistence replaces raw weight-space |
| `Vybn_Mind/creature_dgm_h/experiment_activation_topology.py` | New: activation-space persistence experiment |
| `Vybn_Mind/creature_dgm_h/experiment_analysis.py` | Rewritten: unified analysis for both experiments |
| `Vybn_Mind/creature_dgm_h/vybn.py` | Updated: `fitness()` nw term uses PCA projection |
| `Vybn_Mind/creature_dgm_h/README.md` | Updated: documents both experiment paths |
| `spark/journal/controlled_experiment_spec.md` | Updated: marks original approach as superseded |

## How to invoke

```bash
# PCA-first persistence
python experiment_weight_topology.py --quick       # smoke test
python experiment_weight_topology.py               # full run
python experiment_weight_topology.py --pca_dim 30  # custom PCA dim

# Activation-space persistence
python experiment_activation_topology.py --quick   # smoke test
python experiment_activation_topology.py           # full run

# Unified analysis
python experiment_analysis.py                      # both
python experiment_analysis.py --experiment pca     # PCA only
python experiment_analysis.py --experiment activation  # activation only
```

## Test plan

- [x] Both experiment scripts import and load without errors
- [x] PCA projection produces correct shapes and variance explained
- [x] Both experiments complete `--quick --k 3` smoke tests end-to-end
- [x] Unified analysis script processes results from both experiments
- [x] `fitness()` with PCA-projected weight vectors returns valid results
- [x] No stale references to old raw weight-space approach in modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)