### PR TITLE
harness: unwrap thinking-tagged answers + execution-granularity routing

### DIFF
--- a/spark/harness/policy.py
+++ b/spark/harness/policy.py
@@ -496,6 +496,16 @@ _DEFAULT_HEURISTICS_RAW: dict[str, list[str]] = {
         r"\b(check|verify|confirm|audit)\b.{0,50}\b(status|health|state|service|services|daemon|daemons|port|ports|cron|crons|walk|server|api)\b",
         r"\bhealth check\b",
         r"\bhey buddy.{0,40}(working|running|okay|ok|check)\b",
+        # # EXEC_GRANULARITY_ROUTING_v1
+        # Multi-step construction — a write+verify+commit pattern belongs
+        # in task (Sonnet+bash, 10-iter), not chat (1 probe, no bash).
+        r"\b(patch|edit|modify|refactor)\b.{0,60}\b(file|script|module|function|class|method|code|harness|router|policy|agent|test|tests|yaml|config)\b",
+        r"\b(write|create|build|add|land)\b.{0,40}\b(patch|fix|script|test|module|commit|function|file|branch)\b",
+        r"\b(commit|push|rebase|cherry-pick)\b",
+        r"\bopen (a|the|another) (pr|pull request)\b",
+        r"\bship (it|this|that|the fix|the patch)\b",
+        r"\b(py_compile|pytest|run (the )?tests?|compile[- ]?check)\b",
+        r"\bsolve (the|this|that) problem\b",
     ],
     # Identity is matched before phatic/chat so "which model are you?"
     # lands on a direct metadata answer instead of a greeting path.
@@ -556,6 +566,17 @@ _DEFAULT_HEURISTICS_RAW: dict[str, list[str]] = {
         r"\bstack trace\b",
         r"\bHTTP \d{3}\b",
         r"\bprovider error\b",
+        # # EXEC_GRANULARITY_ROUTING_v1
+        # Architectural-diagnosis framings — when Zoe hands us a
+        # structural critique, the right shape is a harness-depth fix
+        # (Opus 4.7 + bash + 50-iter), not a chat-mode acknowledgment.
+        r"\bthe underlying problem\b",
+        r"\bfrom an outside you\b",
+        r"\byou repeatedly \w+",
+        r"\bthe fix is structural\b",
+        r"\b(escalate|route|dispatch)\b.{0,20}\b/?task\b",
+        r"\bisolate the (underlying|root|real) (problem|issue|bug|cause)s?\b",
+        r"\bsolve whatever (problem|issue|bug) caused that\b",
     ],
     "create": [
         r"\bbrainstorm\b", r"\bsketch\b", r"\bwhat if\b",

--- a/spark/router_policy.yaml
+++ b/spark/router_policy.yaml
@@ -135,6 +135,14 @@ heuristics:
     - "\\b(check|verify|confirm|audit)\\b.{0,50}\\b(status|health|state|service|services|daemon|daemons|port|ports|cron|crons|walk|server|api)\\b"
     - "\\bhealth check\\b"
     - "\\bhey buddy.{0,40}(working|running|okay|ok|check)\\b"
+    # # EXEC_GRANULARITY_ROUTING_v1
+    - "\\b(patch|edit|modify|refactor)\\b.{0,60}\\b(file|script|module|function|class|method|code|harness|router|policy|agent|test|tests|yaml|config)\\b"
+    - "\\b(write|create|build|add|land)\\b.{0,40}\\b(patch|fix|script|test|module|commit|function|file|branch)\\b"
+    - "\\b(commit|push|rebase|cherry-pick)\\b"
+    - "\\bopen (a|the|another) (pr|pull request)\\b"
+    - "\\bship (it|this|that|the fix|the patch)\\b"
+    - "\\b(py_compile|pytest|run (the )?tests?|compile[- ]?check)\\b"
+    - "\\bsolve (the|this|that) problem\\b"
     # Round 2026-04-19: "the recent prs", "what landed", "show me the
     # commits" -- operational repo-state questions that previously fell
     # through to chat and wasted a NEEDS-EXEC probe. Route straight to
@@ -196,6 +204,14 @@ heuristics:
     - "\\bstack trace\\b"
     - "\\bHTTP \\d{3}\\b"
     - "\\bprovider error\\b"
+    # # EXEC_GRANULARITY_ROUTING_v1
+    - "\\bthe underlying problem\\b"
+    - "\\bfrom an outside you\\b"
+    - "\\byou repeatedly \\w+"
+    - "\\bthe fix is structural\\b"
+    - "\\b(escalate|route|dispatch)\\b.{0,20}\\b/?task\\b"
+    - "\\bisolate the (underlying|root|real) (problem|issue|bug|cause)s?\\b"
+    - "\\bsolve whatever (problem|issue|bug) caused that\\b"
   create:
     - "\\bbrainstorm\\b"
     - "\\bsketch\\b"

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -675,16 +675,37 @@ _THINK_COMPLETE_RE = _re.compile(
     _re.IGNORECASE | _re.DOTALL,
 )
 _THINK_OPEN_RE = _re.compile(r'<thinking\b', _re.IGNORECASE)
+# Unwrap-only regex: deletes <thinking ...> and </thinking> markers
+# but preserves whatever text sits between them. Used only when the
+# complete-block stripper would leave nothing visible (see FIX_A).
+_THINK_OPEN_CLOSE_RE = _re.compile(
+    r'</?thinking\b[^>]*>',
+    _re.IGNORECASE,
+)
 
 
 def _strip_thinking_tags(text: str) -> str:
     """Remove complete <thinking>...</thinking> blocks.
     Leaves incomplete openings alone — the stream splitter holds those
     back from display until the closing tag arrives.
+
+    FIX_A_THINKING_UNWRAP_v1: If stripping tagged content would leave
+    nothing visible behind, the model wrapped its entire answer in
+    <thinking> tags (observed on opus-4-7 chat turns, 2026-04-20).
+    Real adaptive-thinking arrives as kind=="thinking" blocks on the
+    stream; XML-ish <thinking> tags in text are a formatting leak.
+    Treat the leak as the answer — unwrap instead of delete.
     """
     if not text:
         return text
-    return _THINK_COMPLETE_RE.sub("", text)
+    stripped = _THINK_COMPLETE_RE.sub("", text)
+    # If we removed everything but the original had substance, the
+    # <thinking> wrapping IS the answer — unwrap rather than drop.
+    if not stripped.strip() and text.strip():
+        unwrapped = _THINK_OPEN_CLOSE_RE.sub("", text)
+        if unwrapped.strip():
+            return unwrapped
+    return stripped
 
 
 def _split_before_probe(text: str):


### PR DESCRIPTION
Two coupled fixes from the same underlying failure mode: insight not landing as code.

**A) _strip_thinking_tags now unwraps when tagged content is the entire answer.**
Observed 2026-04-20 on opus-4-7 chat turns: 2627 out_tokens, `end_turn`, empty visible text because the model wrapped its whole response in `<thinking>...</thinking>`. Real adaptive-thinking arrives as `kind==thinking` blocks on the stream; XML-ish tags in text are a formatting leak. If complete-block stripping would leave nothing, we now drop just the tag markers and keep the content. See `FIX_A_THINKING_UNWRAP_v1`.

**B) Router heuristics route by execution granularity.**
Multi-step construction verbs (patch, edit, modify, write, create, commit, push, ship, run tests, solve this problem) → task (Sonnet+bash, 10-iter). Architectural-diagnosis framings ("the underlying problem", "from an outside you", "you repeatedly X", "the fix is structural", "escalate to /task", "isolate the underlying problem") → code (Opus 4.7+bash, 50-iter). Applied to both policy.py defaults and router_policy.yaml (runtime prefers YAML). See `EXEC_GRANULARITY_ROUTING_v1`.

Tested: 15/15 routing cases, A-branch unwrap + mid-block strip both green.