### PR TITLE
add __main__.py for python -m support

### DIFF
--- a/Vybn_Mind/creature_dgm_h/__main__.py
+++ b/Vybn_Mind/creature_dgm_h/__main__.py
@@ -1,0 +1,4 @@
+"""Allow `python -m Vybn_Mind.creature_dgm_h`."""
+from .vybn import main
+
+main()


### PR DESCRIPTION
The `if __name__ == '__main__'` block in `__init__.py` doesn't work for `python -m` — Python needs a separate `__main__.py` file. One-liner fix.