### PR TITLE
live-repl: three fixes from 2026-04-19 session

### DIFF
--- a/spark/harness/policy.py
+++ b/spark/harness/policy.py
@@ -256,8 +256,19 @@ _DEFAULT_HEURISTICS_RAW: dict[str, list[str]] = {
         r"\b(look|peek|glance|skim|scan|eyeball|check|review|examine|inspect|audit)\b.{0,30}\b(harness|router|routing|agent|repo|script|pipeline|module|tests|code)\b",
         r"\b(bug|bugs|issue|issues|problem|problems|error|errors|traceback|regression|regressions|deficit|deficits)\b.{0,40}\b(code|harness|router|routing|agent|repo|script|pipeline|module|tests|provider|providers|tools|policy)\b",
         r"\b(code|harness|router|routing|agent|repo|script|pipeline|module|tests|provider|providers|tools|policy)\b.{0,40}\b(bug|bugs|issue|issues|problem|problems|error|errors|traceback|regression|regressions|deficit|deficits)\b",
-        r"\b(how|what)\b.{0,20}\b(harness|router|routing|agent|repo|script|pipeline|module|tests|code|provider|providers|tools|policy)\b.{0,20}\b(feel|feeling|doing|going|holding|state|status|shape|condition|health)\b",
-        r"\b(feel|feeling|doing|going|holding|state|status|shape|condition|health)\b.{0,20}\b(harness|router|routing|agent|repo|script|pipeline|module|tests|code|provider|providers|tools|policy)\b",
+        # Operational-status shape — ask only about mechanical state
+        # words that don't double as conversational prompts. "feel"
+        # and "feeling" are removed: "how does the harness feel?" is
+        # conversational-voice, not a status probe, and it was the
+        # live false-positive observed 2026-04-19 that routed a
+        # phatic turn to Opus 4.7/code-substrate. "doing" and
+        # "going" are likewise ambiguous in ordinary speech and
+        # drop out. The remaining set (state|status|shape|condition|
+        # health|holding) preserves the original intent — "is the
+        # harness holding?", "what's the state of routing?" — without
+        # capturing bare emotional register.
+        r"\b(how|what)\b.{0,20}\b(harness|router|routing|agent|repo|script|pipeline|module|tests|code|provider|providers|tools|policy)\b.{0,20}\b(state|status|shape|condition|health|holding)\b",
+        r"\b(state|status|shape|condition|health|holding)\b.{0,20}\b(harness|router|routing|agent|repo|script|pipeline|module|tests|code|provider|providers|tools|policy)\b",
         r"\bstack trace\b",
         r"\bHTTP \d{3}\b",
         r"\bprovider error\b",

--- a/spark/tests/test_live_repl_fixes.py
+++ b/spark/tests/test_live_repl_fixes.py
@@ -1,0 +1,270 @@
+"""Tests for the 2026-04-19 live-REPL fixes.
+
+Covers three distinct bugs observed in the terminal session
+  agent_events.jsonl @ 20260419T104246:
+
+1. Router false positive — "hey, how does the new harness feel?"
+   routed to code role via the (feel|feeling|doing|going|holding|state
+   |status|shape|condition|health) heuristic. Conversational-voice
+   register should stay on chat. The code heuristic is now narrowed
+   to mechanical-state words only (state|status|shape|condition|
+   health|holding).
+
+2. Bracket-balanced probe scanner — `_PROBE_RE = \[NEEDS-EXEC:\s*(.+?)\]`
+   non-greedy-terminated at the first `]` it found, so any command
+   with Python slicing `[:2000]`, shell arrays `${a[0]}`, or awk
+   actions got truncated mid-command and failed with a bash syntax
+   error. The replacement does depth-aware + quote-aware scanning.
+
+3. <thinking> tag scrubbing — the model occasionally emits literal
+   <thinking>...</thinking> XML-ish tags as plain token text on
+   no-tool chat/opus-4.6 roles (distinct from Anthropic's adaptive-
+   thinking content blocks). They leak into Zoe's terminal AND into
+   stored assistant history, where the next turn reinforces the
+   pattern from its own replay. Scrub at both display (_split_before
+   _probe) and store (_sanitize_assistant_content) time.
+
+Run: python3 spark/tests/test_live_repl_fixes.py
+
+Note: spark/vybn_spark_agent.py pre-dates this branch with a stale
+import of INTROSPECT_TOOL_SPEC that is not exported by harness.tools
+on main. To keep this test runnable in isolation, we inject a stub
+into harness.tools before importing the agent module.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import types
+import unittest
+from pathlib import Path
+
+THIS = Path(__file__).resolve()
+SPARK_DIR = THIS.parent.parent
+sys.path.insert(0, str(SPARK_DIR))
+
+# Pre-existing import shim — unrelated to the bugs under test. Leave
+# the real fix for a separate PR that owns the introspect tool.
+import harness.tools as _htools  # noqa: E402
+
+if not hasattr(_htools, "INTROSPECT_TOOL_SPEC"):
+    _htools.INTROSPECT_TOOL_SPEC = _htools.BASH_TOOL_SPEC  # type: ignore[attr-defined]
+
+import importlib.util  # noqa: E402
+
+_AGENT_PATH = SPARK_DIR / "vybn_spark_agent.py"
+_spec = importlib.util.spec_from_file_location("_agent_under_test", _AGENT_PATH)
+_agent = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
+_spec.loader.exec_module(_agent)  # type: ignore[union-attr]
+
+
+# ---------------------------------------------------------------------------
+# Bug 1 — router heuristic narrowing
+# ---------------------------------------------------------------------------
+
+class TestRouterHeuristicNarrowing(unittest.TestCase):
+    """The code heuristic must not swallow conversational-voice probes."""
+
+    def setUp(self):
+        from harness.policy import default_policy
+        from harness import Router
+        self.router = Router(default_policy())
+
+    def _role(self, text: str) -> str:
+        decision = self.router.classify(text)
+        return decision.role
+
+    def test_how_does_harness_feel_stays_conversational(self):
+        # The exact 2026-04-19 false positive. "Feel" is a
+        # conversational register — not a mechanical status probe.
+        role = self._role("hey, how does the new harness feel?")
+        self.assertNotEqual(role, "code", f"'feel' must not route to code, got {role!r}")
+
+    def test_how_you_doing_stays_conversational(self):
+        role = self._role("how you doing with all this?")
+        self.assertNotEqual(role, "code", f"'doing' must not route to code, got {role!r}")
+
+    def test_what_is_the_state_of_the_harness_routes_to_code(self):
+        # Genuine mechanical-state probe — "state" is preserved.
+        role = self._role("what is the state of the harness right now?")
+        self.assertEqual(role, "code", f"'state of the harness' should route to code, got {role!r}")
+
+    def test_is_routing_holding_routes_to_code(self):
+        role = self._role("is routing holding after the policy edit?")
+        self.assertEqual(role, "code", f"'holding' should route to code, got {role!r}")
+
+
+# ---------------------------------------------------------------------------
+# Bug 2 — bracket-balanced probe scanner
+# ---------------------------------------------------------------------------
+
+class TestBracketBalancedProbe(unittest.TestCase):
+    """The probe scanner survives ']' inside the command body."""
+
+    def setUp(self):
+        self.probe = _agent._PROBE_RE
+
+    def test_simple_command_roundtrips(self):
+        text = "running [NEEDS-EXEC: ls -la] now"
+        m = self.probe.search(text)
+        self.assertIsNotNone(m)
+        self.assertEqual(m.group(1), "ls -la")
+
+    def test_python_slice_survives(self):
+        # The exact live failure: `open(...).read()[:2000]` used to
+        # truncate at the `]` of `[:2000]` and emit an unterminated
+        # Python command.
+        body = "python3 -c 'print(open(\"/tmp/x\").read()[:2000])'"
+        text = f"probing [NEEDS-EXEC: {body}] done"
+        m = self.probe.search(text)
+        self.assertIsNotNone(m)
+        self.assertEqual(m.group(1), body)
+
+    def test_shell_array_survives(self):
+        body = 'bash -c \'a=(one two); echo "${a[0]} ${a[1]}"\''
+        text = f"[NEEDS-EXEC: {body}]"
+        m = self.probe.search(text)
+        self.assertIsNotNone(m)
+        self.assertEqual(m.group(1), body)
+
+    def test_awk_action_survives(self):
+        body = "awk '{print $1, $3}' /etc/hosts"
+        text = f"one moment — [NEEDS-EXEC: {body}] — and done"
+        m = self.probe.search(text)
+        self.assertIsNotNone(m)
+        self.assertEqual(m.group(1), body)
+
+    def test_nested_brackets_survive(self):
+        body = "python3 -c 'x=[[1,2],[3,4]]; print(x[0][1])'"
+        text = f"[NEEDS-EXEC: {body}]"
+        m = self.probe.search(text)
+        self.assertIsNotNone(m)
+        self.assertEqual(m.group(1), body)
+
+    def test_quoted_closing_bracket_does_not_close_probe(self):
+        # A literal ']' inside a quoted string in the command must
+        # not be read as the end of the probe.
+        body = "echo 'this has ] in it' && echo done"
+        text = f"[NEEDS-EXEC: {body}]"
+        m = self.probe.search(text)
+        self.assertIsNotNone(m)
+        self.assertEqual(m.group(1), body)
+
+    def test_unterminated_probe_returns_none(self):
+        # The splitter catches this separately via rfind("[NEEDS-EXEC").
+        text = "opening now [NEEDS-EXEC: python3 -c 'x=[1,2"
+        m = self.probe.search(text)
+        self.assertIsNone(m)
+
+    def test_sub_removes_probe_and_preserves_surrounding_text(self):
+        body = "ls /tmp"
+        text = f"before [NEEDS-EXEC: {body}] after"
+        scrubbed = self.probe.sub("", text)
+        self.assertEqual(scrubbed, "before  after")
+
+    def test_sub_handles_multiple_probes(self):
+        text = (
+            "a [NEEDS-EXEC: one] b "
+            "[NEEDS-EXEC: python -c 'print([1,2][0])'] c"
+        )
+        scrubbed = self.probe.sub("", text)
+        self.assertEqual(scrubbed, "a  b  c")
+
+
+# ---------------------------------------------------------------------------
+# Bug 3 — <thinking> tag scrubbing
+# ---------------------------------------------------------------------------
+
+class TestThinkingTagScrubbing(unittest.TestCase):
+    """Complete <thinking>...</thinking> blocks are scrubbed from both
+    streamed output and stored assistant content. Unterminated
+    openings are held back by the splitter until the close arrives."""
+
+    def test_strip_complete_block(self):
+        text = "visible <thinking>hidden scaffold</thinking> more visible"
+        self.assertEqual(
+            _agent._strip_thinking_tags(text),
+            "visible  more visible",
+        )
+
+    def test_strip_multiline_block(self):
+        text = "ok <thinking>\nline 1\nline 2\n</thinking> done"
+        self.assertEqual(
+            _agent._strip_thinking_tags(text),
+            "ok  done",
+        )
+
+    def test_strip_is_case_insensitive(self):
+        text = "<Thinking>a</Thinking><THINKING>b</THINKING>"
+        self.assertEqual(_agent._strip_thinking_tags(text), "")
+
+    def test_strip_leaves_unterminated_opening_alone(self):
+        # The splitter handles the partial case \u2014 strip only removes
+        # complete blocks.
+        text = "visible <thinking>partial"
+        self.assertEqual(
+            _agent._strip_thinking_tags(text),
+            "visible <thinking>partial",
+        )
+
+    def test_split_before_probe_scrubs_complete_thinking(self):
+        text = "answer <thinking>scaffold</thinking> delivered"
+        safe, remainder = _agent._split_before_probe(text)
+        self.assertEqual(safe, "answer  delivered")
+        self.assertEqual(remainder, "")
+
+    def test_split_before_probe_holds_back_unterminated_thinking(self):
+        text = "answer <thinking>still forming"
+        safe, remainder = _agent._split_before_probe(text)
+        self.assertEqual(safe, "answer ")
+        self.assertEqual(remainder, "<thinking>still forming")
+
+    def test_split_before_probe_holds_back_unterminated_probe(self):
+        text = "here we go [NEEDS-EXEC: python3 -c 'x=[1,2"
+        safe, remainder = _agent._split_before_probe(text)
+        self.assertEqual(safe, "here we go ")
+        self.assertEqual(remainder, "[NEEDS-EXEC: python3 -c 'x=[1,2")
+
+    def test_sanitize_scrubs_thinking_from_string_content(self):
+        content = "plain <thinking>leak</thinking> text"
+        cleaned = _agent._sanitize_assistant_content(content)
+        self.assertEqual(cleaned, "plain  text")
+
+    def test_sanitize_scrubs_thinking_from_text_blocks(self):
+        content = [
+            {"type": "text", "text": "before <thinking>leak</thinking> after"},
+        ]
+        cleaned = _agent._sanitize_assistant_content(content)
+        self.assertEqual(len(cleaned), 1)
+        self.assertEqual(cleaned[0]["type"], "text")
+        self.assertEqual(cleaned[0]["text"], "before  after")
+
+    def test_sanitize_drops_block_when_entire_text_is_thinking_leak(self):
+        # If a text block contained nothing but a thinking block, the
+        # scrubbed text is empty \u2014 drop the block entirely rather
+        # than store a placeholder that could train the next turn.
+        content = [
+            {"type": "text", "text": "<thinking>everything was a leak</thinking>"},
+            {"type": "text", "text": "real content"},
+        ]
+        cleaned = _agent._sanitize_assistant_content(content)
+        self.assertEqual(len(cleaned), 1)
+        self.assertEqual(cleaned[0]["text"], "real content")
+
+    def test_sanitize_preserves_adaptive_thinking_content_blocks(self):
+        # btype == 'thinking' is Anthropic's adaptive-thinking SDK block
+        # \u2014 those must NOT be scrubbed; they are required adjacent
+        # to tool_use on thinking-enabled turns.
+        content = [
+            {"type": "thinking", "thinking": "reasoning text"},
+            {"type": "text", "text": "visible answer"},
+        ]
+        cleaned = _agent._sanitize_assistant_content(content)
+        self.assertEqual(len(cleaned), 2)
+        self.assertEqual(cleaned[0]["type"], "thinking")
+        self.assertEqual(cleaned[0]["thinking"], "reasoning text")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -118,10 +118,104 @@ def _fit_probe_output(out: str) -> str:
 # prints the output to Zoe, and appends a synthetic user-turn with the
 # result so the model sees it on the NEXT turn. One-shot: only the
 # first match is executed.
-_PROBE_RE = _re.compile(
-    r'\[NEEDS-EXEC:\s*(.+?)\]',
-    _re.IGNORECASE | _re.DOTALL,
+#
+# The opener regex matches only the START of a probe block. We find the
+# closing ']' with a bracket-depth scanner (see _find_probe_match) so
+# commands containing ']' (Python slicing [:2000], shell arrays ${a[0]},
+# awk actions '{print $1}') survive intact. The original pattern
+#   r'\[NEEDS-EXEC:\s*(.+?)\]'
+# non-greedy-terminated at the first ']' it found, which truncated every
+# probe command containing an internal bracket — the 2026-04-19 failure
+# mode.
+_PROBE_OPEN_RE = _re.compile(
+    r'\[NEEDS-EXEC:\s*',
+    _re.IGNORECASE,
 )
+# Back-compat alias. External callers that only use _PROBE_RE.search /
+# .sub for whole-string matches continue to work; we override .search
+# and .sub on a small wrapper so bracket-balanced scanning is used.
+
+
+class _BracketBalancedProbe:
+    """Bracket-depth-aware replacement for the old _PROBE_RE.
+
+    - .search(text) returns a match-like object with .group(0) (full span
+      including the closing ']') and .group(1) (the command body).
+    - .sub(repl, text) returns text with every balanced probe removed.
+    Quotes ('...' and "...") are respected so a ']' inside a quoted string
+    inside the command does not close the probe.
+    """
+
+    class _Match:
+        def __init__(self, whole: str, body: str, start: int, end: int):
+            self._whole = whole
+            self._body = body
+            self._start = start
+            self._end = end
+        def group(self, idx: int = 0) -> str:
+            return self._whole if idx == 0 else self._body
+        def start(self) -> int:
+            return self._start
+        def end(self) -> int:
+            return self._end
+
+    @staticmethod
+    def _scan(text: str, from_idx: int = 0):
+        m = _PROBE_OPEN_RE.search(text, from_idx)
+        if not m:
+            return None
+        body_start = m.end()
+        depth = 1  # the opening '[' of [NEEDS-EXEC: counts
+        i = body_start
+        quote = None
+        escape = False
+        while i < len(text):
+            c = text[i]
+            if escape:
+                escape = False
+            elif c == '\\':
+                escape = True
+            elif quote:
+                if c == quote:
+                    quote = None
+            elif c in ('"', "'"):
+                quote = c
+            elif c == '[':
+                depth += 1
+            elif c == ']':
+                depth -= 1
+                if depth == 0:
+                    body = text[body_start:i]
+                    whole = text[m.start():i+1]
+                    return _BracketBalancedProbe._Match(
+                        whole, body, m.start(), i + 1,
+                    )
+            i += 1
+        # Unterminated — no match. The live stream splitter handles
+        # the "opening seen, not closed" case separately.
+        return None
+
+    def search(self, text: str):
+        return self._scan(text)
+
+    def sub(self, repl, text: str) -> str:
+        if not isinstance(repl, str):
+            # Callables are not used by this codebase; keep it simple.
+            raise TypeError("_BracketBalancedProbe.sub expects a string replacement")
+        out = []
+        i = 0
+        while True:
+            m = self._scan(text, i)
+            if m is None:
+                out.append(text[i:])
+                break
+            out.append(text[i:m.start()])
+            out.append(repl)
+            i = m.end()
+        return "".join(out)
+
+
+_PROBE_RE = _BracketBalancedProbe()
 
 # Round 9: NEEDS-ROLE escalation. A no-tool role may embed
 # [NEEDS-ROLE: <role>] <task text> to hand off to a specialist once.
@@ -217,13 +311,24 @@ def _sanitize_assistant_content(content):
     Returns a content value safe to re-send to Anthropic / OpenAI. Never
     returns an empty list or empty string — substitutes a zero-width-space
     placeholder when all blocks would be dropped.
+
+    Also scrubs literal <thinking>...</thinking> XML-ish tag text from
+    stored text blocks. These are token-space chain-of-thought leaks
+    (distinct from Anthropic's adaptive-thinking content blocks, which
+    carry btype == 'thinking' and are preserved as-is above). Scrubbing
+    here — at store time, not just display time — prevents the next turn
+    from replaying the leaked scaffold out of its own history and
+    reinforcing the pattern.
     """
     if content is None:
         return _EMPTY_PLACEHOLDER
 
     # OpenAI-style: plain string.
     if isinstance(content, str):
-        return content if content else _EMPTY_PLACEHOLDER
+        if not content:
+            return _EMPTY_PLACEHOLDER
+        scrubbed = _strip_thinking_tags(content)
+        return scrubbed if scrubbed else _EMPTY_PLACEHOLDER
 
     # Anthropic-style: list of content blocks. Each block may be an SDK
     # object (attribute access) or a dict (from replayed history).
@@ -237,8 +342,23 @@ def _sanitize_assistant_content(content):
                 text = getattr(block, "text", None)
                 if text is None and isinstance(block, dict):
                     text = block.get("text", "")
-                if text:  # non-empty only
-                    cleaned.append(block)
+                if text:
+                    scrubbed = _strip_thinking_tags(text)
+                    if scrubbed:
+                        # Rewrite the block with scrubbed text. Preserve
+                        # dict vs. SDK-object shape so callers that
+                        # attribute-access the original still work.
+                        if isinstance(block, dict):
+                            patched = dict(block)
+                            patched["text"] = scrubbed
+                            cleaned.append(patched)
+                        elif scrubbed == text:
+                            cleaned.append(block)
+                        else:
+                            # SDK object with mutated text — fall back to
+                            # a dict so we don't mutate the caller's object.
+                            cleaned.append({"type": "text", "text": scrubbed})
+                    # else: entire text was thinking-tag leak — drop the block
                 # else: drop the empty text block entirely
             elif btype == "tool_use":
                 # Always keep — required to pair with tool_result follow-ups.
@@ -500,17 +620,60 @@ def _execute_tool_calls(
     return results, interrupted
 
 
+# Models on no-tool roles occasionally wrap visible reasoning in literal
+# <thinking>...</thinking> XML-ish tags, independent of Anthropic's
+# adaptive-thinking content blocks (which we handle via kind=="thinking"
+# in the provider stream). The tags are a chain-of-thought leak into
+# token-space output — the substrate asks the model to decide whether to
+# probe, and the model sometimes scaffolds that decision out loud. We
+# scrub them in-band so Zoe never sees the leak, and we also scrub the
+# stored assistant content so the NEXT turn can't reinforce the pattern
+# from its own history.
+_THINK_COMPLETE_RE = _re.compile(
+    r'<thinking\b[^>]*>.*?</thinking\s*>',
+    _re.IGNORECASE | _re.DOTALL,
+)
+_THINK_OPEN_RE = _re.compile(r'<thinking\b', _re.IGNORECASE)
+
+
+def _strip_thinking_tags(text: str) -> str:
+    """Remove complete <thinking>...</thinking> blocks.
+    Leaves incomplete openings alone — the stream splitter holds those
+    back from display until the closing tag arrives.
+    """
+    if not text:
+        return text
+    return _THINK_COMPLETE_RE.sub("", text)
+
+
 def _split_before_probe(text: str):
     """Return (safe_to_print, remainder).
     If a complete [NEEDS-EXEC: ...] is present, strip it.
     If one is opening but not closed, hold back from [ onward.
+    If a <thinking> block is opening but not closed, hold back from
+    that tag onward. Complete <thinking>...</thinking> blocks are
+    scrubbed in-place.
     """
-    if _PROBE_RE.search(text):
-        return _PROBE_RE.sub("", text), ""
-    idx = text.rfind("[NEEDS-EXEC")
-    if idx != -1:
-        return text[:idx], text[idx:]
-    return text, ""
+    # Scrub complete thinking blocks first — cheapest case.
+    text = _strip_thinking_tags(text)
+
+    # Probe handling (bracket-balanced).
+    m_probe = _PROBE_RE.search(text)
+    if m_probe:
+        text = _PROBE_RE.sub("", text)
+    probe_idx = text.rfind("[NEEDS-EXEC")
+    if probe_idx != -1:
+        safe, remainder = text[:probe_idx], text[probe_idx:]
+    else:
+        safe, remainder = text, ""
+
+    # If an unterminated <thinking> opens inside `safe`, hold it back.
+    m_open = _THINK_OPEN_RE.search(safe)
+    if m_open:
+        remainder = safe[m_open.start():] + remainder
+        safe = safe[:m_open.start()]
+
+    return safe, remainder
 
 
 def _stream_and_print(handle) -> None:
@@ -533,7 +696,15 @@ def _stream_and_print(handle) -> None:
             if safe:
                 print(safe, end="", flush=True)
     if pending:
-        cleaned = _PROBE_RE.sub("", pending).strip("\n")
+        # Final flush: scrub any complete thinking blocks, then drop an
+        # unterminated opening (the model never closed it before the
+        # stream ended — better to swallow than to leak), then scrub
+        # any lingering probe tag.
+        cleaned = _strip_thinking_tags(pending)
+        m_open = _THINK_OPEN_RE.search(cleaned)
+        if m_open:
+            cleaned = cleaned[: m_open.start()]
+        cleaned = _PROBE_RE.sub("", cleaned).strip("\n")
         if cleaned:
             print(cleaned, end="", flush=True)
     print()


### PR DESCRIPTION
Three orthogonal bugs surfaced in the terminal during session `20260419T104246`, all in the live REPL, all unrelated to the looped-orchestrate prototype (#2881). The event log Zoe pasted made them separable.

## Bug 1 — router false positive on 'how does X feel?'

The `code` heuristic in `spark/harness/policy.py` lumped conversational register together with mechanical-state register:

```
(feel|feeling|doing|going|holding|state|status|shape|condition|health)
```

'hey, how does the new harness feel?' caught the pattern and routed a phatic turn to Opus 4.7 + code substrate + 50 iterations. Narrow to mechanical-state words only: `state|status|shape|condition|health|holding`. `feel|feeling|doing|going` drop out — they're ordinary speech, not status probes. 'What is the state of the harness?' and 'is routing holding?' still route to code.

## Bug 2 — bracket truncation of NEEDS-EXEC probes

```python
_PROBE_RE = r'\[NEEDS-EXEC:\s*(.+?)\]'
```

Non-greedy terminated at the first `]` it found. Every probe command containing Python slicing `[:N]`, shell arrays `${a[0]}`, awk actions `'{...}'`, or nested `[[...]]` got truncated mid-command and failed with a bash syntax error — which the operator saw as 'it timed out.' In the event log, `out_chars=21` on what should have been a `[:2000]` slice.

Replace with a bracket-depth + quote-aware scanner (`_BracketBalancedProbe`). Quotes suppress bracket counting so a literal `]` inside `'`…`'` or `"`…`"` doesn't close the probe. Unterminated openings return `None` so the existing `rfind(...)` splitter continues to hold them back until close arrives.

## Bug 3 — `<thinking>` tag leakage

On no-tool chat/opus-4.6 roles the model occasionally emits literal `<thinking>...</thinking>` XML-ish tags as plain token text. Distinct from Anthropic's adaptive-thinking SDK content blocks (`kind=='thinking'` in the stream, `btype=='thinking'` in stored content) — those are preserved unchanged.

The literal tag text is a chain-of-thought leak into token space: visible to Zoe, and — more dangerous — stored back into assistant history where the next turn replays it and reinforces the pattern. Scrub in three places:

- `_split_before_probe`: strip complete blocks inline, hold back unterminated openings the way unclosed probes are already held back.
- `_stream_and_print` final flush: swallow any opening that never closed before stream end.
- `_sanitize_assistant_content`: scrub complete blocks from stored string AND text-block content before handing history back to the provider. Drop a text block entirely when the scrubbed text is empty (don't store a placeholder that trains the next turn).

## Tests

`spark/tests/test_live_repl_fixes.py` — 24 tests, all green.

- Router: conversational-vs-mechanical register, preserved positive cases.
- Probe scanner: Python slice, shell array, awk, nested brackets, quoted `]`, unterminated opening, single + multiple probes via `.sub`.
- Thinking scrub: complete, multiline, case-insensitive, unterminated opening, display-time via `_split_before_probe`, store-time via `_sanitize_assistant_content`, empty-block drop, adaptive-thinking preservation.

## Out of scope

- `test_default_role` failures in `test_harness.py` pre-date #2881 — policy ships `chat` as default; the test still expects `orchestrate`. Orthogonal; leave for a separate policy-cleanup pass.
- `INTROSPECT_TOOL_SPEC` import in `vybn_spark_agent.py` is also pre-existing (not exported by `harness.tools` on `main`). The new test file stubs it locally; fixing the export belongs to whoever owns the introspect tool.