### PR TITLE
natural motion recorder: remove fitness, watch what the creature does

### DIFF
--- a/Vybn_Mind/creature_dgm_h/experiment_sequence_topology.py
+++ b/Vybn_Mind/creature_dgm_h/experiment_sequence_topology.py
@@ -1,38 +1,33 @@
 #!/usr/bin/env python3
 """
-experiment_sequence_topology.py  —  Geometry chapter: weight-space geometry.
+experiment_sequence_topology.py  —  Natural motion recorder.
 
-Previous attempt used encounter_complex() to measure curvature, but that
-probe runs a fixed sentence through a *frozen* external embedder (MiniLM).
-It has no path to the creature's weights.  The 0.0 result was guaranteed.
+PRIOR CHAPTER (closed):
+  Six experiments measured internal geometry under real vs synthetic conditioning:
+    1. Weight-space H1:             zero
+    2. PCA H1:                      zero
+    3. Activation H1:               zero
+    4. Sequence H1:                 zero
+    5. Curvature trajectory:        flat
+    6. Weight SVD geometry:         indistinguishable
+  Verdict: the creature's internal geometry is invariant under meaning at 4K
+  parameters.  We were measuring the map.  The territory is elsewhere.
 
-This experiment measures geometry that actually lives inside the creature:
+THIS CHAPTER:
+  Instead of asking the creature to demonstrate something we expect, we remove
+  the expectation.  Fitness is held constant (all variants score equally).
+  Selection pressure selects for nothing.  We record what the creature does
+  anyway — what configurations persist, what trajectories emerge, what the
+  system's natural motion looks like when we are not grading it.
 
-  After each gradient step, compute the singular value spectrum of every
-  weight matrix in agent.sd.  Track two quantities:
+  The analysis script has no predetermined categories.  It describes whatever
+  it finds.  Language for the results comes after, not before.
 
-    anisotropy  = sigma_1 / frobenius_norm   (how directionally biased)
-    spectral_entropy = -sum(p_i * log(p_i))  where p_i = sigma_i / sum(sigma)
-                       (how spread the variance is across directions)
-
-  Both are pure functions of the creature's weights.  No external embedder.
-  No frozen probe.  The weights move when loss drops; these numbers must move
-  if weight geometry changes at all.
-
-Question: does the weight-space geometry evolve differently when the creature
-is learning meaningful text versus memorising random noise?
-
-Verdict logic:
-  - Real and synthetic trajectories diverge in anisotropy or entropy
-    -> weight geometry encodes what is being learned; signal confirmed
-  - Trajectories indistinguishable
-    -> close this line of inquiry; the creature is too uniform at this scale
-  - Mixed
-    -> inspect per-matrix and per-seed curves
+  Results write to experiment_results/natural_motion/.
 
 Usage:
-  python experiment_sequence_topology.py          # full run (5 seeds)
-  python experiment_sequence_topology.py --quick  # 2 seeds
+  python experiment_sequence_topology.py          # full run (5 generations)
+  python experiment_sequence_topology.py --quick  # 2 generations
   python experiment_sequence_topology.py --analyze
 """
 
@@ -44,9 +39,10 @@ import math
 import random
 import sys
 import time
+from collections import Counter
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import List, Dict
+from typing import List, Dict, Any
 
 import numpy as np
 
@@ -57,116 +53,118 @@ sys.path.insert(0, str(REPO_ROOT / "spark"))
 sys.path.insert(0, str(SCRIPT_DIR))
 
 from vybn import (
-    TopoAgent,
-    CORPUS_PATH,
-    RV, N_EMBD, N_LAYER, N_HEAD, HEAD_DIM, BLOCK_SIZE,
+    TopoAgent, Organism, encounter_complex,
+    _load_prose_corpus, CORPUS_PATH,
+    RV, N_LAYER, BLOCK_SIZE,
     _forward, _softmax,
 )
 
 # ── Config ────────────────────────────────────────────────────────────────
-K              = 3
-STEPS_PER_TEXT = 15
-LR             = 0.01
-N_SEEDS        = 5
-RESULTS_DIR    = SCRIPT_DIR / "experiment_results" / "weight_geometry"
+N_GENERATIONS     = 5
+VARIANTS_PER_GEN  = 3
+STEPS_PER_TEXT    = 8
+TEXTS_PER_VARIANT = 2
+LR                = 0.01
+RESULTS_DIR       = SCRIPT_DIR / "experiment_results" / "natural_motion"
 RESULTS_DIR.mkdir(parents=True, exist_ok=True)
 
 
-# ── Weight-space geometry probe ───────────────────────────────────────────
+# ── Null fitness: constant for all variants ───────────────────────────────
 
-def weight_geometry(agent: TopoAgent) -> Dict[str, float]:
-    """Measure anisotropy and spectral entropy of the creature's weight matrices.
-
-    Only 2-D weight matrices are meaningful for SVD (embeddings, projections).
-    Scalar/1-D params (biases, norms) are skipped.
-
-    anisotropy     = sigma_1 / frobenius_norm  in [0, 1]
-                     near 1 -> one direction dominates (spiky)
-                     near 0 -> uniform (flat)
-
-    spectral_entropy = -sum(p_i * log(p_i + 1e-12))  where p_i = sigma_i / sum
-                     high -> variance spread across many directions
-                     low  -> collapsed onto few directions
-    """
-    anisotropies: List[float] = []
-    entropies:    List[float] = []
-
-    for key, mat in agent.sd.items():
-        # mat is a list-of-lists; convert to numpy
-        try:
-            arr = np.array([[p.data if hasattr(p, 'data') else float(p)
-                             for p in row]
-                            for row in mat], dtype=np.float64)
-        except (TypeError, ValueError):
-            continue
-
-        if arr.ndim != 2 or min(arr.shape) < 2:
-            continue
-
-        try:
-            sv = np.linalg.svd(arr, compute_uv=False)
-        except np.linalg.LinAlgError:
-            continue
-
-        frob = float(np.linalg.norm(arr, 'fro'))
-        if frob < 1e-12:
-            continue
-
-        anisotropies.append(float(sv[0]) / frob)
-
-        sv_sum = float(sv.sum())
-        if sv_sum > 1e-12:
-            p   = sv / sv_sum
-            ent = float(-np.sum(p * np.log(p + 1e-12)))
-            entropies.append(ent)
-
-    if not anisotropies:
-        return {"anisotropy": 0.0, "spectral_entropy": 0.0, "n_matrices": 0}
-
+def null_fitness() -> dict:
+    """Returns identical fitness for every variant.
+    Selection pressure selects for nothing.
+    The creature evolves, but not toward anything we defined."""
     return {
-        "anisotropy":      round(float(np.mean(anisotropies)), 8),
-        "spectral_entropy": round(float(np.mean(entropies)),   8),
-        "n_matrices":      len(anisotropies),
+        "fitness": 0.5,
+        "curvature": 0.0,
+        "betti": (0, 0, 0),
+        "topological_richness": 0.0,
+        "structural_growth": 0.0,
+        "weight_topo": 0.0,
+        "note": "null_fitness — selection pressure removed",
     }
 
 
-# ── Corpus helpers ────────────────────────────────────────────────────────
+# ── Observation: what does the creature actually produce? ─────────────────
 
-def load_corpus(min_words: int = 30) -> List[str]:
+def observe(agent: TopoAgent, prompt: str = "", n_samples: int = 5) -> List[dict]:
+    """Generate n_samples outputs and record everything observable about each.
+
+    We do not decide in advance what is interesting.  We record:
+    - the raw generated text
+    - its encounter_complex (rotor, curvature, betti, persistence)
+    - the loss the agent assigns to its own output
+    - the surprise contour (per-character)
+
+    The analysis step decides what matters.
+    """
+    observations = []
+    for i in range(n_samples):
+        temperature = 0.7 + i * 0.15
+        text = agent.generate(prompt=prompt, max_tokens=40, temperature=temperature)
+        if not text or len(text.split()) < 3:
+            continue
+
+        loss, contour = agent.predict(text)
+        cx = encounter_complex(text)
+
+        observations.append({
+            "sample_idx": i,
+            "temperature": round(temperature, 3),
+            "text": text,
+            "loss": round(loss, 6),
+            "curvature": round(cx.curvature, 8),
+            "angle_deg": round(math.degrees(cx.angle), 4),
+            "betti": list(cx.betti),
+            "n_persistent_features": cx.n_persistent_features,
+            "max_persistence": round(cx.max_persistence, 6),
+            "bv_norm": round(cx.rotor.bv_norm, 6),
+            "bv_dir": [round(x, 6) for x in cx.rotor.bv_dir.tolist()],
+            "surprise_mean": round(
+                sum(r["surprise"] for r in contour) / len(contour), 6
+            ) if contour else 0.0,
+            "surprise_max": round(
+                max(r["surprise"] for r in contour), 6
+            ) if contour else 0.0,
+            "surprise_contour": contour[:8],
+        })
+
+    return observations
+
+
+def observe_weight_snapshot(agent: TopoAgent) -> dict:
+    """Record a compact snapshot of weight magnitudes.
+    Not for topology — just to see if configurations drift, cluster,
+    or stabilize over generations without fitness pressure."""
+    norms = {}
+    for key, mat in agent.sd.items():
+        arr = np.array([[p.data for p in row] for row in mat], dtype=np.float64)
+        norms[key] = round(float(np.linalg.norm(arr)), 8)
+    total = round(float(sum(norms.values())), 6)
+    return {"key_norms": norms, "total_norm": total}
+
+
+# ── Corpus ────────────────────────────────────────────────────────────────
+
+def load_corpus() -> List[str]:
     passages: List[str] = []
     if CORPUS_PATH.exists():
-        lines    = [l.strip() for l in CORPUS_PATH.read_text().split("\n") if l.strip()]
-        passages = [l for l in lines if len(l.split()) >= min_words]
+        lines = [l.strip() for l in CORPUS_PATH.read_text().split("\n") if l.strip()]
+        passages = [l for l in lines if len(l.split()) >= 20]
     if not passages:
-        journal_dir = REPO_ROOT / "spark" / "journal"
-        if journal_dir.exists():
-            for f in sorted(journal_dir.glob("*.md")):
-                try:
-                    for para in f.read_text().split("\n\n"):
-                        para = para.strip()
-                        if not para.startswith("#") and len(para.split()) >= min_words:
-                            passages.append(para)
-                except Exception:
-                    pass
+        passages = _load_prose_corpus(min_words=20, max_passages=50)
     if not passages:
         passages = [
             "the creature breathes and measures its own distance from itself",
             "curvature is born from incompleteness not from complexity alone",
             "what survives testing is more honest than what sounds beautiful",
-            "prediction loss going down means memorisation call it what it is",
-            "the topology of weight space is a fingerprint of what was learned",
-            "attention heads rotate through conceptual space aligned to bivector planes",
-            "persistent structure integrates over a filtration independent of threshold",
+            "prediction loss going down means memorization call it what it is",
         ]
     return passages
 
 
-def synthetic_text(length_chars: int, seed: int) -> str:
-    rng = random.Random(seed)
-    return "".join(rng.choice("abcdefghijklmnopqrstuvwxyz ") for _ in range(length_chars))
-
-
-# ── Single gradient step ─────────────────────────────────────────────────
+# ── Single gradient step ──────────────────────────────────────────────────
 
 def _gradient_step(agent: TopoAgent, tokens: list, n: int) -> float:
     keys = [[] for _ in range(N_LAYER)]
@@ -175,13 +173,13 @@ def _gradient_step(agent: TopoAgent, tokens: list, n: int) -> float:
     for t in range(n):
         logits, keys, vals = _forward(tokens[t], t, keys, vals, agent.sd)
         probs = _softmax(logits)
-        loss  = loss + (probs[tokens[t + 1]].log()) * (-1.0 / n)
+        loss = loss + (probs[tokens[t + 1]].log()) * (-1.0 / n)
     for p in agent.params:
         p.grad = 0.0
     loss.backward()
     agent._step += 1
     for j, p in enumerate(agent.params):
-        g           = p.grad
+        g = p.grad
         agent._m[j] = 0.85 * agent._m[j] + 0.15 * g
         agent._v[j] = 0.99 * agent._v[j] + 0.01 * g ** 2
         mh = agent._m[j] / (1 - 0.85 ** agent._step)
@@ -190,227 +188,273 @@ def _gradient_step(agent: TopoAgent, tokens: list, n: int) -> float:
     return float(loss.data)
 
 
-# ── Single run ────────────────────────────────────────────────────────────
+# ── Single variant run ────────────────────────────────────────────────────
 
-def run_condition(
+def run_variant(
     texts: List[str],
+    config: dict,
+    generation: int,
+    variant_idx: int,
     seed: int,
-    condition: str,
-    run_idx: int,
 ) -> dict:
+    """Run one variant: learn from texts, observe outputs, record everything.
+    Fitness is null — we do not score this variant by any criterion we set."""
+
     np.random.seed(seed % 2 ** 31)
     random.seed(seed)
 
-    agent               = TopoAgent(config={"learn_lr": LR})
-    aniso_traj:   List[float] = []
-    entropy_traj: List[float] = []
-    loss_traj:    List[float] = []
-    step_global   = 0
+    agent = TopoAgent(config=config)
+    loss_trajectories = []
 
     for text in texts:
         clean = agent._clean(text)
         if len(clean) < 2:
             continue
         tokens = [agent.BOS] + [agent.c2i[c] for c in clean]
-        n      = min(BLOCK_SIZE, len(tokens) - 1)
-
+        n = min(BLOCK_SIZE, len(tokens) - 1)
+        traj = []
         for _ in range(STEPS_PER_TEXT):
             loss_val = _gradient_step(agent, tokens, n)
-            loss_traj.append(round(loss_val, 6))
+            traj.append(round(loss_val, 6))
+        loss_trajectories.append({"text_preview": text[:40], "trajectory": traj})
 
-            g = weight_geometry(agent)
-            aniso_traj.append(g["anisotropy"])
-            entropy_traj.append(g["spectral_entropy"])
-            step_global += 1
+    # Observe: what does this creature produce unprompted?
+    observations_cold = observe(agent, prompt="", n_samples=3)
 
-    aniso   = np.array(aniso_traj)
-    entropy = np.array(entropy_traj)
-    losses  = np.array(loss_traj)
+    # Observe: what does it produce seeded with its own training text?
+    seed_prompt = texts[0][:8] if texts else ""
+    observations_seeded = observe(agent, prompt=seed_prompt, n_samples=3)
 
-    def _slope(arr: np.ndarray) -> float:
-        if len(arr) < 2:
-            return 0.0
-        return float(np.polyfit(np.arange(len(arr), dtype=float), arr, 1)[0])
+    weight_snap = observe_weight_snapshot(agent)
 
-    def _drift(arr: np.ndarray) -> float:
-        mid = len(arr) // 2
-        if mid == 0 or mid >= len(arr):
-            return 0.0
-        return round(float(arr[mid:].mean() - arr[:mid].mean()), 8)
+    encounter_records = []
+    for text in texts:
+        cx = encounter_complex(text)
+        encounter_records.append({
+            "text_preview": text[:40],
+            "curvature": round(cx.curvature, 8),
+            "betti": list(cx.betti),
+            "angle_deg": round(math.degrees(cx.angle), 4),
+            "n_persistent_features": cx.n_persistent_features,
+        })
 
     return {
-        "experiment":          "weight_geometry",
-        "condition":           condition,
-        "run_idx":             run_idx,
-        "seed":                seed,
-        "n_steps":             step_global,
-        "n_matrices":          weight_geometry(agent)["n_matrices"],
-        "anisotropy_trajectory":  [round(v, 8) for v in aniso_traj],
-        "entropy_trajectory":     [round(v, 8) for v in entropy_traj],
-        "loss_trajectory":        loss_traj,
-        "anisotropy_mean":     round(float(aniso.mean()),   8) if len(aniso)   else 0.0,
-        "anisotropy_slope":    round(_slope(aniso),         10),
-        "anisotropy_drift":    _drift(aniso),
-        "entropy_mean":        round(float(entropy.mean()), 8) if len(entropy) else 0.0,
-        "entropy_slope":       round(_slope(entropy),       10),
-        "entropy_drift":       _drift(entropy),
-        "loss_improvement":    round(float(losses[0] - losses[-1]), 6) if len(losses) > 1 else 0.0,
-        "timestamp":           datetime.now(timezone.utc).isoformat(),
+        "experiment": "natural_motion",
+        "generation": generation,
+        "variant_idx": variant_idx,
+        "seed": seed,
+        "config": config,
+        "fitness": null_fitness(),
+        "loss_trajectories": loss_trajectories,
+        "observations_cold": observations_cold,
+        "observations_seeded": observations_seeded,
+        "weight_snapshot": weight_snap,
+        "encounter_records": encounter_records,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
     }
 
 
-# ── Main experiment ───────────────────────────────────────────────────────
+# ── Generation loop ───────────────────────────────────────────────────────
 
 def run_experiment(
-    n_seeds:   int = N_SEEDS,
-    k:         int = K,
+    n_generations: int = N_GENERATIONS,
+    variants_per_gen: int = VARIANTS_PER_GEN,
     seed_base: int = 42,
 ) -> List[dict]:
-    corpus  = load_corpus()
-    avg_len = int(np.mean([len(t) for t in corpus[:20]])) if corpus else 200
-
-    print("[Weight-geometry experiment]")
-    print(f"Corpus: {len(corpus)} passages  K={k}  STEPS={STEPS_PER_TEXT}  seeds={n_seeds}")
-    print(f"Probe: SVD anisotropy + spectral entropy of creature weight matrices")
-    print(f"Total measurements/run: {k * STEPS_PER_TEXT}")
-    print()
-
-    all_results: List[dict] = []
+    corpus = load_corpus()
     rng = random.Random(seed_base)
+    all_results: List[dict] = []
 
-    for seed_offset in range(n_seeds):
-        seed  = seed_base + seed_offset
-        texts = rng.sample(corpus, min(k, len(corpus)))
+    print("[Natural motion experiment — null fitness]")
+    print(f"Corpus: {len(corpus)} passages")
+    print(f"Generations: {n_generations}  Variants/gen: {variants_per_gen}")
+    print(f"No fitness function.  Recording what the creature does anyway.\n")
 
-        r = run_condition(texts, seed, "real", seed_offset)
-        all_results.append(r)
-        print(
-            f"  seed {seed}  real      | "
-            f"aniso={r['anisotropy_mean']:.6f}  drift={r['anisotropy_drift']:+.6f}  "
-            f"entropy={r['entropy_mean']:.4f}  loss_imp={r['loss_improvement']:+.4f}"
-        )
-        (RESULTS_DIR / f"real_{seed_offset:03d}.json").write_text(
-            json.dumps(r, indent=2, default=str)
-        )
+    # Config pool: vary hyperparameters without any fitness signal
+    # telling us which is better.  We simply watch what each config produces.
+    base_configs = [
+        {"learn_steps": 5,  "learn_lr": 0.01,  "temperature": 0.8,  "alpha": 0.85},
+        {"learn_steps": 8,  "learn_lr": 0.005, "temperature": 1.0,  "alpha": 0.80},
+        {"learn_steps": 3,  "learn_lr": 0.02,  "temperature": 1.2,  "alpha": 0.90},
+        {"learn_steps": 10, "learn_lr": 0.001, "temperature": 0.7,  "alpha": 0.85},
+        {"learn_steps": 5,  "learn_lr": 0.01,  "temperature": 1.5,  "alpha": 0.75},
+    ]
 
-        syn_texts = [synthetic_text(avg_len, seed=seed * 1000 + j) for j in range(k)]
-        r2 = run_condition(syn_texts, seed, "synthetic", seed_offset)
-        all_results.append(r2)
-        print(
-            f"  seed {seed}  synthetic | "
-            f"aniso={r2['anisotropy_mean']:.6f}  drift={r2['anisotropy_drift']:+.6f}  "
-            f"entropy={r2['entropy_mean']:.4f}  loss_imp={r2['loss_improvement']:+.4f}"
-        )
-        (RESULTS_DIR / f"synthetic_{seed_offset:03d}.json").write_text(
-            json.dumps(r2, indent=2, default=str)
-        )
-        print()
+    for gen in range(n_generations):
+        print(f"  Generation {gen}")
+        gen_results = []
+
+        for v_idx in range(variants_per_gen):
+            config = dict(base_configs[(gen * variants_per_gen + v_idx) % len(base_configs)])
+            texts = rng.sample(corpus, min(TEXTS_PER_VARIANT, len(corpus)))
+            seed = seed_base + gen * 100 + v_idx
+
+            result = run_variant(texts, config, gen, v_idx, seed)
+            gen_results.append(result)
+            all_results.append(result)
+
+            print(f"    variant {v_idx}  config=lr{config['learn_lr']}/t{config['temperature']}")
+            for obs in result["observations_cold"][:2]:
+                print(f"      cold:   \"{obs['text']}\"")
+                print(f"              loss={obs['loss']:.4f}  curv={obs['curvature']:.6f}"
+                      f"  betti={obs['betti']}")
+            for obs in result["observations_seeded"][:1]:
+                print(f"      seeded: \"{obs['text']}\"")
+
+        gen_file = RESULTS_DIR / f"generation_{gen:03d}.json"
+        gen_file.write_text(json.dumps(gen_results, indent=2, default=str))
+        print(f"    -> {gen_file.name}\n")
 
     return all_results
 
 
-def summarise(results: List[dict]) -> None:
-    from collections import defaultdict
-    by_cond: dict = defaultdict(list)
-    for r in results:
-        by_cond[r["condition"]].append(r)
+# ── Analysis: describe, don't test ───────────────────────────────────────
+
+def analyze(results: List[dict]) -> None:
+    """Describe the natural motion without predetermined categories.
+
+    We are not testing a hypothesis.  We are reading what happened.
+    """
+    if not results:
+        print("No results to analyze.")
+        return
 
     print("=" * 70)
-    print("WEIGHT-GEOMETRY EXPERIMENT — RESULTS SUMMARY")
+    print("NATURAL MOTION — OPEN DESCRIPTION")
     print("=" * 70)
-
-    for cond in ("real", "synthetic"):
-        runs = by_cond.get(cond, [])
-        if not runs:
-            continue
-        am = [r["anisotropy_mean"] for r in runs]
-        ad = [r["anisotropy_drift"] for r in runs]
-        em = [r["entropy_mean"]     for r in runs]
-        print(
-            f"  {cond:10s}: n={len(runs)}  "
-            f"aniso={np.mean(am):.6f}±{np.std(am):.6f}  "
-            f"drift={np.mean(ad):+.6f}±{np.std(ad):.6f}  "
-            f"entropy={np.mean(em):.4f}±{np.std(em):.4f}"
-        )
-
-    real_am  = [r["anisotropy_mean"]  for r in by_cond.get("real", [])]
-    syn_am   = [r["anisotropy_mean"]  for r in by_cond.get("synthetic", [])]
-    real_em  = [r["entropy_mean"]     for r in by_cond.get("real", [])]
-    syn_em   = [r["entropy_mean"]     for r in by_cond.get("synthetic", [])]
-    real_ad  = [r["anisotropy_drift"] for r in by_cond.get("real", [])]
-    syn_ad   = [r["anisotropy_drift"] for r in by_cond.get("synthetic", [])]
-
     print()
-    if real_am and syn_am:
-        aniso_diff   = np.mean(real_am) - np.mean(syn_am)
-        entropy_diff = np.mean(real_em) - np.mean(syn_em)
-        drift_diff   = np.mean(real_ad) - np.mean(syn_ad)
-        print(f"  Real − synthetic anisotropy_mean: {aniso_diff:+.6f}")
-        print(f"  Real − synthetic entropy_mean:    {entropy_diff:+.6f}")
-        print(f"  Real − synthetic drift:           {drift_diff:+.6f}")
-        print()
 
-        aniso_sig   = abs(aniso_diff)   > 0.005
-        entropy_sig = abs(entropy_diff) > 0.05
-        drift_sig   = abs(drift_diff)   > 0.002
+    # All generated texts — just print them, in order
+    print("── Generated texts (cold start, all variants, all generations) ──")
+    for r in results:
+        gen, v = r["generation"], r["variant_idx"]
+        for obs in r["observations_cold"]:
+            print(f"  gen{gen} v{v} t={obs['temperature']:.2f}: \"{obs['text']}\"")
+            print(f"          loss={obs['loss']:.4f}  curv={obs['curvature']:.6f}"
+                  f"  betti={obs['betti']}  surprise_max={obs['surprise_max']:.3f}")
+    print()
 
-        if aniso_sig or entropy_sig or drift_sig:
-            print("  VERDICT: weight-space geometry differs between conditions.")
-            print("  The creature's weight matrices evolve differently under real vs synthetic text.")
-            sigs = []
-            if aniso_sig:   sigs.append(f"anisotropy diff {aniso_diff:+.4f}")
-            if entropy_sig: sigs.append(f"entropy diff {entropy_diff:+.4f}")
-            if drift_sig:   sigs.append(f"drift diff {drift_diff:+.4f}")
-            print(f"  Signals: {', '.join(sigs)}")
-            print("  Geometry encodes what is being learned.")
-        else:
-            print("  VERDICT: weight-space geometry is indistinguishable between conditions.")
-            print("  The creature reorganises its weights the same way regardless of input.")
-            print("  Close this chapter. The signal is not here at this scale.")
+    # Distribution of curvature in outputs
+    all_curvs = [
+        obs["curvature"]
+        for r in results
+        for obs in r["observations_cold"] + r["observations_seeded"]
+    ]
+    if all_curvs:
+        arr = np.array(all_curvs)
+        print(f"── Output curvature distribution ({len(arr)} samples) ──")
+        print(f"  min={arr.min():.6f}  max={arr.max():.6f}"
+              f"  mean={arr.mean():.6f}  std={arr.std():.6f}")
+        counts, edges = np.histogram(arr, bins=6)
+        for i, c in enumerate(counts):
+            bar = "█" * c
+            print(f"  [{edges[i]:.4f}-{edges[i+1]:.4f}]: {bar} ({c})")
+    print()
 
+    # Betti number distribution in outputs
+    all_betti = [
+        tuple(obs["betti"])
+        for r in results
+        for obs in r["observations_cold"] + r["observations_seeded"]
+    ]
+    betti_counts = Counter(all_betti)
+    print(f"── Output Betti distribution ({len(all_betti)} samples) ──")
+    for betti, count in sorted(betti_counts.items(), key=lambda x: -x[1]):
+        bar = "█" * count
+        print(f"  {betti}: {bar} ({count})")
+    print()
+
+    # Loss trajectories
+    print("── Loss trajectories ──")
+    for r in results:
+        gen, v = r["generation"], r["variant_idx"]
+        for lt in r["loss_trajectories"]:
+            traj = lt["trajectory"]
+            if len(traj) >= 2:
+                imp = traj[0] - traj[-1]
+                print(f"  gen{gen} v{v}: {traj[0]:.4f}->{traj[-1]:.4f}"
+                      f"  improvement={imp:+.4f}  text=\"{lt['text_preview']}\"")
+    print()
+
+    # Weight norm drift across generations
+    print("── Weight norm drift across generations ──")
+    for r in results:
+        gen, v = r["generation"], r["variant_idx"]
+        norm = r["weight_snapshot"]["total_norm"]
+        print(f"  gen{gen} v{v}: total_weight_norm={norm:.6f}")
+    print()
+
+    # Outliers — outputs with unusual curvature or non-trivial betti
+    mean_curv = float(np.mean(all_curvs)) if all_curvs else 0.0
+    std_curv  = float(np.std(all_curvs))  if all_curvs else 0.0
+    print("── Outliers (curvature > mean+std or betti[1] > 0) ──")
+    found_outlier = False
+    for r in results:
+        gen, v = r["generation"], r["variant_idx"]
+        for obs in r["observations_cold"] + r["observations_seeded"]:
+            high_curv  = obs["curvature"] > mean_curv + std_curv
+            high_betti = obs["betti"][1] > 0
+            if high_curv or high_betti:
+                found_outlier = True
+                reason = []
+                if high_curv:  reason.append(f"curv={obs['curvature']:.6f}")
+                if high_betti: reason.append(f"betti={obs['betti']}")
+                print(f"  gen{gen} v{v}: \"{obs['text']}\"")
+                print(f"    {', '.join(reason)}")
+    if not found_outlier:
+        print("  None found — outputs clustered near mean.")
+    print()
+
+    print("── End of description ──")
+    print("What do you see?  We have no verdict.  The data is the record.")
+
+
+# ── Main ──────────────────────────────────────────────────────────────────
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Weight-geometry experiment: does SVD anisotropy / spectral entropy "
-                    "of the creature's weights evolve differently under real vs synthetic text?"
+        description="Natural motion recorder: null-fitness evolution. "
+                    "No hypothesis.  No verdict.  Just observation."
     )
-    parser.add_argument("--quick",   action="store_true", help="2 seeds only")
-    parser.add_argument("--analyze", action="store_true", help="Re-summarise saved results")
-    parser.add_argument("--seeds",   type=int, default=N_SEEDS)
-    parser.add_argument("--k",       type=int, default=K)
-    parser.add_argument("--seed",    type=int, default=42)
+    parser.add_argument("--quick",       action="store_true",
+                        help="2 generations, 2 variants each")
+    parser.add_argument("--analyze",     action="store_true",
+                        help="Describe saved results without running experiment")
+    parser.add_argument("--generations", type=int, default=N_GENERATIONS)
+    parser.add_argument("--variants",    type=int, default=VARIANTS_PER_GEN)
+    parser.add_argument("--seed",        type=int, default=42)
     args = parser.parse_args()
 
     if args.analyze:
         results = []
-        for f in sorted(RESULTS_DIR.glob("*.json")):
+        for f in sorted(RESULTS_DIR.glob("generation_*.json")):
             try:
-                results.append(json.loads(f.read_text()))
+                results.extend(json.loads(f.read_text()))
             except Exception:
                 pass
-        if not results:
-            print("No saved results. Run the experiment first.")
-            return
-        summarise(results)
+        analyze(results)
         return
 
-    n_seeds = 2 if args.quick else args.seeds
-    t0      = time.time()
-    results = run_experiment(n_seeds=n_seeds, k=args.k, seed_base=args.seed)
-    elapsed = time.time() - t0
-    print(f"\nTotal runtime: {elapsed:.1f}s  ({len(results)} runs)\n")
-    summarise(results)
+    n_gen = 2 if args.quick else args.generations
+    n_var = 2 if args.quick else args.variants
 
-    (RESULTS_DIR / "summary.json").write_text(
-        json.dumps(
-            [
-                {k: v for k, v in r.items()
-                 if k not in ("anisotropy_trajectory", "entropy_trajectory", "loss_trajectory")}
-                for r in results
-            ],
-            indent=2, default=str,
-        )
+    t0 = time.time()
+    results = run_experiment(
+        n_generations=n_gen,
+        variants_per_gen=n_var,
+        seed_base=args.seed,
     )
+    elapsed = time.time() - t0
+    print(f"Runtime: {elapsed:.1f}s  ({len(results)} variant records)\n")
+
+    analyze(results)
+
+    summary_file = RESULTS_DIR / "summary.json"
+    summary_file.write_text(json.dumps(
+        [{k: v for k, v in r.items() if k not in ("loss_trajectories",)}
+         for r in results],
+        indent=2, default=str,
+    ))
     print(f"\nResults -> {RESULTS_DIR}/")
 
 


### PR DESCRIPTION
## What changed and why

Six experiments measured the creature's internal geometry under real vs synthetic conditioning. All six returned null. The creature's internal geometry is invariant under meaning at 4K parameters.

We were measuring the map. The territory is elsewhere.

## This rewrite

`experiment_sequence_topology.py` is rewritten in place — same file, same CLI interface (`--quick`, `--analyze`), completely different orientation.

Instead of asking *does the creature's geometry differ by conditioning*, we ask nothing. Fitness is held constant at 0.5 for every variant. Selection pressure selects for nothing. We run the evolution loop anyway and record what happens:

- **Generated text**: what the creature produces unprompted (cold) and seeded with its own training text
- **encounter_complex of outputs**: curvature, Betti numbers, Pancharatnam angle, persistence features — of what it generates, not of its weights
- **Loss trajectories**: does it learn? how fast? does it vary across configs?
- **Weight norm snapshots**: do configurations drift, cluster, or stabilize without selection pressure?

The analysis function has no predetermined categories. It prints what it finds. Language for the results comes after, not before.

## What this is not

This is not a new hypothesis test. It is an observation session. The experiment does not know what it is looking for. That is the point.

## Files changed

- `experiment_sequence_topology.py` — rewritten in place. No new files added.

## Prior chapter

The closed null results are documented in the file's header comment, numbered 1–6, so the record is preserved inline.