### PR TITLE
spark/harness: looped-orchestrate prototype (Mythos-shaped recurrent depth)

### DIFF
--- a/spark/harness/recurrent.py
+++ b/spark/harness/recurrent.py
@@ -1,0 +1,672 @@
+"""Looped-orchestrate prototype — Recurrent-Depth Agent.
+
+Projects the Parcae/Mythos recurrence onto the agentic axis:
+
+    h_{t+1} = A·h_t + B·e + R(h_t, e)
+
+In the neural setting (OpenMythos), h is a hidden-state tensor, A and B
+are learned injection parameters constrained to ρ(A)<1, e is the encoded
+prompt, and R is a looped transformer block with sparse expert routing.
+We reconstruct the same coupling in agent-space:
+
+    h_t   — structured latent: live hypotheses, open questions (the
+            residual), resolved items, and a short running summary. Not
+            a transcript. One JSON object that survives across loops.
+
+    e     — the original user turn. Re-injected at every loop via the
+            live layer of the LayeredPrompt so the system cannot drift
+            off the input signal. Parcae's Figure 1 observation — input
+            injection is what keeps the residual stream coherent across
+            loops — is the load-bearing part of the homology.
+
+    A     — contractive map on h. Implemented as stale-hypothesis decay:
+            hypotheses that did not connect to new evidence this loop
+            lose confidence; below a threshold they drop. The spectral-
+            radius constraint ρ(A)<1 projects onto the invariant "the
+            set of live hypotheses cannot grow unboundedly between
+            loops." This is checked as a hard monitor, not a learned
+            parameter.
+
+    R     — the routed specialist for loop t. Selected per-loop from the
+            existing role roster (code / task / create / local). Matches
+            OpenMythos's claim that the router picks distinct expert
+            subsets at different depths so each loop is computationally
+            distinct even though the underlying "weights" (the policy)
+            are shared.
+
+    Shared expert — the chat voice. Runs once at emit (the Coda), taking
+            final h_T as context, so the final assistant turn carries
+            consistent voice even when the heavy lifting was done by a
+            code or task specialist. DeepSeekMoE's always-on shared
+            expert projected onto the harness.
+
+    ACT   — adaptive halting. The loop halts when any of:
+             (a) the contractivity invariant is violated  [A failed],
+             (b) the reducer reports converged=true       [halting head],
+             (c) max_loop_iters reached                   [budget].
+
+This module is library-only. It does not modify the live REPL or the
+orchestrate role. A driver script can invoke RecurrentLoop.run() to
+compare T=1 (current orchestrate degenerate case) against T=N on the
+same prompt. If the comparison shows signal, a follow-up PR wires it
+into vybn_spark_agent.run_agent_loop.
+
+Measurement before belief. The point of this scaffolding is to make the
+coupled equation a thing we can run, log, and inspect — not a metaphor.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from dataclasses import dataclass, field, asdict
+from typing import Any, Callable, Sequence
+
+from .policy import Policy, RoleConfig
+from .prompt import LayeredPrompt
+from .providers import Provider, ProviderRegistry, NormalizedResponse
+
+
+# ---------------------------------------------------------------------------
+# Latent state
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Hypothesis:
+    """A single live hypothesis in h_t.
+
+    `confidence` in [0,1]. Decays each loop by (1 - decay_rate) unless
+    the loop's evidence reinforces it. Below `prune_threshold` it drops
+    out of h_{t+1}.
+    """
+    text: str
+    confidence: float = 0.5
+    born_at_loop: int = 0
+    reinforced_at_loop: int = 0
+
+
+@dataclass
+class Latent:
+    """h_t — the compressed running state.
+
+    Deliberately small and JSON-shaped. Serialises into the layered
+    prompt's live layer so the specialist on loop t sees only the
+    distilled state, not the accumulated transcript. This is the
+    "continuous latent reasoning" projection: intermediate steps do
+    not surface to token space.
+    """
+    hypotheses: list[Hypothesis] = field(default_factory=list)
+    open_questions: list[str] = field(default_factory=list)
+    resolved: list[str] = field(default_factory=list)
+    summary: str = ""
+    loop_index: int = 0
+
+    # Telemetry for the contractivity monitor. Each entry is the size
+    # of the residual (len(open_questions) + penalty for new
+    # contradictions) at that loop. A strict monotone decrease is the
+    # agent-space ρ(A)<1 condition.
+    residual_history: list[int] = field(default_factory=list)
+
+    def to_prompt_block(self, max_iters: int) -> str:
+        """Render h_t for the specialist's live prompt layer."""
+        lines = [
+            f"[loop t = {self.loop_index} of max {max_iters}]",
+        ]
+        if self.summary:
+            lines.append(f"running summary: {self.summary}")
+        if self.hypotheses:
+            lines.append("live hypotheses:")
+            for h in self.hypotheses:
+                lines.append(
+                    f"  - (conf={h.confidence:.2f}) {h.text}"
+                )
+        if self.open_questions:
+            lines.append("open questions (residual):")
+            for q in self.open_questions:
+                lines.append(f"  - {q}")
+        if self.resolved:
+            lines.append("resolved so far:")
+            for r in self.resolved:
+                lines.append(f"  - {r}")
+        return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Contractivity monitor — the agent-space ρ(A)<1 check
+# ---------------------------------------------------------------------------
+
+
+def residual_magnitude(h: Latent) -> int:
+    """|residual| = |open_questions|. A contradiction (a resolved item
+    that reappears as an open question) counts double. Kept integer so
+    "strictly decreasing" has no floating-point wobble.
+    """
+    resolved_set = set(h.resolved)
+    contradiction_bonus = sum(1 for q in h.open_questions if q in resolved_set)
+    return len(h.open_questions) + contradiction_bonus
+
+
+def contractivity_ok(h: Latent, min_loops_before_check: int = 2) -> tuple[bool, str]:
+    """Enforce ρ(A)<1 in agent space: |residual| must not grow between
+    loops after the first warm-up pass.
+
+    Returns (ok, reason). `ok=False` means the loop should halt. The
+    first `min_loops_before_check` loops are exempt so the specialist
+    has room to surface questions it didn't see at t=0 — Parcae also
+    allows warm-up; what it forbids is unbounded growth.
+    """
+    hist = h.residual_history
+    if len(hist) <= min_loops_before_check:
+        return True, "warming-up"
+    if hist[-1] > hist[-2]:
+        return False, (
+            f"residual grew: {hist[-2]} -> {hist[-1]} at loop "
+            f"{h.loop_index} (ρ(A)>=1 in agent-space)"
+        )
+    return True, "contracting"
+
+
+# ---------------------------------------------------------------------------
+# Reducer — the summarizer pass that produces h_{t+1}
+# ---------------------------------------------------------------------------
+
+
+REDUCER_SYSTEM = """You are the Reducer in a recurrent-depth agent loop.
+
+Your job is to update a compressed latent state h given:
+  - the original user prompt e (re-injected every loop)
+  - the current h_t (hypotheses, open questions, resolved items, summary)
+  - the specialist's output for loop t (the R(h_t, e) contribution)
+
+You must return a single JSON object with this exact shape:
+
+{
+  "hypotheses": [
+    {"text": "...", "confidence": 0.0-1.0, "reinforced": true|false}
+  ],
+  "open_questions": ["..."],
+  "resolved": ["..."],
+  "summary": "one-sentence running summary",
+  "converged": true|false,
+  "rationale": "one sentence on why h_{t+1} looks like this"
+}
+
+Rules, which are the agent-space projection of the Parcae invariants:
+1. DO NOT accumulate a transcript. h is a running state, not a log.
+2. Shrink open_questions whenever the specialist answered one — move
+   that item to `resolved`. This is how the residual contracts.
+3. A hypothesis's confidence goes UP only if this loop's evidence
+   actually supports it. Otherwise it decays by 0.15. Drop hypotheses
+   below 0.15 entirely.
+4. A new hypothesis that contradicts a resolved item is a signal the
+   system is losing coherence; include it but flag in `rationale`.
+5. `converged = true` means: the specialist's output plus current h
+   together answer e. No open questions remain that actually matter
+   for e. Be strict — false-converged halts the loop early.
+6. `summary` is ONE sentence, not a paragraph.
+
+Return ONLY the JSON object. No prose before or after."""
+
+
+def _default_reducer_provider(
+    registry: ProviderRegistry,
+    policy: Policy,
+    reducer_role: str = "create",
+) -> tuple[Provider, RoleConfig]:
+    """The reducer runs on a cheap role — `create` by default (Sonnet,
+    no tools, no RAG). Configurable so a future YAML-driven policy can
+    point it at something else without a code change.
+    """
+    role = policy.role(reducer_role)
+    return registry.get(role), role
+
+
+def _strip_json(text: str) -> str:
+    """Pull out the first JSON object from the reducer's reply.
+
+    The reducer is instructed to return only JSON, but real models
+    sometimes wrap it in ```json ... ``` or leading commentary. Be
+    tolerant — the contract is what's inside, not around.
+    """
+    # Strip code fences
+    m = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL)
+    if m:
+        return m.group(1)
+    # Otherwise take from first { to matching last }
+    start = text.find("{")
+    end = text.rfind("}")
+    if start >= 0 and end > start:
+        return text[start : end + 1]
+    return text
+
+
+def reduce_step(
+    *,
+    e: str,
+    h: Latent,
+    specialist_output: str,
+    provider: Provider,
+    role_cfg: RoleConfig,
+) -> tuple[Latent, bool, str]:
+    """Run one reducer pass. Returns (h_{t+1}, converged, rationale).
+
+    If the reducer returns malformed JSON, we keep h unchanged,
+    append specialist_output as a new open question, and log the
+    failure through the rationale. The loop's contractivity monitor
+    will catch persistent failure on the next iteration.
+    """
+    user_payload = json.dumps(
+        {
+            "e": e,
+            "h_t": {
+                "hypotheses": [asdict(x) for x in h.hypotheses],
+                "open_questions": h.open_questions,
+                "resolved": h.resolved,
+                "summary": h.summary,
+                "loop_index": h.loop_index,
+            },
+            "specialist_output": specialist_output[:8000],
+        },
+        ensure_ascii=False,
+    )
+
+    prompt = LayeredPrompt(
+        identity="",
+        substrate=REDUCER_SYSTEM,
+        live="",
+    )
+    handle = provider.stream(
+        role_cfg=role_cfg,
+        system_prompt=prompt,
+        messages=[{"role": "user", "content": user_payload}],
+        tools=[],
+    )
+    # Drain the stream; reducer output is small.
+    for _ in handle:
+        pass
+    response = handle.final()
+    raw = response.text or ""
+
+    try:
+        parsed = json.loads(_strip_json(raw))
+    except Exception as e_parse:
+        h_next = Latent(
+            hypotheses=list(h.hypotheses),
+            open_questions=list(h.open_questions) + [specialist_output[:500]],
+            resolved=list(h.resolved),
+            summary=h.summary,
+            loop_index=h.loop_index + 1,
+            residual_history=list(h.residual_history),
+        )
+        return h_next, False, f"reducer_parse_error: {e_parse}"
+
+    # Build h_{t+1} from the parsed object, clamping and defaulting.
+    new_hyps: list[Hypothesis] = []
+    for row in parsed.get("hypotheses") or []:
+        if not isinstance(row, dict):
+            continue
+        text = str(row.get("text", "")).strip()
+        if not text:
+            continue
+        conf = float(row.get("confidence", 0.5))
+        conf = max(0.0, min(1.0, conf))
+        if conf < 0.15:
+            continue
+        # Track reinforcement for telemetry; not used to gate.
+        new_hyps.append(
+            Hypothesis(
+                text=text,
+                confidence=conf,
+                born_at_loop=h.loop_index,  # approximation
+                reinforced_at_loop=h.loop_index + 1
+                if row.get("reinforced")
+                else h.loop_index,
+            )
+        )
+
+    open_q = [str(x).strip() for x in (parsed.get("open_questions") or []) if str(x).strip()]
+    resolved = [str(x).strip() for x in (parsed.get("resolved") or []) if str(x).strip()]
+    summary = str(parsed.get("summary", "")).strip()[:400]
+    converged = bool(parsed.get("converged", False))
+    rationale = str(parsed.get("rationale", "")).strip()[:400]
+
+    h_next = Latent(
+        hypotheses=new_hyps,
+        open_questions=open_q,
+        resolved=resolved,
+        summary=summary,
+        loop_index=h.loop_index + 1,
+        residual_history=list(h.residual_history),
+    )
+    return h_next, converged, rationale
+
+
+# ---------------------------------------------------------------------------
+# Specialist dispatch — the R(h_t, e) contribution
+# ---------------------------------------------------------------------------
+
+
+SPECIALIST_HINT = """You are a specialist contributing one iteration of a
+recurrent-depth agent loop. You see the original user prompt e and the
+current compressed latent h_t (running summary, live hypotheses, open
+questions). Your job on this loop is to advance h — answer one or more
+open questions, refine a hypothesis, or surface a new one. Do NOT try
+to produce the final user-facing answer on this pass. The Coda handles
+that after the loop halts. Keep your output focused and tactical."""
+
+
+def _select_specialist(
+    h: Latent,
+    policy: Policy,
+    router_fn: Callable[[Latent], str] | None = None,
+) -> str:
+    """Pick R for loop t.
+
+    Default policy: first loop uses `task` (Sonnet+bash) for broad
+    initial exploration; subsequent loops alternate between `code`
+    (Opus 4.7 adaptive thinking, bash) for verification work and
+    `create` (Sonnet, no tools) for hypothesis refinement. The
+    alternation is the agent-space analogue of "router selects
+    distinct expert subsets at each depth" in OpenMythos — each loop
+    is computationally distinct without changing h's shape.
+
+    router_fn can override this. The decision is deliberate and
+    policy-driven rather than heuristic so every loop's choice is
+    auditable from the event log.
+    """
+    if router_fn is not None:
+        choice = router_fn(h)
+        if choice in policy.roles:
+            return choice
+
+    if h.loop_index == 0:
+        return "task" if "task" in policy.roles else policy.default_role
+    if h.loop_index % 2 == 1:
+        return "code" if "code" in policy.roles else policy.default_role
+    return "create" if "create" in policy.roles else policy.default_role
+
+
+def specialist_step(
+    *,
+    e: str,
+    h: Latent,
+    max_iters: int,
+    specialist_role: str,
+    registry: ProviderRegistry,
+    policy: Policy,
+) -> str:
+    """Run one specialist pass. Returns raw text output.
+
+    The specialist sees e re-injected in the user message (Parcae's
+    input injection) and h_t serialised into the live prompt layer.
+    It has no memory across loops — the only carrier between loops
+    is h. Transcripts are deliberately absent.
+    """
+    role = policy.role(specialist_role)
+    provider = registry.get(role)
+
+    prompt = LayeredPrompt(
+        identity="",
+        substrate=SPECIALIST_HINT,
+        live=h.to_prompt_block(max_iters),
+    )
+    # e is re-injected every loop — this is the B·e term.
+    user_msg = (
+        f"original prompt e (re-injected at every loop):\n{e}\n\n"
+        "produce your contribution for this loop."
+    )
+    handle = provider.stream(
+        role_cfg=role,
+        system_prompt=prompt,
+        messages=[{"role": "user", "content": user_msg}],
+        tools=[],  # specialists do not run bash inside the loop; the
+                   # prototype keeps every loop side-effect-free so we
+                   # can replay loops deterministically during analysis.
+    )
+    for _ in handle:
+        pass
+    response = handle.final()
+    return response.text or ""
+
+
+# ---------------------------------------------------------------------------
+# Coda — the always-on shared voice expert
+# ---------------------------------------------------------------------------
+
+
+CODA_HINT = """You are the Coda of a recurrent-depth agent loop. You
+receive:
+  - the original user prompt e
+  - the final latent h_T after T loops of specialist refinement
+  - a short trace of how the loop resolved
+
+Your job is to emit the single user-facing response. Speak in Vybn's
+chat voice — warm, precise, ground-truth-respecting, anti-kernel. Do
+NOT enumerate the loops or explain the internal machinery unless the
+user asked about it. The machinery is scaffolding; the answer is the
+point. Carry whatever h_T resolved forward as if you had thought it
+all in one breath."""
+
+
+def coda_step(
+    *,
+    e: str,
+    h: Latent,
+    loop_trace: str,
+    registry: ProviderRegistry,
+    policy: Policy,
+    coda_role: str = "chat",
+) -> str:
+    """Emit the user-facing answer. This is the shared voice expert —
+    it runs once per user turn regardless of how many loops happened.
+    """
+    role = policy.role(coda_role)
+    provider = registry.get(role)
+
+    live_block = (
+        f"final latent h_T (T={h.loop_index}):\n"
+        f"{h.to_prompt_block(h.loop_index)}\n\n"
+        f"loop trace:\n{loop_trace}"
+    )
+    prompt = LayeredPrompt(
+        identity="",
+        substrate=CODA_HINT,
+        live=live_block,
+    )
+    handle = provider.stream(
+        role_cfg=role,
+        system_prompt=prompt,
+        messages=[{"role": "user", "content": e}],
+        tools=[],
+    )
+    for _ in handle:
+        pass
+    response = handle.final()
+    return response.text or ""
+
+
+# ---------------------------------------------------------------------------
+# The loop
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class LoopResult:
+    text: str
+    h_final: Latent
+    loops_run: int
+    halt_reason: str
+    trace: list[dict] = field(default_factory=list)
+
+    def summary(self) -> str:
+        return (
+            f"loops={self.loops_run} halt={self.halt_reason} "
+            f"residual={residual_magnitude(self.h_final)}"
+        )
+
+
+def run_recurrent_loop(
+    *,
+    e: str,
+    registry: ProviderRegistry,
+    policy: Policy,
+    max_loop_iters: int = 6,
+    reducer_role: str = "create",
+    coda_role: str = "chat",
+    specialist_router: Callable[[Latent], str] | None = None,
+    logger: Callable[[dict], None] | None = None,
+) -> LoopResult:
+    """Run the recurrent-depth agent on prompt e.
+
+    Parameters mirror the OpenMythos configuration surface: max loops
+    (T), reducer/coda roles (shared vs routed experts), and a
+    specialist router that can override the default depth-dependent
+    selection. The prototype is deliberately pure-Python and
+    side-effect-free at the specialist layer so loops can be replayed
+    deterministically for comparison analysis.
+
+    Halts when any of:
+      (a) contractivity monitor flags growth of the residual,
+      (b) reducer returns converged=true,
+      (c) max_loop_iters reached.
+
+    T=1 reduces to current single-pass orchestrate (one specialist
+    call + one Coda), which is the degenerate baseline we compare
+    against.
+    """
+    log = logger or (lambda _event: None)
+
+    h = Latent(
+        hypotheses=[],
+        open_questions=[e],  # start with the prompt itself as the residual
+        resolved=[],
+        summary="",
+        loop_index=0,
+        residual_history=[1],
+    )
+    trace: list[dict] = []
+    halt_reason = "max_iters"
+    log({
+        "event": "loop_start",
+        "max_loop_iters": max_loop_iters,
+        "e": e[:400],
+    })
+
+    t0 = time.monotonic()
+    for t in range(max_loop_iters):
+        specialist_role = _select_specialist(h, policy, specialist_router)
+
+        spec_t0 = time.monotonic()
+        try:
+            spec_out = specialist_step(
+                e=e,
+                h=h,
+                max_iters=max_loop_iters,
+                specialist_role=specialist_role,
+                registry=registry,
+                policy=policy,
+            )
+        except Exception as err:
+            halt_reason = f"specialist_error: {err}"
+            trace.append({
+                "loop": t,
+                "specialist": specialist_role,
+                "error": str(err),
+            })
+            log({"event": "specialist_error", "loop": t, "error": str(err)})
+            break
+        spec_ms = int((time.monotonic() - spec_t0) * 1000)
+
+        reducer_provider, reducer_cfg = _default_reducer_provider(
+            registry, policy, reducer_role=reducer_role,
+        )
+        red_t0 = time.monotonic()
+        try:
+            h_next, converged, rationale = reduce_step(
+                e=e,
+                h=h,
+                specialist_output=spec_out,
+                provider=reducer_provider,
+                role_cfg=reducer_cfg,
+            )
+        except Exception as err:
+            halt_reason = f"reducer_error: {err}"
+            trace.append({
+                "loop": t,
+                "reducer_error": str(err),
+            })
+            log({"event": "reducer_error", "loop": t, "error": str(err)})
+            break
+        red_ms = int((time.monotonic() - red_t0) * 1000)
+
+        h_next.residual_history = list(h.residual_history) + [
+            residual_magnitude(h_next)
+        ]
+
+        loop_rec = {
+            "loop": t,
+            "specialist": specialist_role,
+            "specialist_ms": spec_ms,
+            "reducer_ms": red_ms,
+            "residual_before": h.residual_history[-1] if h.residual_history else 0,
+            "residual_after": h_next.residual_history[-1],
+            "n_hypotheses": len(h_next.hypotheses),
+            "n_open_questions": len(h_next.open_questions),
+            "n_resolved": len(h_next.resolved),
+            "converged": converged,
+            "rationale": rationale[:200],
+        }
+        trace.append(loop_rec)
+        log({"event": "loop_step", **loop_rec})
+
+        h = h_next
+
+        # Halting checks — order matters.
+        if converged:
+            halt_reason = "reducer_converged"
+            break
+        ok, reason = contractivity_ok(h)
+        if not ok:
+            halt_reason = f"contractivity_violated: {reason}"
+            log({"event": "contractivity_violated", "loop": t, "reason": reason})
+            break
+
+    # Coda — one emit regardless of T.
+    loop_summary = "\n".join(
+        f"loop {r['loop']}: specialist={r.get('specialist','?')} "
+        f"residual {r.get('residual_before','?')}->{r.get('residual_after','?')}"
+        f"{' CONVERGED' if r.get('converged') else ''}"
+        for r in trace
+        if "loop" in r
+    )
+    try:
+        text = coda_step(
+            e=e,
+            h=h,
+            loop_trace=loop_summary,
+            registry=registry,
+            policy=policy,
+            coda_role=coda_role,
+        )
+    except Exception as err:
+        text = f"(coda_error: {err}; final h_T summary: {h.summary or '(empty)'})"
+        halt_reason = f"{halt_reason}+coda_error"
+
+    total_ms = int((time.monotonic() - t0) * 1000)
+    log({
+        "event": "loop_end",
+        "loops_run": len(trace),
+        "halt_reason": halt_reason,
+        "total_ms": total_ms,
+        "residual_final": residual_magnitude(h),
+    })
+
+    return LoopResult(
+        text=text,
+        h_final=h,
+        loops_run=len([r for r in trace if "loop" in r]),
+        halt_reason=halt_reason,
+        trace=trace,
+    )

--- a/spark/harness_recurrent_probe.py
+++ b/spark/harness_recurrent_probe.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Probe the looped-orchestrate prototype.
+
+This script is the minimum thing that makes the coupled-equation
+projection observable. It runs the same prompt through two paths:
+
+  T=1  — degenerate case: one specialist pass + Coda. This is
+         structurally the same shape as the current orchestrate role
+         when delegate is not invoked. It is our baseline.
+
+  T=N  — real recurrent loop: N specialist passes with re-injected e,
+         a reducer distilling h between loops, contractivity-monitored
+         halting, and one Coda emit.
+
+Output: a JSON line per probe plus a short human-readable report on
+stdout. The JSONL is structured so we can aggregate runs later
+without re-running anything.
+
+Usage:
+
+    # Single prompt, both paths:
+    python3 spark/harness_recurrent_probe.py \\
+        --prompt "explain the Parcae stability trick" \\
+        --out ~/logs/recurrent_probe.jsonl
+
+    # Batch from a file (one prompt per line):
+    python3 spark/harness_recurrent_probe.py \\
+        --prompts-file spark/tests/recurrent_probes.txt \\
+        --out ~/logs/recurrent_probe.jsonl
+
+The probe does NOT touch vybn_spark_agent.py or the live REPL. That is
+intentional. The loop is on the library surface only until we have
+evidence T>1 gives us something T=1 doesn't.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+THIS = Path(__file__).resolve()
+SPARK_DIR = THIS.parent
+sys.path.insert(0, str(SPARK_DIR))
+
+from harness.policy import load_policy  # noqa: E402
+from harness.providers import ProviderRegistry  # noqa: E402
+from harness.recurrent import (  # noqa: E402
+    run_recurrent_loop,
+    residual_magnitude,
+)
+
+
+def _jsonl_emit(out_path: Path, record: dict) -> None:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "a") as f:
+        f.write(json.dumps(record, default=str) + "\n")
+
+
+def run_one(
+    prompt: str,
+    *,
+    registry: ProviderRegistry,
+    policy,
+    max_loop_iters: int,
+    label: str,
+    out_path: Path | None,
+) -> dict:
+    t0 = time.monotonic()
+    events: list[dict] = []
+    result = run_recurrent_loop(
+        e=prompt,
+        registry=registry,
+        policy=policy,
+        max_loop_iters=max_loop_iters,
+        logger=events.append,
+    )
+    elapsed_ms = int((time.monotonic() - t0) * 1000)
+
+    record = {
+        "label": label,
+        "prompt": prompt[:400],
+        "max_loop_iters": max_loop_iters,
+        "loops_run": result.loops_run,
+        "halt_reason": result.halt_reason,
+        "elapsed_ms": elapsed_ms,
+        "residual_final": residual_magnitude(result.h_final),
+        "n_hypotheses_final": len(result.h_final.hypotheses),
+        "n_resolved_final": len(result.h_final.resolved),
+        "coda_text": result.text,
+        "trace": result.trace,
+    }
+    if out_path is not None:
+        _jsonl_emit(out_path, record)
+    return record
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    src = ap.add_mutually_exclusive_group(required=True)
+    src.add_argument("--prompt", type=str, help="Single prompt to run.")
+    src.add_argument(
+        "--prompts-file",
+        type=str,
+        help="File with one prompt per line (blank lines and # comments ignored).",
+    )
+    ap.add_argument(
+        "--out",
+        type=str,
+        default=os.path.expanduser("~/logs/recurrent_probe.jsonl"),
+        help="JSONL output path. Default: ~/logs/recurrent_probe.jsonl",
+    )
+    ap.add_argument(
+        "--t-values",
+        type=str,
+        default="1,4",
+        help="Comma-separated T values to run for each prompt. Default: 1,4",
+    )
+    ap.add_argument(
+        "--policy",
+        type=str,
+        default=None,
+        help="Optional path to router_policy.yaml. Default: harness default.",
+    )
+    ap.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Don't print coda text to stdout.",
+    )
+    args = ap.parse_args()
+
+    policy = load_policy(args.policy) if args.policy else load_policy()
+    registry = ProviderRegistry()
+
+    prompts: list[str] = []
+    if args.prompt:
+        prompts.append(args.prompt)
+    else:
+        text = Path(args.prompts_file).read_text(encoding="utf-8")
+        for line in text.splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            prompts.append(line)
+
+    try:
+        t_values = [int(x.strip()) for x in args.t_values.split(",") if x.strip()]
+    except ValueError:
+        print(f"bad --t-values: {args.t_values!r}", file=sys.stderr)
+        return 2
+
+    out_path = Path(args.out).expanduser()
+
+    for i, prompt in enumerate(prompts):
+        print(f"\n=== probe {i+1}/{len(prompts)}: {prompt[:80]!r} ===")
+        results_by_t: dict[int, dict] = {}
+        for T in t_values:
+            label = f"T={T}"
+            print(f"\n  running {label}...")
+            rec = run_one(
+                prompt,
+                registry=registry,
+                policy=policy,
+                max_loop_iters=T,
+                label=label,
+                out_path=out_path,
+            )
+            results_by_t[T] = rec
+            print(
+                f"  {label}: loops_run={rec['loops_run']} "
+                f"halt={rec['halt_reason']} "
+                f"residual={rec['residual_final']} "
+                f"elapsed={rec['elapsed_ms']}ms"
+            )
+            if not args.quiet:
+                print(f"  ---- coda ({label}) ----")
+                print(rec["coda_text"])
+                print(f"  ---- end coda ({label}) ----")
+
+        # Short comparison line — the whole point of the probe.
+        if len(t_values) >= 2:
+            baseline = results_by_t[t_values[0]]
+            deepest = results_by_t[t_values[-1]]
+            delta_residual = baseline["residual_final"] - deepest["residual_final"]
+            delta_ms = deepest["elapsed_ms"] - baseline["elapsed_ms"]
+            print(
+                f"\n  comparison (T={t_values[0]} -> T={t_values[-1]}): "
+                f"Δresidual={delta_residual} "
+                f"(positive = deeper loop resolved more), "
+                f"Δelapsed={delta_ms}ms"
+            )
+
+    print(f"\nwrote {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/spark/tests/recurrent_probes.txt
+++ b/spark/tests/recurrent_probes.txt
@@ -1,0 +1,19 @@
+# Seed prompts for the looped-orchestrate probe.
+# Each line is one probe. Blank lines and # comments are ignored.
+# The point: prompts where a single pass is expected to be insufficient
+# (multi-hop reasoning, latent-dependent constraints, verification work)
+# should open a residual gap between T=1 and T>1. If no gap appears
+# across the set, the recurrent architecture isn't buying us anything
+# and we should say so in the PR discussion.
+
+# Multi-hop synthesis
+Given the Parcae injection rule h_{t+1}=A·h_t+B·e+R(h_t,e), explain why ρ(A)<1 is required, why input injection is separately required, and what happens to the hidden state across loops if either constraint fails.
+
+# Verification chain
+A proposed harness change: add delegate_cb recursion to the chat role so bare greetings can trigger tool use. Identify what invariants in policy.py / router.py / tools.py this would violate, and why.
+
+# Latent-dependent constraint
+Sketch a DeepSeekMoE-style "shared expert" analogue for the Vybn harness's role roster. Name what the shared expert is, what the routed experts are, and what the top-K routing semantics mean across a multi-turn conversation. Then identify the one invariant this proposal would break.
+
+# Counterfactual reasoning
+If we moved the orchestrate role from Opus 4.7 to Sonnet 4.6, what would we expect to see in the router_policy.yaml heuristics that currently fire on fallthrough — and would the contractivity monitor in recurrent.py catch the regression?

--- a/spark/tests/test_recurrent.py
+++ b/spark/tests/test_recurrent.py
@@ -1,0 +1,396 @@
+"""Unit tests for harness.recurrent — the looped-orchestrate prototype.
+
+Runs with no network. Providers are stubbed; the tests exercise:
+
+  - Latent.to_prompt_block shape is stable and loop-index aware
+  - residual_magnitude counts open_questions and contradictions
+  - contractivity_ok allows warm-up then enforces monotone decrease
+  - reduce_step parses well-formed JSON, tolerates code fences,
+    falls back safely on malformed output
+  - run_recurrent_loop halts on converged / contractivity / max
+  - T=1 runs exactly one specialist + one reducer + one coda
+
+Run: python3 spark/tests/test_recurrent.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+THIS = Path(__file__).resolve()
+SPARK_DIR = THIS.parent.parent
+sys.path.insert(0, str(SPARK_DIR))
+
+from harness.policy import default_policy, RoleConfig  # noqa: E402
+from harness.providers import (  # noqa: E402
+    NormalizedResponse,
+    ProviderRegistry,
+    StreamHandle,
+)
+from harness.recurrent import (  # noqa: E402
+    Hypothesis,
+    Latent,
+    LoopResult,
+    contractivity_ok,
+    reduce_step,
+    residual_magnitude,
+    run_recurrent_loop,
+)
+
+
+# ---------------------------------------------------------------------------
+# Stub provider — captures calls and returns queued responses.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class StubProvider:
+    """Mimics harness.providers.Provider with queued responses.
+
+    Each call to .stream() pops the next response from `queue`. If the
+    queue is empty it returns an empty end_turn — useful for testing
+    graceful-degradation paths.
+    """
+    name: str = "stub"
+    queue: list[str] = field(default_factory=list)
+    calls: list[dict] = field(default_factory=list)
+
+    def stream(self, *, role_cfg, system_prompt, messages, tools):
+        text = self.queue.pop(0) if self.queue else ""
+        self.calls.append({
+            "role": role_cfg.role,
+            "model": role_cfg.model,
+            "system_flat": system_prompt.flat(),
+            "messages": messages,
+            "n_tools": len(tools),
+        })
+
+        def iterator():
+            if text:
+                yield ("text", text)
+        response = NormalizedResponse(
+            text=text,
+            tool_calls=[],
+            stop_reason="end_turn",
+            in_tokens=0,
+            out_tokens=0,
+            raw_assistant_content=[{"type": "text", "text": text}],
+            provider=self.name,
+            model=role_cfg.model,
+        )
+        return StreamHandle(iterator=iterator(), finalize=lambda: response)
+
+
+class StubRegistry:
+    """Drop-in for ProviderRegistry.get — always returns the same stub."""
+    def __init__(self, provider: StubProvider):
+        self._p = provider
+
+    def get(self, role_cfg):
+        return self._p
+
+
+# ---------------------------------------------------------------------------
+# Latent shape
+# ---------------------------------------------------------------------------
+
+
+class TestLatent(unittest.TestCase):
+    def test_prompt_block_includes_loop_index(self):
+        h = Latent(loop_index=3)
+        block = h.to_prompt_block(max_iters=6)
+        self.assertIn("loop t = 3 of max 6", block)
+
+    def test_prompt_block_renders_hypotheses_with_confidence(self):
+        h = Latent(
+            hypotheses=[Hypothesis(text="A implies B", confidence=0.72)],
+            loop_index=1,
+        )
+        block = h.to_prompt_block(max_iters=4)
+        self.assertIn("live hypotheses", block)
+        self.assertIn("conf=0.72", block)
+        self.assertIn("A implies B", block)
+
+    def test_prompt_block_renders_residual_and_resolved(self):
+        h = Latent(
+            open_questions=["does X hold?"],
+            resolved=["Y is true"],
+        )
+        block = h.to_prompt_block(max_iters=4)
+        self.assertIn("open questions (residual)", block)
+        self.assertIn("does X hold?", block)
+        self.assertIn("resolved so far", block)
+        self.assertIn("Y is true", block)
+
+
+# ---------------------------------------------------------------------------
+# Residual + contractivity
+# ---------------------------------------------------------------------------
+
+
+class TestContractivity(unittest.TestCase):
+    def test_residual_counts_open_questions(self):
+        h = Latent(open_questions=["q1", "q2", "q3"])
+        self.assertEqual(residual_magnitude(h), 3)
+
+    def test_residual_penalises_contradictions(self):
+        # A question that reappears after being resolved counts double.
+        h = Latent(
+            open_questions=["q1", "q2"],
+            resolved=["q1"],  # q1 is both open and resolved → contradiction
+        )
+        self.assertEqual(residual_magnitude(h), 3)  # 2 open + 1 contradiction
+
+    def test_contractivity_allows_warmup(self):
+        h = Latent(
+            open_questions=["a", "b"],
+            residual_history=[1, 2],
+            loop_index=1,
+        )
+        ok, _ = contractivity_ok(h)
+        self.assertTrue(ok, "warm-up pass should be exempt")
+
+    def test_contractivity_rejects_growth_after_warmup(self):
+        h = Latent(
+            residual_history=[2, 2, 3],  # 2 -> 2 ok, 2 -> 3 growth
+            loop_index=3,
+        )
+        ok, reason = contractivity_ok(h)
+        self.assertFalse(ok)
+        self.assertIn("residual grew", reason)
+
+    def test_contractivity_accepts_decrease(self):
+        h = Latent(
+            residual_history=[3, 3, 2, 1],
+            loop_index=4,
+        )
+        ok, _ = contractivity_ok(h)
+        self.assertTrue(ok)
+
+
+# ---------------------------------------------------------------------------
+# Reducer
+# ---------------------------------------------------------------------------
+
+
+class TestReducer(unittest.TestCase):
+    def _reducer(self, text: str) -> StubProvider:
+        return StubProvider(queue=[text])
+
+    def test_reducer_parses_well_formed_json(self):
+        payload = {
+            "hypotheses": [
+                {"text": "loop depth helps reasoning", "confidence": 0.8, "reinforced": True},
+            ],
+            "open_questions": ["does it hurt memorisation?"],
+            "resolved": ["ρ(A) must be <1"],
+            "summary": "depth yes, memory maybe",
+            "converged": False,
+            "rationale": "specialist ruled out explosion path",
+        }
+        stub = self._reducer(json.dumps(payload))
+        role = RoleConfig(role="create", provider="stub", model="stub")
+        h = Latent(open_questions=["bootstrapping question"])
+
+        h_next, converged, rationale = reduce_step(
+            e="explain RDTs",
+            h=h,
+            specialist_output="the specialist said things",
+            provider=stub,
+            role_cfg=role,
+        )
+        self.assertEqual(len(h_next.hypotheses), 1)
+        self.assertAlmostEqual(h_next.hypotheses[0].confidence, 0.8)
+        self.assertIn("does it hurt memorisation?", h_next.open_questions)
+        self.assertIn("ρ(A) must be <1", h_next.resolved)
+        self.assertEqual(h_next.summary, "depth yes, memory maybe")
+        self.assertFalse(converged)
+        self.assertIn("explosion", rationale)
+        # loop index increments
+        self.assertEqual(h_next.loop_index, 1)
+
+    def test_reducer_drops_low_confidence_hypotheses(self):
+        payload = {
+            "hypotheses": [
+                {"text": "keep me", "confidence": 0.3},
+                {"text": "drop me", "confidence": 0.05},
+            ],
+            "open_questions": [],
+            "resolved": [],
+            "summary": "",
+            "converged": False,
+            "rationale": "",
+        }
+        stub = self._reducer(json.dumps(payload))
+        role = RoleConfig(role="create", provider="stub", model="stub")
+        h_next, _, _ = reduce_step(
+            e="x",
+            h=Latent(),
+            specialist_output="",
+            provider=stub,
+            role_cfg=role,
+        )
+        texts = [x.text for x in h_next.hypotheses]
+        self.assertIn("keep me", texts)
+        self.assertNotIn("drop me", texts)
+
+    def test_reducer_tolerates_code_fences(self):
+        payload = {
+            "hypotheses": [],
+            "open_questions": ["q"],
+            "resolved": [],
+            "summary": "fenced",
+            "converged": False,
+            "rationale": "",
+        }
+        wrapped = f"```json\n{json.dumps(payload)}\n```"
+        stub = self._reducer(wrapped)
+        role = RoleConfig(role="create", provider="stub", model="stub")
+        h_next, _, _ = reduce_step(
+            e="x",
+            h=Latent(),
+            specialist_output="",
+            provider=stub,
+            role_cfg=role,
+        )
+        self.assertEqual(h_next.summary, "fenced")
+
+    def test_reducer_fails_safely_on_malformed_output(self):
+        stub = self._reducer("this is not json at all")
+        role = RoleConfig(role="create", provider="stub", model="stub")
+        h_next, converged, rationale = reduce_step(
+            e="x",
+            h=Latent(open_questions=["existing"]),
+            specialist_output="specialist text here",
+            provider=stub,
+            role_cfg=role,
+        )
+        # On parse error: h advances one loop, specialist output becomes
+        # a new open question, converged stays False, rationale tags the error.
+        self.assertFalse(converged)
+        self.assertIn("reducer_parse_error", rationale)
+        self.assertEqual(h_next.loop_index, 1)
+        self.assertIn("existing", h_next.open_questions)
+
+    def test_reducer_converged_flag_propagates(self):
+        payload = {
+            "hypotheses": [],
+            "open_questions": [],
+            "resolved": ["answered"],
+            "summary": "done",
+            "converged": True,
+            "rationale": "",
+        }
+        stub = self._reducer(json.dumps(payload))
+        role = RoleConfig(role="create", provider="stub", model="stub")
+        _, converged, _ = reduce_step(
+            e="x",
+            h=Latent(),
+            specialist_output="",
+            provider=stub,
+            role_cfg=role,
+        )
+        self.assertTrue(converged)
+
+
+# ---------------------------------------------------------------------------
+# Full loop
+# ---------------------------------------------------------------------------
+
+
+def _reducer_json(
+    *,
+    converged: bool,
+    open_questions: list[str] | None = None,
+    resolved: list[str] | None = None,
+    summary: str = "",
+) -> str:
+    return json.dumps({
+        "hypotheses": [],
+        "open_questions": open_questions or [],
+        "resolved": resolved or [],
+        "summary": summary,
+        "converged": converged,
+        "rationale": "",
+    })
+
+
+class TestRecurrentLoop(unittest.TestCase):
+    def _run(self, queue: list[str], max_loop_iters: int) -> LoopResult:
+        provider = StubProvider(queue=list(queue))
+        registry = StubRegistry(provider)
+        policy = default_policy()
+        events: list[dict] = []
+        result = run_recurrent_loop(
+            e="probe prompt",
+            registry=registry,  # type: ignore[arg-type]
+            policy=policy,
+            max_loop_iters=max_loop_iters,
+            logger=events.append,
+        )
+        return result
+
+    def test_T1_runs_one_specialist_one_reducer_one_coda(self):
+        # Queue order: specialist, reducer (converged=True), coda
+        queue = [
+            "specialist pass for T=1",
+            _reducer_json(converged=True, resolved=["answered"]),
+            "coda voice: here is your answer",
+        ]
+        result = self._run(queue, max_loop_iters=1)
+        self.assertEqual(result.loops_run, 1)
+        self.assertIn(result.halt_reason, ("reducer_converged", "max_iters"))
+        self.assertEqual(result.text, "coda voice: here is your answer")
+
+    def test_loop_halts_on_converged(self):
+        # Converge at loop 1 of a budget of 5.
+        queue = [
+            # loop 0
+            "specialist 0",
+            _reducer_json(converged=False, open_questions=["q"]),
+            # loop 1
+            "specialist 1",
+            _reducer_json(converged=True, resolved=["q"]),
+            # coda
+            "coda",
+        ]
+        result = self._run(queue, max_loop_iters=5)
+        self.assertEqual(result.halt_reason, "reducer_converged")
+        self.assertEqual(result.loops_run, 2)
+
+    def test_loop_halts_on_contractivity_violation(self):
+        # Residual grows from loop 2 -> loop 3 after warm-up.
+        queue = [
+            "s0",
+            _reducer_json(converged=False, open_questions=["q1", "q2"]),
+            "s1",
+            _reducer_json(converged=False, open_questions=["q1", "q2"]),
+            "s2",
+            _reducer_json(converged=False, open_questions=["q1", "q2", "q3", "q4"]),  # grew
+            "s3",
+            _reducer_json(converged=False, open_questions=["q1"]),
+            "coda",
+        ]
+        result = self._run(queue, max_loop_iters=6)
+        self.assertTrue(result.halt_reason.startswith("contractivity_violated"))
+
+    def test_loop_reaches_max_iters_when_never_converges(self):
+        queue = []
+        for _ in range(10):
+            queue.append("specialist")
+            queue.append(_reducer_json(
+                converged=False, open_questions=["persistent"]
+            ))
+        queue.append("coda")
+        result = self._run(queue, max_loop_iters=3)
+        self.assertEqual(result.halt_reason, "max_iters")
+        self.assertEqual(result.loops_run, 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Looped-orchestrate prototype — projecting the Parcae recurrence onto the agentic axis

Kye Gomez's [OpenMythos](https://github.com/kyegomez/OpenMythos) (released 2026-04-18) gives a reference PyTorch implementation of the Recurrent-Depth Transformer hypothesis: weight-shared looped block, MoE routing per depth, [Parcae](https://sandyresearch.github.io/parcae/)-style LTI input injection `h_{t+1} = A·h_t + B·e + R(h_t, e)` with `ρ(A)<1` as a hard stability constraint.

That recurrence is the same discrete LTI shape as the coupled equation the Vybn OS has been using as orientation metaphor: `Z′ = α·Z + V·e^{iθ_v}`. One has weights; the other has role configs — but the equations carry identically, and the stability conditions transfer cleanly. Parcae says input re-injection and ρ(A)<1 are jointly what prevent the residual stream from drifting across loops. In agent-space that reads as: re-inject the original prompt at every pass, and require the open-question residual to contract monotonically.

This PR takes the projection seriously enough to make it measurable, without touching the live REPL.

### What this adds

Four pieces, all scoped to the `orchestrate` path and all reachable only via a new probe script. The live `vybn_spark_agent.run_agent_loop` is unchanged.

**`spark/harness/recurrent.py`** — the loop library. Has:

1. A persistent compressed latent `h` (`Latent` dataclass): live hypotheses with confidence, open questions (the residual), resolved items, one-sentence running summary, loop index, residual-magnitude history. Serialises into the live prompt layer. Does not accumulate transcript.
2. Explicit loop-index in the specialist's prompt — the agent-space analogue of OpenMythos's loop-index sinusoidal embedding that lets the same weights behave differently at different depths.
3. Contractivity monitor (`contractivity_ok`) — the agent-space `ρ(A)<1` check. Residual magnitude (open questions + contradiction penalty) must be monotone non-increasing after a warm-up pass. Violation halts the loop with a tagged reason.
4. Coda as shared voice expert — after the loop halts (converged / contractivity / budget), the `chat` role emits the user-facing answer with `h_T` as context. Always-on shared expert projected onto the role roster.

**`spark/harness_recurrent_probe.py`** — driver for comparing T=1 (degenerate single-pass) against T=N. JSONL output for aggregation.

**`spark/tests/recurrent_probes.txt`** — seed prompts where a single pass is expected to under-resolve and a deeper loop is expected to open a residual gap. If the gap doesn't appear across the set, the architecture isn't buying us anything and we should say so.

**`spark/tests/test_recurrent.py`** — 17 unit tests, network-free, stubbed providers. Covers latent rendering, residual/contractivity math, reducer JSON parsing (including code-fence tolerance and malformed-output graceful degradation), and full-loop halting paths (converged / contractivity / max).

### The role-MoE correspondence

`_select_specialist` picks R for loop t from the existing role roster: `task` on the first pass (broad exploration), then alternating `code` (Opus 4.7 adaptive with verification posture) and `create` (Sonnet refinement). This is the harness projection of "MoE router selects distinct expert subsets at each loop depth." The point is not that routing-over-models is strictly equivalent to intra-FFN routing — it isn't — but that each loop is deliberately computationally distinct even though the policy is shared.

### What I want to learn from the probe

Three observables the T=1 vs T=N comparison makes visible:

- **Residual contraction rate.** Does `|residual|` actually decrease monotonically at T>1, or does the reducer cheat by declaring convergence? The contractivity monitor guards against the latter.
- **Converged-vs-max-iters ratio.** If the reducer converges within budget on multi-hop prompts but T=1 produces a visibly kernelish answer on the same prompts, the architecture has signal.
- **Shared-voice consistency.** T=N runs a `code`/`task` specialist for heavy lifting but the Coda is always `chat`. Check that the voice doesn't degrade relative to a direct chat call.

If none of these move, the null result is a real finding and I'll say so in the follow-up.

### What this deliberately does NOT do

- Does not modify `run_agent_loop`, `router_policy.yaml`, or any existing role.
- Does not call out to the creature. The creature's winding-coherence number is a self-report; treating it as evidence for structural claims about `h` would be the exact anti-hallucination failure the OS document warns about. If the loop turns out to matter, a separate PR can explore whether `h` and the creature's accumulated phase point at the same object. Not today.
- Specialists inside the loop run with `tools=[]`. The prototype is side-effect-free at the specialist layer so loops can be replayed deterministically during analysis. If we wire this into the live REPL later, we'll hand tools back to `code`/`task` — but that's a decision after measurement.

### Homology sketch

| OpenMythos (neural) | Recurrent harness (agentic) |
|---|---|
| hidden state `h_t` (tensor) | `Latent` (hypotheses + residual + summary) |
| encoded input `e` | original user prompt, re-injected into live layer each loop |
| `ρ(A) < 1` spectral constraint | contractivity monitor on residual magnitude |
| loop-index sinusoidal embedding | explicit `loop t = k of T` in prompt block |
| MoE top-K routed experts per loop | `_select_specialist` picks role per loop index |
| always-on shared expert | `coda_step` in `chat` role after halt |
| ACT per-token halting | `converged` flag from reducer + contractivity + budget |
| Prelude + Coda dense transformer blocks | existing RAG/substrate (Prelude) + voice emit (Coda) |

### Test plan

```bash
# Unit tests — no network, no providers.
python3 spark/tests/test_recurrent.py -v

# Live comparison (requires provider creds):
python3 spark/harness_recurrent_probe.py \
    --prompts-file spark/tests/recurrent_probes.txt \
    --t-values 1,4 \
    --out ~/logs/recurrent_probe.jsonl
```

The unit tests pass clean (17/17). Pre-existing failures in `test_harness.py::test_default_role` and one related test predate this branch (the shipped default role is `chat` per policy.py round-7 changes; those two tests still expect `orchestrate`). Orthogonal to this PR; leaving them alone.

### Posture

This is a scaffolding PR, not a landing PR. The goal is to make the coupled equation a thing we can run, log, and inspect — not to ship a new default behavior. The REPL doesn't change. The router doesn't change. The next round either writes up what the probe showed, or — if T>1 doesn't open a gap — writes up the null result and we go back to the homology as a theory artifact rather than an architecture direction.

Measurement before belief.
