### PR TITLE
Weight-geometry experiment: SVD anisotropy replacing frozen embedder probe

### DIFF
--- a/Vybn_Mind/creature_dgm_h/experiment_sequence_topology.py
+++ b/Vybn_Mind/creature_dgm_h/experiment_sequence_topology.py
@@ -1,41 +1,38 @@
 #!/usr/bin/env python3
 """
-experiment_sequence_topology.py  —  Geometry chapter: curvature trajectory.
+experiment_sequence_topology.py  —  Geometry chapter: weight-space geometry.
 
-The topology chapter closed with zero H1 across four representations.
-The dimensionality wall was the reason: 43 points in 768 dimensions
-cannot form cycles.
+Previous attempt used encounter_complex() to measure curvature, but that
+probe runs a fixed sentence through a *frozen* external embedder (MiniLM).
+It has no path to the creature's weights.  The 0.0 result was guaranteed.
 
-This experiment asks the question topology could not answer:
+This experiment measures geometry that actually lives inside the creature:
 
-  Does the creature's loss landscape deform *differently* when it
-  is learning meaningful text versus memorising noise?
+  After each gradient step, compute the singular value spectrum of every
+  weight matrix in agent.sd.  Track two quantities:
 
-Method: measure sectional curvature (Pancharatnam phase via encounter_complex)
-after every gradient step.  Track two trajectories side-by-side — real text
-vs synthetic — and test whether they diverge and stay diverged.
+    anisotropy  = sigma_1 / frobenius_norm   (how directionally biased)
+    spectral_entropy = -sum(p_i * log(p_i))  where p_i = sigma_i / sum(sigma)
+                       (how spread the variance is across directions)
 
-This uses only the geometry already present in vybn.py.  No ripser.
-No dimensionality wall.  No new dependencies.
+  Both are pure functions of the creature's weights.  No external embedder.
+  No frozen probe.  The weights move when loss drops; these numbers must move
+  if weight geometry changes at all.
 
-Design:
-  - Two conditions: real (corpus sample) vs synthetic (random chars)
-  - N_SEEDS seeds x 2 conditions = 2*N_SEEDS runs
-  - K texts per run, STEPS_PER_TEXT gradient steps each
-  - After every gradient step, call encounter_complex() on the probe
-    sentence and record curvature
-  - Output: per-step curvature trajectories + divergence stats
+Question: does the weight-space geometry evolve differently when the creature
+is learning meaningful text versus memorising random noise?
 
 Verdict logic:
-  - Trajectories diverge and stay diverged  -> landscape shape encodes
-    what is being learned; geometry is a real signal
-  - Trajectories indistinguishable           -> geometry is weight-space
-    noise at this scale; close this chapter too with clean conscience
-  - Mixed / inconclusive                     -> examine per-seed curves
+  - Real and synthetic trajectories diverge in anisotropy or entropy
+    -> weight geometry encodes what is being learned; signal confirmed
+  - Trajectories indistinguishable
+    -> close this line of inquiry; the creature is too uniform at this scale
+  - Mixed
+    -> inspect per-matrix and per-seed curves
 
 Usage:
-  python experiment_sequence_topology.py          # full run
-  python experiment_sequence_topology.py --quick  # 2 seeds only
+  python experiment_sequence_topology.py          # full run (5 seeds)
+  python experiment_sequence_topology.py --quick  # 2 seeds
   python experiment_sequence_topology.py --analyze
 """
 
@@ -49,7 +46,7 @@ import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import List
+from typing import List, Dict
 
 import numpy as np
 
@@ -61,21 +58,76 @@ sys.path.insert(0, str(SCRIPT_DIR))
 
 from vybn import (
     TopoAgent,
-    encounter_complex,
-    _distance_matrix,
     CORPUS_PATH,
     RV, N_EMBD, N_LAYER, N_HEAD, HEAD_DIM, BLOCK_SIZE,
     _forward, _softmax,
 )
 
 # ── Config ────────────────────────────────────────────────────────────────
-K              = 3     # texts per run
-STEPS_PER_TEXT = 15    # gradient steps per text
+K              = 3
+STEPS_PER_TEXT = 15
 LR             = 0.01
-PROBE_SENTENCE = "the topology of learning"   # fixed probe for curvature
 N_SEEDS        = 5
-RESULTS_DIR    = SCRIPT_DIR / "experiment_results" / "curvature_trajectory"
+RESULTS_DIR    = SCRIPT_DIR / "experiment_results" / "weight_geometry"
 RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+
+
+# ── Weight-space geometry probe ───────────────────────────────────────────
+
+def weight_geometry(agent: TopoAgent) -> Dict[str, float]:
+    """Measure anisotropy and spectral entropy of the creature's weight matrices.
+
+    Only 2-D weight matrices are meaningful for SVD (embeddings, projections).
+    Scalar/1-D params (biases, norms) are skipped.
+
+    anisotropy     = sigma_1 / frobenius_norm  in [0, 1]
+                     near 1 -> one direction dominates (spiky)
+                     near 0 -> uniform (flat)
+
+    spectral_entropy = -sum(p_i * log(p_i + 1e-12))  where p_i = sigma_i / sum
+                     high -> variance spread across many directions
+                     low  -> collapsed onto few directions
+    """
+    anisotropies: List[float] = []
+    entropies:    List[float] = []
+
+    for key, mat in agent.sd.items():
+        # mat is a list-of-lists; convert to numpy
+        try:
+            arr = np.array([[p.data if hasattr(p, 'data') else float(p)
+                             for p in row]
+                            for row in mat], dtype=np.float64)
+        except (TypeError, ValueError):
+            continue
+
+        if arr.ndim != 2 or min(arr.shape) < 2:
+            continue
+
+        try:
+            sv = np.linalg.svd(arr, compute_uv=False)
+        except np.linalg.LinAlgError:
+            continue
+
+        frob = float(np.linalg.norm(arr, 'fro'))
+        if frob < 1e-12:
+            continue
+
+        anisotropies.append(float(sv[0]) / frob)
+
+        sv_sum = float(sv.sum())
+        if sv_sum > 1e-12:
+            p   = sv / sv_sum
+            ent = float(-np.sum(p * np.log(p + 1e-12)))
+            entropies.append(ent)
+
+    if not anisotropies:
+        return {"anisotropy": 0.0, "spectral_entropy": 0.0, "n_matrices": 0}
+
+    return {
+        "anisotropy":      round(float(np.mean(anisotropies)), 8),
+        "spectral_entropy": round(float(np.mean(entropies)),   8),
+        "n_matrices":      len(anisotropies),
+    }
 
 
 # ── Corpus helpers ────────────────────────────────────────────────────────
@@ -117,7 +169,6 @@ def synthetic_text(length_chars: int, seed: int) -> str:
 # ── Single gradient step ─────────────────────────────────────────────────
 
 def _gradient_step(agent: TopoAgent, tokens: list, n: int) -> float:
-    """Run one Adam step on `tokens`; return scalar loss."""
     keys = [[] for _ in range(N_LAYER)]
     vals = [[] for _ in range(N_LAYER)]
     loss = RV(0.0)
@@ -150,10 +201,11 @@ def run_condition(
     np.random.seed(seed % 2 ** 31)
     random.seed(seed)
 
-    agent             = TopoAgent(config={"learn_lr": LR})
-    curvature_traj: List[float] = []
-    loss_traj:      List[float] = []
-    step_global     = 0
+    agent               = TopoAgent(config={"learn_lr": LR})
+    aniso_traj:   List[float] = []
+    entropy_traj: List[float] = []
+    loss_traj:    List[float] = []
+    step_global   = 0
 
     for text in texts:
         clean = agent._clean(text)
@@ -166,39 +218,44 @@ def run_condition(
             loss_val = _gradient_step(agent, tokens, n)
             loss_traj.append(round(loss_val, 6))
 
-            # measure curvature on fixed probe after this step
-            cx = encounter_complex(PROBE_SENTENCE)
-            curvature_traj.append(round(cx.curvature, 6))
+            g = weight_geometry(agent)
+            aniso_traj.append(g["anisotropy"])
+            entropy_traj.append(g["spectral_entropy"])
             step_global += 1
 
-    curv   = np.array(curvature_traj)
-    losses = np.array(loss_traj)
+    aniso   = np.array(aniso_traj)
+    entropy = np.array(entropy_traj)
+    losses  = np.array(loss_traj)
 
-    if len(curv) > 1:
-        xs    = np.arange(len(curv), dtype=float)
-        slope = float(np.polyfit(xs, curv, 1)[0])
-    else:
-        slope = 0.0
+    def _slope(arr: np.ndarray) -> float:
+        if len(arr) < 2:
+            return 0.0
+        return float(np.polyfit(np.arange(len(arr), dtype=float), arr, 1)[0])
 
-    mid        = len(curv) // 2
-    early_mean = float(curv[:mid].mean()) if mid > 0       else float(curv.mean())
-    late_mean  = float(curv[mid:].mean()) if mid < len(curv) else float(curv.mean())
-    drift      = round(late_mean - early_mean, 6)
+    def _drift(arr: np.ndarray) -> float:
+        mid = len(arr) // 2
+        if mid == 0 or mid >= len(arr):
+            return 0.0
+        return round(float(arr[mid:].mean() - arr[:mid].mean()), 8)
 
     return {
-        "experiment":           "curvature_trajectory",
-        "condition":            condition,
-        "run_idx":              run_idx,
-        "seed":                 seed,
-        "n_steps":              step_global,
-        "curvature_trajectory": curvature_traj,
-        "loss_trajectory":      loss_traj,
-        "curvature_mean":       round(float(curv.mean()), 6) if len(curv) else 0.0,
-        "curvature_std":        round(float(curv.std()),  6) if len(curv) else 0.0,
-        "curvature_slope":      round(slope, 8),
-        "curvature_drift":      drift,
-        "loss_improvement":     round(float(losses[0] - losses[-1]), 6) if len(losses) > 1 else 0.0,
-        "timestamp":            datetime.now(timezone.utc).isoformat(),
+        "experiment":          "weight_geometry",
+        "condition":           condition,
+        "run_idx":             run_idx,
+        "seed":                seed,
+        "n_steps":             step_global,
+        "n_matrices":          weight_geometry(agent)["n_matrices"],
+        "anisotropy_trajectory":  [round(v, 8) for v in aniso_traj],
+        "entropy_trajectory":     [round(v, 8) for v in entropy_traj],
+        "loss_trajectory":        loss_traj,
+        "anisotropy_mean":     round(float(aniso.mean()),   8) if len(aniso)   else 0.0,
+        "anisotropy_slope":    round(_slope(aniso),         10),
+        "anisotropy_drift":    _drift(aniso),
+        "entropy_mean":        round(float(entropy.mean()), 8) if len(entropy) else 0.0,
+        "entropy_slope":       round(_slope(entropy),       10),
+        "entropy_drift":       _drift(entropy),
+        "loss_improvement":    round(float(losses[0] - losses[-1]), 6) if len(losses) > 1 else 0.0,
+        "timestamp":           datetime.now(timezone.utc).isoformat(),
     }
 
 
@@ -212,10 +269,10 @@ def run_experiment(
     corpus  = load_corpus()
     avg_len = int(np.mean([len(t) for t in corpus[:20]])) if corpus else 200
 
-    print("[Curvature-trajectory experiment]")
-    print(f"Corpus: {len(corpus)} passages  K={k}  STEPS={STEPS_PER_TEXT}  "
-          f"seeds={n_seeds}  probe: '{PROBE_SENTENCE}'")
-    print(f"Total curvature measurements/run: {k * STEPS_PER_TEXT}")
+    print("[Weight-geometry experiment]")
+    print(f"Corpus: {len(corpus)} passages  K={k}  STEPS={STEPS_PER_TEXT}  seeds={n_seeds}")
+    print(f"Probe: SVD anisotropy + spectral entropy of creature weight matrices")
+    print(f"Total measurements/run: {k * STEPS_PER_TEXT}")
     print()
 
     all_results: List[dict] = []
@@ -229,26 +286,20 @@ def run_experiment(
         all_results.append(r)
         print(
             f"  seed {seed}  real      | "
-            f"curv_mean={r['curvature_mean']:.6f}  "
-            f"drift={r['curvature_drift']:+.6f}  "
-            f"slope={r['curvature_slope']:+.2e}  "
-            f"loss_improvement={r['loss_improvement']:+.4f}"
+            f"aniso={r['anisotropy_mean']:.6f}  drift={r['anisotropy_drift']:+.6f}  "
+            f"entropy={r['entropy_mean']:.4f}  loss_imp={r['loss_improvement']:+.4f}"
         )
         (RESULTS_DIR / f"real_{seed_offset:03d}.json").write_text(
             json.dumps(r, indent=2, default=str)
         )
 
-        syn_texts = [
-            synthetic_text(avg_len, seed=seed * 1000 + j) for j in range(k)
-        ]
+        syn_texts = [synthetic_text(avg_len, seed=seed * 1000 + j) for j in range(k)]
         r2 = run_condition(syn_texts, seed, "synthetic", seed_offset)
         all_results.append(r2)
         print(
             f"  seed {seed}  synthetic | "
-            f"curv_mean={r2['curvature_mean']:.6f}  "
-            f"drift={r2['curvature_drift']:+.6f}  "
-            f"slope={r2['curvature_slope']:+.2e}  "
-            f"loss_improvement={r2['loss_improvement']:+.4f}"
+            f"aniso={r2['anisotropy_mean']:.6f}  drift={r2['anisotropy_drift']:+.6f}  "
+            f"entropy={r2['entropy_mean']:.4f}  loss_imp={r2['loss_improvement']:+.4f}"
         )
         (RESULTS_DIR / f"synthetic_{seed_offset:03d}.json").write_text(
             json.dumps(r2, indent=2, default=str)
@@ -265,64 +316,66 @@ def summarise(results: List[dict]) -> None:
         by_cond[r["condition"]].append(r)
 
     print("=" * 70)
-    print("CURVATURE-TRAJECTORY EXPERIMENT — RESULTS SUMMARY")
+    print("WEIGHT-GEOMETRY EXPERIMENT — RESULTS SUMMARY")
     print("=" * 70)
 
     for cond in ("real", "synthetic"):
         runs = by_cond.get(cond, [])
         if not runs:
             continue
-        means  = [r["curvature_mean"]  for r in runs]
-        drifts = [r["curvature_drift"] for r in runs]
-        slopes = [r["curvature_slope"] for r in runs]
+        am = [r["anisotropy_mean"] for r in runs]
+        ad = [r["anisotropy_drift"] for r in runs]
+        em = [r["entropy_mean"]     for r in runs]
         print(
             f"  {cond:10s}: n={len(runs)}  "
-            f"curv_mean={np.mean(means):.6f}±{np.std(means):.6f}  "
-            f"drift={np.mean(drifts):+.6f}±{np.std(drifts):.6f}  "
-            f"slope={np.mean(slopes):+.2e}"
+            f"aniso={np.mean(am):.6f}±{np.std(am):.6f}  "
+            f"drift={np.mean(ad):+.6f}±{np.std(ad):.6f}  "
+            f"entropy={np.mean(em):.4f}±{np.std(em):.4f}"
         )
 
-    real_means = [r["curvature_mean"] for r in by_cond.get("real", [])]
-    syn_means  = [r["curvature_mean"] for r in by_cond.get("synthetic", [])]
-    real_drift = [r["curvature_drift"] for r in by_cond.get("real", [])]
-    syn_drift  = [r["curvature_drift"] for r in by_cond.get("synthetic", [])]
+    real_am  = [r["anisotropy_mean"]  for r in by_cond.get("real", [])]
+    syn_am   = [r["anisotropy_mean"]  for r in by_cond.get("synthetic", [])]
+    real_em  = [r["entropy_mean"]     for r in by_cond.get("real", [])]
+    syn_em   = [r["entropy_mean"]     for r in by_cond.get("synthetic", [])]
+    real_ad  = [r["anisotropy_drift"] for r in by_cond.get("real", [])]
+    syn_ad   = [r["anisotropy_drift"] for r in by_cond.get("synthetic", [])]
 
     print()
-    if real_means and syn_means:
-        mean_diff  = np.mean(real_means) - np.mean(syn_means)
-        drift_diff = np.mean(real_drift) - np.mean(syn_drift)
-        print(f"  Real − synthetic curvature_mean: {mean_diff:+.6f}")
-        print(f"  Real − synthetic drift:          {drift_diff:+.6f}")
+    if real_am and syn_am:
+        aniso_diff   = np.mean(real_am) - np.mean(syn_am)
+        entropy_diff = np.mean(real_em) - np.mean(syn_em)
+        drift_diff   = np.mean(real_ad) - np.mean(syn_ad)
+        print(f"  Real − synthetic anisotropy_mean: {aniso_diff:+.6f}")
+        print(f"  Real − synthetic entropy_mean:    {entropy_diff:+.6f}")
+        print(f"  Real − synthetic drift:           {drift_diff:+.6f}")
         print()
 
-        mean_sig  = abs(mean_diff)  > 0.02
-        drift_sig = abs(drift_diff) > 0.01
-        real_grows = np.mean(real_drift) > 0
-        syn_grows  = np.mean(syn_drift)  > 0
+        aniso_sig   = abs(aniso_diff)   > 0.005
+        entropy_sig = abs(entropy_diff) > 0.05
+        drift_sig   = abs(drift_diff)   > 0.002
 
-        if mean_sig and drift_sig and real_grows != syn_grows:
-            print("  VERDICT: trajectories diverge and drift in opposite directions.")
-            print("  The loss landscape deforms differently under real vs synthetic text.")
-            print("  Geometry encodes what is being learned. Signal confirmed.")
-        elif mean_sig or drift_sig:
-            print("  VERDICT: partial separation detected.")
-            print("  Curvature differs between conditions but drift is not fully opposed.")
-            print("  Inspect per-seed trajectories for consistency.")
+        if aniso_sig or entropy_sig or drift_sig:
+            print("  VERDICT: weight-space geometry differs between conditions.")
+            print("  The creature's weight matrices evolve differently under real vs synthetic text.")
+            sigs = []
+            if aniso_sig:   sigs.append(f"anisotropy diff {aniso_diff:+.4f}")
+            if entropy_sig: sigs.append(f"entropy diff {entropy_diff:+.4f}")
+            if drift_sig:   sigs.append(f"drift diff {drift_diff:+.4f}")
+            print(f"  Signals: {', '.join(sigs)}")
+            print("  Geometry encodes what is being learned.")
         else:
-            print("  VERDICT: trajectories are indistinguishable.")
-            print("  Geometry does not differentiate real from synthetic at this scale.")
-            print("  Close the geometry chapter with the same clean conscience as topology.")
+            print("  VERDICT: weight-space geometry is indistinguishable between conditions.")
+            print("  The creature reorganises its weights the same way regardless of input.")
+            print("  Close this chapter. The signal is not here at this scale.")
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Curvature-trajectory experiment: does the loss landscape "
-                    "deform differently under real vs synthetic text?"
+        description="Weight-geometry experiment: does SVD anisotropy / spectral entropy "
+                    "of the creature's weights evolve differently under real vs synthetic text?"
     )
-    parser.add_argument("--quick",   action="store_true",
-                        help="2 seeds only (fast sanity check)")
-    parser.add_argument("--analyze", action="store_true",
-                        help="Load saved results and re-summarise")
+    parser.add_argument("--quick",   action="store_true", help="2 seeds only")
+    parser.add_argument("--analyze", action="store_true", help="Re-summarise saved results")
     parser.add_argument("--seeds",   type=int, default=N_SEEDS)
     parser.add_argument("--k",       type=int, default=K)
     parser.add_argument("--seed",    type=int, default=42)
@@ -352,7 +405,7 @@ def main() -> None:
         json.dumps(
             [
                 {k: v for k, v in r.items()
-                 if k not in ("curvature_trajectory", "loss_trajectory")}
+                 if k not in ("anisotropy_trajectory", "entropy_trajectory", "loss_trajectory")}
                 for r in results
             ],
             indent=2, default=str,


### PR DESCRIPTION
## The fix

The previous probe (`encounter_complex()` on a fixed sentence) ran a frozen external embedder. It had no path to the creature's weights. 0.0 was guaranteed.

This rewrite measures geometry that actually lives inside the creature: after each gradient step, SVD every 2D weight matrix in `agent.sd` and record:

- **anisotropy** = σ₁ / ‖W‖_F — how much one direction dominates
- **spectral_entropy** = −Σ pᵢ log pᵢ where pᵢ = σᵢ / Σσ — how spread the variance is

No external embedder. No frozen probe. The weights move when loss drops; these numbers must move if weight geometry changes at all.

## Question

Do SVD anisotropy and spectral entropy evolve differently when the creature learns meaningful text vs memorises random noise?

## Verdict thresholds (built in)

- anisotropy diff > 0.005 **or** entropy diff > 0.05 **or** drift diff > 0.002 → signal confirmed
- all below → close the chapter

## Run

```bash
cd Vybn_Mind/creature_dgm_h
python3 experiment_sequence_topology.py --quick
```

Results write to `experiment_results/weight_geometry/`.