### PR TITLE
policy: narrow router_policy.yaml 'feel' heuristic to match #2882 defaults

### DIFF
--- a/spark/router_policy.yaml
+++ b/spark/router_policy.yaml
@@ -176,8 +176,14 @@ heuristics:
     - "\\b(look|peek|glance|skim|scan|eyeball|check|review|examine|inspect|audit)\\b.{0,30}\\b(harness|router|routing|agent|repo|script|pipeline|module|tests|code)\\b"
     - "\\b(bug|bugs|issue|issues|problem|problems|error|errors|traceback|regression|regressions|deficit|deficits)\\b.{0,40}\\b(code|harness|router|routing|agent|repo|script|pipeline|module|tests|provider|providers|tools|policy)\\b"
     - "\\b(code|harness|router|routing|agent|repo|script|pipeline|module|tests|provider|providers|tools|policy)\\b.{0,40}\\b(bug|bugs|issue|issues|problem|problems|error|errors|traceback|regression|regressions|deficit|deficits)\\b"
-    - "\\b(how|what)\\b.{0,20}\\b(harness|router|routing|agent|repo|script|pipeline|module|tests|code|provider|providers|tools|policy)\\b.{0,20}\\b(feel|feeling|doing|going|holding|state|status|shape|condition|health)\\b"
-    - "\\b(feel|feeling|doing|going|holding|state|status|shape|condition|health)\\b.{0,20}\\b(harness|router|routing|agent|repo|script|pipeline|module|tests|code|provider|providers|tools|policy)\\b"
+    # Operational-status shape — mechanical-state words only.
+    # 'feel|feeling|doing|going' dropped: conversational register,
+    # not a status probe. Live false positive 2026-04-19: "how does
+    # the new harness feel?" routed to Opus 4.7 + code substrate.
+    # The python defaults in harness/policy.py were narrowed in
+    # #2882; this file overrides those defaults and must match.
+    - "\\b(how|what)\\b.{0,20}\\b(harness|router|routing|agent|repo|script|pipeline|module|tests|code|provider|providers|tools|policy)\\b.{0,20}\\b(state|status|shape|condition|health|holding)\\b"
+    - "\\b(state|status|shape|condition|health|holding)\\b.{0,20}\\b(harness|router|routing|agent|repo|script|pipeline|module|tests|code|provider|providers|tools|policy)\\b"
     - "\\bstack trace\\b"
     - "\\bHTTP \\d{3}\\b"
     - "\\bprovider error\\b"


### PR DESCRIPTION
Follow-up to #2882 closing a missed source of truth.

## The bug

Live reproduction 2026-04-19 at 11:13 AM PDT, after #2882 and #2883 had both merged:

```
zoe> hey buddy - how is the harness feeling now?
vybn>   [route: code -> anthropic:claude-opus-4-7
          (heuristic=\b(how|what)\b.{0,20}\b(harness|...)\b.{0,20}
           \b(feel|feeling|doing|going|holding|state|status|shape|
           condition|health)\b)]
```

The exact wide pattern #2882 narrowed. But in this session it was still live.

## Why

`spark/harness/policy.py` carries defaults. `spark/router_policy.yaml` overrides them at startup. #2882 edited the defaults only. The YAML file still carried the original `feel|feeling|doing|going|holding|...` pattern, so once `load_policy()` read the YAML, the narrowed defaults were replaced with the old wide net.

Both files co-vary. When the Python defaults move, the YAML has to move with them or the fix doesn't reach the live path. Added a comment at the call site pointing at #2882 so the next editor knows.

## What this PR does

`spark/router_policy.yaml`: narrow the two heuristics from

```
(feel|feeling|doing|going|holding|state|status|shape|condition|health)
```

to

```
(state|status|shape|condition|health|holding)
```

— exactly matching the Python defaults. 'feel|feeling|doing|going' drop out; genuine status words remain.

## Scope

- Policy YAML only. Zero Python changes. Tests unchanged.
- The tests in `test_live_repl_fixes.py` that pin the routing expectation were passing against the default policy in isolation — this PR makes the same expectation hold in the live REPL once the process is cycled.