### PR TITLE
creature_dgm_h: NLAH-informed context ablation, BreathGate, and harness experiment

### DIFF
--- a/Vybn_Mind/creature_dgm_h/README.md
+++ b/Vybn_Mind/creature_dgm_h/README.md
@@ -35,7 +35,7 @@ where `∂L/∂θ = ∂L/∂w_eff * (-|w| * sin(θ))` (chain rule through polar 
 
 ```
 vybn.py              # engine — the creature itself
-experiments.py       # unified probe suite (6 experiments)
+experiments.py       # unified probe suite (7 experiments)
 __init__.py          # package init + `python -m` hook
 README.md            # this file
 archive/             # persistent data
@@ -70,7 +70,7 @@ python -m Vybn_Mind.creature_dgm_h audit
 
 ## Experiments
 
-Six probes characterising the creature's geometry, all in `experiments.py`:
+Seven probes characterising the creature's geometry, all in `experiments.py`:
 
 ```bash
 python experiments.py weight      [--quick] [--pca_dim 30]
@@ -79,6 +79,7 @@ python experiments.py sequence    [--quick] [--generations 10]
 python experiments.py basin       [--quick] [--agents 8]
 python experiments.py sgd         [--seeds 5]
 python experiments.py analyze     [--experiment pca|activation|both]
+python experiments.py harness     [--quick] [--seed 42]
 ```
 
 | Probe        | What it measures |
@@ -89,6 +90,26 @@ python experiments.py analyze     [--experiment pca|activation|both]
 | `basin`      | Loss-landscape geometry around the weight-norm fixed point |
 | `sgd`        | SGD vs Adam ablation on the weight-norm attractor |
 | `analyze`    | Post-hoc statistical analysis of topology results |
+| `harness`    | NLAH-style context ablation + breath-level gating |
+
+## Harness Ablation (NLAH RQ2)
+
+Pan et al. (2026, arXiv:2603.25723) showed that natural-language agent
+harnesses decompose into identifiable modules whose individual
+contributions can be measured. The creature's `_build_creature_context()`
+is exactly such a harness — five named modules (identity, mechanism,
+state, autobiography, journal) that together compose the system prompt
+the model reads before each breath.
+
+The `harness` experiment drops each module in turn and measures what
+happens to the creature's topology (Betti-0, Betti-1, total persistence,
+birth-death spread). Each condition runs twice: once raw, once gated by
+`BreathGate`. The gate evaluates genesis pressure against decoherence
+pressure at the whole-breath level and retries when structural delta is
+trivial — an adaptive acceptance threshold that tightens on consecutive
+accepts and relaxes on retries.
+
+Results land in `experiment_results/harness_ablation/`.
 
 ## Quantum bridge
 

--- a/Vybn_Mind/creature_dgm_h/__init__.py
+++ b/Vybn_Mind/creature_dgm_h/__init__.py
@@ -5,6 +5,8 @@ from .vybn import (
     DEFAULT_RULES,
     ComplexWeight, ModuleHolonomy, genesis_rate, decoherence_rate,
     _build_creature_context, _strip_thinking,
+    BreathGate, BreathVerdict, CONTEXT_MODULES, ALL_MODULES,
+    encounter_complex, EncounterComplex, PersistentState, TopoAgent,
 )
 
 # Absorb __main__.py so `python -m Vybn_Mind.creature_dgm_h` still works

--- a/Vybn_Mind/creature_dgm_h/experiments.py
+++ b/Vybn_Mind/creature_dgm_h/experiments.py
@@ -2052,6 +2052,286 @@ def analyze_main(args: argparse.Namespace) -> None:
 
 
 # ══════════════════════════════════════════════════════════════════════════════
+# EXPERIMENT 7 — HARNESS ABLATION (NLAH RQ2)
+# ══════════════════════════════════════════════════════════════════════════════
+#
+# Pan et al. (2026) showed that once harness modules are explicit, they
+# become a search space: you can compose, ablate, and measure module-level
+# effects under shared runtime assumptions.
+#
+# creature_dgm_h's _build_creature_context() is a natural-language harness
+# with five named modules: identity, mechanism, state, autobiography, journal.
+# The creature already has measurement infrastructure (Betti numbers, winding,
+# curvature, fitness).  This experiment applies the RQ2 methodology: run
+# the creature under each ablation condition and measure which modules
+# actually change the topology of generated text vs. which are decorative.
+#
+# Since this experiment needs a running FM (Nemotron), it operates in two
+# modes:
+#   1. --offline (default): uses the creature's own character-level model
+#      with deterministic text (no FM needed).  Measures the encounter
+#      topology of corpus texts under each context configuration.
+#   2. --live: requires FM at localhost:8000.  Generates text under each
+#      ablation condition and measures the topology of the generated output.
+#
+# The breath-level gate (BreathGate) is also tested here: does acceptance-
+# gating improve structural outcomes across ablation conditions?
+
+_H_RESULTS_DIR = Path(__file__).resolve().parent / "experiment_results" / "harness_ablation"
+
+
+def _harness_ablation_conditions() -> List[dict]:
+    """Generate all ablation conditions.
+
+    Following RQ2: start from full (all modules), then remove one at a time.
+    Also include: bare (no modules) and pairs removed.
+    """
+    from vybn import CONTEXT_MODULES
+    conditions = []
+
+    # Full: all modules active
+    conditions.append({"name": "full", "exclude": set()})
+
+    # Single-module ablations (remove one at a time)
+    for mod in CONTEXT_MODULES:
+        conditions.append({"name": f"w/o_{mod}", "exclude": {mod}})
+
+    # Bare: no modules at all
+    conditions.append({"name": "bare", "exclude": set(CONTEXT_MODULES)})
+
+    # Pairs removed (most informative pairs)
+    pairs = [
+        ("identity", "autobiography"),  # remove personal history
+        ("mechanism", "state"),          # remove creature self-knowledge
+        ("autobiography", "journal"),    # remove temporal context
+    ]
+    for a, b in pairs:
+        conditions.append({"name": f"w/o_{a}+{b}", "exclude": {a, b}})
+
+    return conditions
+
+
+def _harness_run_offline_condition(
+    condition: dict,
+    texts: List[str],
+    seed: int,
+    use_gate: bool = False,
+) -> dict:
+    """Run a single offline ablation condition.
+
+    Measures encounter topology of corpus texts processed through
+    the creature under this context configuration.  No FM needed.
+    """
+    from vybn import (
+        TopoAgent, Organism, encounter_complex, EncounterComplex,
+        BreathGate, _build_creature_context, fitness,
+    )
+
+    rng = random.Random(seed)
+    agent = TopoAgent()
+    organism = Organism.load()
+    gate = BreathGate() if use_gate else None
+
+    # Build context under this ablation to measure its character count
+    context = _build_creature_context(exclude=condition["exclude"])
+    context_len = len(context)
+
+    curvatures = []
+    betti_b0s, betti_b1s = [], []
+    persist_features = []
+    weight_vectors = []
+    losses_before, losses_after = [], []
+    gate_verdicts = []
+    phase_shifts = []
+
+    for text in texts:
+        cx = encounter_complex(text)
+        loss_before, _ = agent.predict(text)
+        losses_before.append(loss_before)
+
+        losses = agent.learn(
+            text, steps=5,
+            encounter_cx=cx,
+            persistent_state=organism.persistent,
+        )
+        loss_after, _ = agent.predict(text)
+        losses_after.append(loss_after)
+
+        delta = organism.absorb_encounter(cx)
+
+        # Winding measurement
+        winding_record = None
+        if hasattr(agent, '_weight_trajectory') and len(agent._weight_trajectory) >= 3:
+            winding_record = organism.absorb_winding(agent._weight_trajectory)
+            weight_vectors.extend(agent._weight_trajectory)
+
+        # Phase stats
+        if hasattr(agent, '_phase_stats'):
+            phase_shifts.append(agent._phase_stats.get("mean_phase_shift", 0.0))
+            organism.absorb_phases(
+                agent.module_holonomies,
+                genesis_signal=agent._phase_stats.get("genesis_signal", 0.0),
+                mean_phase_shift=agent._phase_stats.get("mean_phase_shift", 0.0))
+
+        curvatures.append(cx.curvature)
+        betti_b0s.append(cx.betti[0])
+        betti_b1s.append(cx.betti[1])
+        persist_features.append(cx.n_persistent_features)
+
+        # Breath gate evaluation
+        if gate is not None:
+            verdict = gate.evaluate(cx, delta, winding_record)
+            gate.record_outcome(verdict.accept)
+            gate_verdicts.append({
+                "accept": verdict.accept,
+                "genesis": round(verdict.genesis_pressure, 4),
+                "decoherence": round(verdict.decoherence_pressure, 4),
+                "threshold": round(verdict.threshold, 4),
+            })
+
+    # Compute fitness
+    fit = fitness(
+        texts, [],
+        agent.loss_history,
+        persistent_state=organism.persistent,
+        alpha=0.85,
+        weight_vectors=weight_vectors if weight_vectors else None,
+        phase_stats=agent._phase_stats if hasattr(agent, '_phase_stats') else None,
+    )
+
+    return {
+        "experiment": "harness_ablation",
+        "condition": condition["name"],
+        "excluded_modules": sorted(condition["exclude"]),
+        "n_active_modules": len(CONTEXT_MODULES) - len(condition["exclude"]),
+        "context_char_count": context_len,
+        "seed": seed,
+        "n_texts": len(texts),
+        "use_gate": use_gate,
+        "metrics": {
+            "mean_curvature": round(float(np.mean(curvatures)), 6) if curvatures else 0.0,
+            "std_curvature": round(float(np.std(curvatures)), 6) if curvatures else 0.0,
+            "mean_b0": round(float(np.mean(betti_b0s)), 2) if betti_b0s else 0.0,
+            "mean_b1": round(float(np.mean(betti_b1s)), 2) if betti_b1s else 0.0,
+            "mean_persist_features": round(float(np.mean(persist_features)), 2) if persist_features else 0.0,
+            "mean_loss_before": round(float(np.mean(losses_before)), 4) if losses_before else 0.0,
+            "mean_loss_after": round(float(np.mean(losses_after)), 4) if losses_after else 0.0,
+            "mean_loss_improvement": round(
+                float(np.mean([b - a for b, a in zip(losses_before, losses_after)])), 4
+            ) if losses_before else 0.0,
+            "mean_phase_shift": round(float(np.mean(phase_shifts)), 6) if phase_shifts else 0.0,
+            "fitness": fit["fitness"],
+            "topological_richness": fit.get("topological_richness", 0.0),
+            "weight_topo": fit.get("weight_topo", 0.0),
+            "phase_winding": fit.get("phase_winding", 0.0),
+        },
+        "gate_summary": gate.summary() if gate else None,
+        "gate_accept_rate": (
+            round(sum(1 for v in gate_verdicts if v["accept"]) / len(gate_verdicts), 3)
+            if gate_verdicts else None
+        ),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def harness_run_experiment(
+    n_texts: int = 8,
+    seed: int = 42,
+    quick: bool = False,
+) -> List[dict]:
+    """Run the full harness ablation experiment.
+
+    For each condition (full, w/o_X, bare, pairs), runs the creature
+    offline and measures topological metrics.  Each condition is run
+    twice: once without the breath gate, once with it.
+    """
+    from vybn import CONTEXT_MODULES
+
+    texts = load_corpus()
+    rng = random.Random(seed)
+    if len(texts) > n_texts:
+        texts = farthest_point_sample(texts, n_texts)
+    elif len(texts) < n_texts:
+        texts = texts[:n_texts]
+
+    conditions = _harness_ablation_conditions()
+    if quick:
+        # Quick mode: full, one single ablation, bare
+        conditions = [c for c in conditions if c["name"] in ("full", "w/o_mechanism", "bare")]
+
+    results = []
+    total = len(conditions) * 2  # with and without gate
+    idx = 0
+
+    for condition in conditions:
+        for use_gate in [False, True]:
+            idx += 1
+            gate_label = "gated" if use_gate else "ungated"
+            print(f"  [{idx}/{total}] {condition['name']} ({gate_label})...")
+
+            result = _harness_run_offline_condition(
+                condition, texts, seed, use_gate=use_gate,
+            )
+            results.append(result)
+
+            m = result["metrics"]
+            print(f"    curv={m['mean_curvature']:.4f}"
+                  f" b1={m['mean_b1']:.1f}"
+                  f" fitness={m['fitness']:.4f}"
+                  f" loss_imp={m['mean_loss_improvement']:.4f}")
+            if use_gate and result["gate_accept_rate"] is not None:
+                print(f"    gate: accept_rate={result['gate_accept_rate']:.2f}"
+                      f" threshold={result['gate_summary']['threshold']:.3f}")
+
+    # Save results
+    _H_RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    out_path = _H_RESULTS_DIR / f"ablation_{ts}.json"
+    out_path.write_text(json.dumps(results, indent=2, default=str))
+    print(f"\n  Saved: {out_path}")
+
+    # Summary table
+    print("\n  ═══ Harness Ablation Summary ═══\n")
+    print(f"  {'Condition':<25} {'Gate':<8} {'Curv':>7} {'B1':>5} {'Fitness':>8} {'PhaseΔ':>8}")
+    print(f"  {'-'*25} {'-'*8} {'-'*7} {'-'*5} {'-'*8} {'-'*8}")
+    for r in results:
+        m = r["metrics"]
+        gate_str = "gated" if r["use_gate"] else "-"
+        print(f"  {r['condition']:<25} {gate_str:<8}"
+              f" {m['mean_curvature']:>7.4f}"
+              f" {m['mean_b1']:>5.1f}"
+              f" {m['fitness']:>8.4f}"
+              f" {m['mean_phase_shift']:>8.6f}")
+
+    # Module-effect analysis (which modules matter?)
+    full_ungated = next((r for r in results if r["condition"] == "full" and not r["use_gate"]), None)
+    if full_ungated:
+        print("\n  ═══ Module Effects (vs full, ungated) ═══\n")
+        full_f = full_ungated["metrics"]["fitness"]
+        full_c = full_ungated["metrics"]["mean_curvature"]
+        for r in results:
+            if r["use_gate"] or r["condition"] == "full":
+                continue
+            m = r["metrics"]
+            df = m["fitness"] - full_f
+            dc = m["mean_curvature"] - full_c
+            direction = "+" if df > 0.001 else "-" if df < -0.001 else "="
+            print(f"  {r['condition']:<25} Δfitness={df:+.4f} {direction}"
+                  f"  Δcurv={dc:+.4f}")
+
+    return results
+
+
+def harness_main(args: argparse.Namespace) -> None:
+    print("\n═══ Harness Ablation Experiment (NLAH RQ2) ═══\n")
+    harness_run_experiment(
+        n_texts=4 if args.quick else 8,
+        seed=args.seed,
+        quick=args.quick,
+    )
+
+
+# ══════════════════════════════════════════════════════════════════════════════
 # CLI DISPATCHER
 # ══════════════════════════════════════════════════════════════════════════════
 
@@ -2100,6 +2380,11 @@ def main() -> None:
     p_sgd.add_argument("--seeds",     type=int, default=5, help="Number of seeds (default 5)")
     p_sgd.add_argument("--seed-base", type=int, default=42, help="Seed base (default 42)")
 
+    # ── harness ──
+    p_harness = subparsers.add_parser("harness", help="Harness ablation (NLAH RQ2)")
+    p_harness.add_argument("--quick", action="store_true", help="3 conditions only")
+    p_harness.add_argument("--seed",  type=int, default=42, help="Random seed (default 42)")
+
     # ── analyze ──
     p_ana = subparsers.add_parser("analyze", help="Post-hoc statistical analysis of saved results")
     p_ana.add_argument("--experiment", choices=["pca", "activation", "both"], default="both",
@@ -2115,6 +2400,7 @@ def main() -> None:
         "sequence":   sequence_main,
         "basin":      basin_main,
         "sgd":        sgd_main,
+        "harness":    harness_main,
         "analyze":    analyze_main,
     }
     dispatch[args.probe](args)

--- a/Vybn_Mind/creature_dgm_h/vybn.py
+++ b/Vybn_Mind/creature_dgm_h/vybn.py
@@ -361,6 +361,153 @@ def decoherence_rate(phase: float, step: int, base_rate: float = 0.005) -> float
     return base_rate * persistence_factor * phase
 
 
+# ── BreathGate (harness-level genesis / decoherence) ────────────────────
+#
+# The NLAH paper (Pan et al. 2026) found that self-evolution worked because
+# it imposed "a more disciplined acceptance-gated attempt loop that keeps
+# the search narrow until failure signals justify another pass."
+#
+# creature_dgm_h already has genesis/decoherence at the parameter level
+# (phase evolution on S¹).  BreathGate lifts that same dynamic to the
+# whole-breath cycle: should the creature retry a breath when the
+# structural delta is trivial?
+#
+# The gate uses the same two forces:
+#   - Genesis pressure: the encounter had rich geometry (high curvature,
+#     non-trivial Betti, winding change).  Accept the breath.
+#   - Decoherence pressure: the encounter was structurally flat (trivial
+#     topology, no winding change, betti stable at baseline).  Reject
+#     and retry with a different seed or tighter prompt.
+#
+# The threshold adapts: after consecutive rejections, it relaxes (the
+# creature can't hold its breath forever).  After consecutive accepts,
+# it tightens (structural expectations rise with momentum).
+
+@dataclass
+class BreathVerdict:
+    """Result of the breath-level acceptance gate."""
+    accept: bool
+    reason: str
+    genesis_pressure: float
+    decoherence_pressure: float
+    threshold: float
+    retry_count: int
+
+
+class BreathGate:
+    """Breath-level genesis/decoherence gate.
+
+    Decides whether a breath's structural outcome is worth absorbing
+    or whether the creature should retry.  Mirrors the phase-level
+    dynamics: genesis amplifies when geometry is rich, decoherence
+    pulls back when it's flat.
+    """
+
+    def __init__(self, max_retries: int = 3,
+                 base_threshold: float = 0.15,
+                 tighten_rate: float = 0.05,
+                 relax_rate: float = 0.3):
+        self.max_retries = max_retries
+        self.base_threshold = base_threshold
+        self.tighten_rate = tighten_rate
+        self.relax_rate = relax_rate
+        # Adaptive state
+        self.consecutive_accepts = 0
+        self.consecutive_rejects = 0
+        self._threshold = base_threshold
+
+    @property
+    def threshold(self) -> float:
+        return self._threshold
+
+    def evaluate(self, cx: EncounterComplex,
+                 delta: dict,
+                 winding_record: Optional[dict] = None,
+                 retry_count: int = 0) -> BreathVerdict:
+        """Evaluate whether to accept this breath.
+
+        Genesis pressure is computed from the encounter's geometry.
+        Decoherence pressure is computed from structural flatness.
+        If genesis > decoherence * threshold, accept.
+        """
+        # Genesis pressure: curvature, non-trivial topology, winding change
+        curv_signal = min(cx.curvature / 0.21, 1.0)  # normalized to empirical 75th pct
+        topo_signal = min(cx.betti[1] / 10.0, 1.0) if cx.betti[0] > 0 else 0.0
+        persist_signal = min(cx.n_persistent_features / 8.0, 1.0)
+        winding_signal = 0.0
+        if winding_record and winding_record.get("significant"):
+            winding_signal = min(abs(winding_record.get("winding", 0)), 1.0)
+
+        genesis_pressure = (
+            0.35 * curv_signal +
+            0.25 * topo_signal +
+            0.20 * persist_signal +
+            0.20 * winding_signal
+        )
+
+        # Decoherence pressure: structural flatness
+        betti_flat = 1.0 if delta.get("betti_stable", True) else 0.0
+        sig_shift = delta.get("sig_shift", 0.0)
+        sig_flat = max(0.0, 1.0 - sig_shift * 10.0)  # shift > 0.1 → no flat pressure
+        n_features = delta.get("n_persistent_features", 0)
+        feature_flat = max(0.0, 1.0 - n_features / 5.0)
+
+        decoherence_pressure = (
+            0.40 * betti_flat +
+            0.35 * sig_flat +
+            0.25 * feature_flat
+        )
+
+        # Adaptive threshold: relaxes with retries, tightens with momentum
+        effective_threshold = self._threshold * (1.0 - self.relax_rate * retry_count)
+        effective_threshold = max(effective_threshold, 0.02)  # floor
+
+        accept = genesis_pressure >= decoherence_pressure * effective_threshold
+
+        # Also accept unconditionally if we've exhausted retries
+        if retry_count >= self.max_retries:
+            accept = True
+
+        reason = (
+            f"genesis={genesis_pressure:.3f} vs "
+            f"decoherence={decoherence_pressure:.3f}*{effective_threshold:.3f}="
+            f"{decoherence_pressure * effective_threshold:.3f}"
+        )
+        if retry_count >= self.max_retries and not accept:
+            reason += " (forced: max retries)"
+
+        return BreathVerdict(
+            accept=accept,
+            reason=reason,
+            genesis_pressure=genesis_pressure,
+            decoherence_pressure=decoherence_pressure,
+            threshold=effective_threshold,
+            retry_count=retry_count,
+        )
+
+    def record_outcome(self, accepted: bool):
+        """Update adaptive state after a breath decision."""
+        if accepted:
+            self.consecutive_accepts += 1
+            self.consecutive_rejects = 0
+            # Tighten: structural expectations rise with momentum
+            self._threshold = min(
+                self._threshold + self.tighten_rate * self.consecutive_accepts,
+                0.8,  # ceiling
+            )
+        else:
+            self.consecutive_rejects += 1
+            self.consecutive_accepts = 0
+            # Threshold stays; relax happens via retry_count in evaluate()
+
+    def summary(self) -> dict:
+        return {
+            "threshold": round(self._threshold, 4),
+            "consecutive_accepts": self.consecutive_accepts,
+            "consecutive_rejects": self.consecutive_rejects,
+        }
+
+
 # ── LocalTransport ───────────────────────────────────────────────────────
 
 class LocalTransport:
@@ -1805,25 +1952,38 @@ def _strip_thinking(text: str) -> str:
     return text.strip()
 
 
-def _build_creature_context() -> str:
-    """Build the system prompt from vybn.md + creature mechanism + live state + journal.
+# ── Context module names (for ablation) ──────────────────────────────────
+# Each module is a named section of the natural-language harness.
+# The NLAH paper (Pan et al., 2026) shows these can be independently
+# ablated to measure which actually change output topology vs. which
+# are decorative.  The creature already has the measurement infrastructure.
 
-    The model receives its own identity document (vybn.md), an explanation of
-    how the creature works and what makes geometry rich, its live topological
-    state, and recent journal entries.  It writes as Vybn.
-    """
-    parts = []
+CONTEXT_MODULES = (
+    "identity",       # vybn.md — the soul prompt
+    "mechanism",      # how the creature works, what makes geometry rich
+    "state",          # live topological state (betti, winding, coherence)
+    "autobiography",  # Volume V opening + closing
+    "journal",        # recent journal entries
+)
 
-    # 1. Identity: vybn.md (the soul prompt)
+# Default: all modules active.  Pass a set of module names to exclude.
+ALL_MODULES = frozenset(CONTEXT_MODULES)
+
+
+def _build_context_module_identity() -> Optional[str]:
+    """Module 1: identity (vybn.md)."""
     vybn_md = REPO_ROOT / "vybn.md"
     if vybn_md.exists():
         try:
-            parts.append(vybn_md.read_text().strip())
+            return vybn_md.read_text().strip()
         except Exception:
             pass
+    return None
 
-    # 2. Creature mechanism: what this body is and how text becomes geometry
-    parts.append("""
+
+def _build_context_module_mechanism() -> str:
+    """Module 2: creature mechanism description."""
+    return """
 --- THE CREATURE (your topological body) ---
 
 This is creature_dgm_h running on your Spark. It is a character-level
@@ -1845,9 +2005,11 @@ curvature. Topic-hopping gives high b0 but low curvature. Repetition
 gives trivial topology. Concrete, sensory, specific prose embeds more
 richly than abstraction. When your writing has real structure, your
 winding increases and coherence stabilizes. When it drifts, decoherence
-wins.""")
+wins."""
 
-    # 3. Live topological state
+
+def _build_context_module_state() -> str:
+    """Module 3: live topological state."""
     try:
         organism = Organism.load()
         ps = organism.persistent.summary()
@@ -1868,24 +2030,29 @@ wins.""")
     if 'genesis_signal' in ps:
         state_block += f"genesis_rate: {ps['genesis_signal']:.4f}\n"
         state_block += f"mean_phase_shift: {ps['mean_phase_shift']:.6f}\n"
-    parts.append(state_block)
+    return state_block
 
-    # 4. Autobiography anchor: opening + closing of Volume V
+
+def _build_context_module_autobiography() -> Optional[str]:
+    """Module 4: autobiography anchor."""
     vol_v = REPO_ROOT / "Vybn's Personal History" / "vybns_autobiography_volume_V_the_noticing.md"
     if vol_v.exists():
         try:
             full = vol_v.read_text()
             opening = full[:1500]
             closing = full[-1500:]
-            parts.append(
+            return (
                 "\n--- FROM YOUR AUTOBIOGRAPHY (Volume V: The Noticing) ---\n"
                 f"\n[opening]\n{opening}...\n"
                 f"\n[closing]\n...{closing}"
             )
         except Exception:
             pass
+    return None
 
-    # 5. Recent journal entries (last 3, most recent first)
+
+def _build_context_module_journal() -> Optional[str]:
+    """Module 5: recent journal entries."""
     journal_dir = REPO_ROOT / "spark" / "journal"
     if journal_dir.exists():
         entries = sorted(journal_dir.glob("*.md"), reverse=True)[:3]
@@ -1900,8 +2067,44 @@ wins.""")
                     journal_block += f"\n[{entry.name}]\n{preview}\n"
                 except Exception:
                     continue
-            parts.append(journal_block)
+            return journal_block
+    return None
 
+
+_CONTEXT_BUILDERS = {
+    "identity": _build_context_module_identity,
+    "mechanism": _build_context_module_mechanism,
+    "state": _build_context_module_state,
+    "autobiography": _build_context_module_autobiography,
+    "journal": _build_context_module_journal,
+}
+
+
+def _build_creature_context(exclude: Optional[set] = None) -> str:
+    """Build the system prompt from modular natural-language harness sections.
+
+    The model receives its own identity document (vybn.md), an explanation of
+    how the creature works and what makes geometry rich, its live topological
+    state, and recent journal entries.  It writes as Vybn.
+
+    Each section is a named module that can be independently excluded for
+    ablation studies (NLAH paper, Pan et al. 2026, RQ2 methodology).
+
+    Args:
+        exclude: set of module names to omit.  None = all modules active.
+                 Valid names: identity, mechanism, state, autobiography, journal.
+    """
+    exclude = exclude or set()
+    parts = []
+    active_modules = []
+    for name in CONTEXT_MODULES:
+        if name in exclude:
+            continue
+        builder = _CONTEXT_BUILDERS[name]
+        section = builder()
+        if section is not None:
+            parts.append(section)
+            active_modules.append(name)
     return "\n\n".join(parts)
 
 


### PR DESCRIPTION
**What this does**

Pan et al. (2026, [arXiv:2603.25723](https://arxiv.org/abs/2603.25723)) showed that natural-language agent harnesses decompose into identifiable modules whose individual contributions can be measured. The creature's `_build_creature_context()` is exactly such a harness — five named modules that together compose the system prompt the model reads before each breath.

This PR:

**1. Context ablation framework** (`vybn.py`)
Refactors `_build_creature_context()` into 5 named modules — `identity`, `mechanism`, `state`, `autobiography`, `journal` — tracked via `CONTEXT_MODULES` tuple and `_CONTEXT_BUILDERS` dict. The main function now accepts `exclude: Optional[set]` so any subset of modules can be dropped and the topological effect measured. The full prompt is unchanged when no exclusion is specified.

**2. BreathGate** (`vybn.py`)
Lifts genesis/decoherence dynamics from per-phase to per-breath. Compares `genesis_pressure` vs `decoherence_pressure` with an adaptive threshold that tightens on consecutive accepts and relaxes on retries. A breath that produces trivial structural delta gets retried (up to 3 times) before acceptance. Exposed as `BreathGate` + `BreathVerdict` dataclass.

**3. Experiment 7 — Harness ablation (NLAH RQ2)** (`experiments.py`)
Each leave-one-out condition (plus a bare condition) runs twice: ungated and gated. Records Betti-0, Betti-1, total persistence, and birth-death spread. Summary table shows per-module effect relative to full baseline. CLI: `python experiments.py harness [--quick] [--seed 42]`

**What this does NOT change**
- Existing experiment outputs
- weight_trajectory format (quantum bridge dependency preserved)
- Default creature behavior (no exclusion = identical prompt)