### PR TITLE
harness: bounded probe-synthesis loop + route PR queries to task

### DIFF
--- a/spark/router_policy.yaml
+++ b/spark/router_policy.yaml
@@ -135,6 +135,15 @@ heuristics:
     - "\\b(check|verify|confirm|audit)\\b.{0,50}\\b(status|health|state|service|services|daemon|daemons|port|ports|cron|crons|walk|server|api)\\b"
     - "\\bhealth check\\b"
     - "\\bhey buddy.{0,40}(working|running|okay|ok|check)\\b"
+    # Round 2026-04-19: "the recent prs", "what landed", "show me the
+    # commits" -- operational repo-state questions that previously fell
+    # through to chat and wasted a NEEDS-EXEC probe. Route straight to
+    # task so gh/git run in the native bash loop.
+    - "\\b(the |our |recent |open |closed |merged |latest )?(pr|prs|pull request|pull requests)\\b"
+    - "\\b(what|which|show|list|any).{0,20}\\b(prs?|pull requests?|branches?|commits?)\\b"
+    - "\\b(what|which).{0,20}\\b(landed|merged|shipped|pushed|committed|deployed)\\b"
+    - "\\b(gh pr|git log|git branch|git status)\\b"
+    - "\\bcheck (the )?(pr|prs|branches?|commits?|repo)\\b"
   # Identity matched first so "which model are you?" skips the chat path.
   identity:
     - "\\bwhich model\\b"

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -1148,21 +1148,38 @@ def run_agent_loop(
                 # NEXT turn sees it naturally. No recursion, no extra
                 # LLM call on this turn.
                 if not role_cfg.tools:
-                    probe_match = _PROBE_RE.search(response.text or "")
-                    if probe_match:
+                    # Bounded probe-synthesis loop. Current response may
+                    # carry a [NEEDS-EXEC: ...] directive; execute it,
+                    # synthesize a reply, and if that synthesis itself
+                    # contains another NEEDS-EXEC, loop (up to
+                    # PROBE_BUDGET total probes per turn). Previously
+                    # this was a single-shot: a second probe emitted
+                    # during synthesis was silently stripped and the
+                    # turn ended mid-sentence. Zoe observed this in the
+                    # REPL on 2026-04-19: chat synthesized 'Good - PRs
+                    # #2885-2888 merged. Let me look at what actually
+                    # landed...' with a trailing probe that was dropped.
+                    PROBE_BUDGET = 3
+                    probe_iter = 0
+                    current_text = response.text or ""
+                    synth_failed = False
+                    while probe_iter < PROBE_BUDGET:
+                        probe_match = _PROBE_RE.search(current_text)
+                        if not probe_match:
+                            break
+                        probe_iter += 1
                         probe_cmd = probe_match.group(1).strip()
                         ran, probe_out = _run_probe_subturn(probe_cmd, bash)
                         logger.emit(
                             "probe_exec",
                             turn=turn_number,
+                            iteration=probe_iter,
                             role=decision.role,
                             model=role_cfg.model,
                             ran=ran,
                             command=probe_cmd[:500],
                             out_chars=len(probe_out),
                         )
-                        # Silent synthesis: inject probe result and
-                        # let the model give one clean answer.
                         probe_note = (
                             "[probe result | cmd: "
                             + probe_cmd[:200]
@@ -1195,26 +1212,35 @@ def run_agent_loop(
                                     synth_resp.raw_assistant_content
                                 ),
                             })
+                            current_text = synth_resp.text or ""
                         except KeyboardInterrupt:
-                            # User interrupted during synthesis -- pop the
-                            # orphan probe message so history stays clean.
                             if messages and messages[-1].get("role") == "user":
                                 messages.pop()
-                            pass
+                            synth_failed = True
+                            break
                         except Exception as _synth_err:
-                            # Synthesis call failed (regional overload,
-                            # timeout, etc). The probe output is already
-                            # on screen; pop the orphan probe-result user
-                            # message so the next turn is not forever
-                            # trying to "answer" a stale probe, and tell
-                            # Zoe what happened instead of leaving a
-                            # silent prompt.
                             if messages and messages[-1].get("role") == "user":
                                 messages.pop()
                             _warn(
                                 f"probe synthesis failed ({type(_synth_err).__name__}: "
                                 f"{str(_synth_err)[:160]}) -- probe output above is "
                                 "the raw result; ask me again and I will read from it."
+                            )
+                            synth_failed = True
+                            break
+                    # If we exhausted the budget and still had a probe
+                    # pending, tell Zoe rather than silently drop.
+                    if not synth_failed and probe_iter >= PROBE_BUDGET:
+                        if _PROBE_RE.search(current_text):
+                            _warn(
+                                f"probe budget exhausted ({PROBE_BUDGET}) -- "
+                                "further investigation needed. Try /task with "
+                                "the same question to get bash + iteration budget."
+                            )
+                            logger.emit(
+                                "probe_budget_exhausted",
+                                turn=turn_number,
+                                budget=PROBE_BUDGET,
                             )
 
 


### PR DESCRIPTION
## The hang you saw

```
zoe> the recent prs
vybn> Good — so PRs #2885 through #2888 all merged. Let me look at what actually landed...
zoe> ^C
```

Truncated sentence, blank prompt. Not the 529 overload from PR #2889 — a different bug with the same visible symptom.

## Root cause

Chat role is `tools=[]`, `max_iterations=1`. To answer "the recent prs" it had to emit `[NEEDS-EXEC: gh pr list]`. The harness ran that, fed the output to a synthesis call, and the synthesis response said _"Good. PRs merged. Let me look at what actually landed — `[NEEDS-EXEC: gh pr view ...]`"_.

The probe handler only ran on the **outer** response, not on the synthesis response. The display stripper erased the second `[NEEDS-EXEC]` tag from what Zoe saw. The model thought its probe was queued; the harness thought the turn was over. Cut off mid-investigation.

## Fix 1 — bounded probe-synthesis loop

Turn the probe cycle into a bounded loop (3 iterations). If the synthesis response itself contains `[NEEDS-EXEC]`, execute it and synthesize again. If the budget is exhausted and there's still a pending probe, print a visible warning suggesting `/task`.

This matches what the model is actually trying to do — investigate iteratively — instead of cutting it off after one probe. Previously a multi-step investigation from chat was architecturally impossible; now it works up to 3 steps before handing off.

## Fix 2 — route PR queries to task

Added heuristics so "the recent prs", "what landed", "show me commits", "check the branches" route to **task** (Sonnet 4.6 + bash + 10 iterations) natively. No probe cycle needed for these operational repo-state questions.

Router smoke test:
```
'the recent prs'                   -> task
'what PRs are open?'               -> task
'show me recent commits'           -> task
'check the branches'               -> task
'latest pr'                        -> task
'what landed today'                -> task
'hey buddy, try again?'            -> chat
'what do you see?'                 -> chat
'i was asking about your take'     -> chat
```

PR queries go to task. Conversational queries stay in chat. Clean.

## Together with PR #2889

- #2889 handled transient 529/overloaded errors during synthesis (retry in place before walking the chain).
- This PR handles synthesis emitting a second probe (loop it instead of dropping it) and reroutes operational questions away from the probe cycle entirely.

Both were visible as "probe synthesis error" / blank prompts; different root causes, different fixes.
