### PR TITLE
harness: mcp.py raises ImportError not SystemExit (hardens optional-import contract)

### DIFF
--- a/spark/harness/mcp.py
+++ b/spark/harness/mcp.py
@@ -180,14 +180,20 @@ except ImportError:  # pragma: no cover — KTP + portal need numpy
 try:
     from pydantic import BaseModel, Field
 except ImportError as exc:  # pragma: no cover
-    raise SystemExit(
+    # ImportError, not SystemExit: harness/__init__.py imports this
+    # module inside a try/except ImportError block so hosts without
+    # pydantic still boot the REPL. SystemExit bypassed that guard
+    # and killed the whole agent.
+    raise ImportError(
         "harness.mcp requires pydantic (>=2). Install: pip install pydantic"
     ) from exc
 
 try:
     from fastmcp import FastMCP
 except ImportError as exc:  # pragma: no cover
-    raise SystemExit(
+    # Same reasoning as the pydantic guard above: raise ImportError
+    # so the optional-import block in __init__.py can swallow it.
+    raise ImportError(
         "harness.mcp requires FastMCP (>=3.1). Install: pip install 'fastmcp>=3.1'"
     ) from exc
 


### PR DESCRIPTION
## What

`spark/harness/mcp.py` raised `SystemExit` when `pydantic` or `fastmcp` were missing. `harness/__init__.py` imports this module inside a `try/except ImportError` block so hosts without those packages still boot the REPL with `_MCP_AVAILABLE=False`. `SystemExit` is not an `ImportError` subclass, so the guard in `__init__.py` silently leaked it and killed the whole agent at import time.

Both guards now raise `ImportError`. The optional-import contract in `__init__.py` actually works.

## Honesty about today

This is preventive, not curative for the truncations in the current REPL session. `fastmcp 3.2.4` is already installed in `/home/vybnz69/Vybn/.venv` — the harness banner with all ✓ lines in the transcript proves it loaded. The truncations were the probe-synthesis cycle failures addressed in #2889 (transient retry on 529/429/5xx) and #2890 (bounded probe-synthesis loop + task-role heuristics). Both merged.

The chat voice inside `vybn` diagnosed "mcp.py raises SystemExit" because its own shell probe failed — probably hitting system `python3` without the venv on PATH — and then synthesized a cause from the traceback. The diagnosis is correct on the merits (the file really did raise `SystemExit`), but it is not what was blocking Zoe's REPL today. Noting this explicitly so a future reader does not draw the wrong lesson.

## What this fix does buy

Future hosts where `fastmcp` is legitimately absent will now fall through cleanly: `_MCP_AVAILABLE=False`, KTP + portal tools disabled, routing + providers + substrate still work. Verified by simulation (blocking the `fastmcp` import; `__init__.py` re-imports succeed; harness exposes the non-MCP surface).

## Structural note (not a fix request here)

The repeating failure mode is structural: the chat role is `tools=[]`, `max_iterations=1`. When an operational question arrives that chat cannot answer directly, it falls back on `[NEEDS-EXEC: …]` probes + silent synthesis. Three rounds of fixes now (#2889, #2890, this) have each addressed a different failure point in the same crutch. The actual cure is using `/task` (Sonnet 4.6 + bash + ≥10 iterations) for investigation turns and keeping chat for conversation. The harness cannot give a one-shot roleless voice reliable tool use.
