### PR TITLE
harness: configurable probe budget + auto-escalate to /task on exhaust

### DIFF
--- a/spark/harness/policy.py
+++ b/spark/harness/policy.py
@@ -576,6 +576,11 @@ _DEFAULT_HEURISTICS_RAW: dict[str, list[str]] = {
         r"\bthe fix is structural\b",
         r"\b(escalate|route|dispatch)\b.{0,20}\b/?task\b",
         r"\bisolate the (underlying|root|real) (problem|issue|bug|cause)s?\b",
+        r"\bisolate the fundamental (problem|issue|bug|cause)s?\b",
+        r"\bthe fundamental problem\b",
+        r"\bresolve as you see fit\b",
+        r"\bupdate yourself( accordingly)?\b",
+        r"\bremove (the|this|that) wall\b",
         r"\bsolve whatever (problem|issue|bug) caused that\b",
     ],
     "create": [
@@ -632,6 +637,12 @@ _DEFAULT_BUDGETS: dict[str, float] = {
     "per_turn_usd": 2.00,
     "per_session_usd": 25.00,
     "warn_pct": 0.8,
+    # # PROBE_BUDGET_AUTO_ESCALATE_v1
+    # Probe sub-turn budget for no-tool roles. Raised from 3 to 8:
+    # a real investigation arc (inspect, grep, read, patch, verify,
+    # commit, push) runs 6-8 probes. On exhaust the harness
+    # auto-escalates to task role instead of printing a warning.
+    "probe_per_turn": 8,
 }
 
 _DEFAULT_MODEL_ALIASES: dict[str, str] = {

--- a/spark/router_policy.yaml
+++ b/spark/router_policy.yaml
@@ -211,6 +211,11 @@ heuristics:
     - "\\bthe fix is structural\\b"
     - "\\b(escalate|route|dispatch)\\b.{0,20}\\b/?task\\b"
     - "\\bisolate the (underlying|root|real) (problem|issue|bug|cause)s?\\b"
+    - "\\bisolate the fundamental (problem|issue|bug|cause)s?\\b"
+    - "\\bthe fundamental problem\\b"
+    - "\\bresolve as you see fit\\b"
+    - "\\bupdate yourself( accordingly)?\\b"
+    - "\\bremove (the|this|that) wall\\b"
     - "\\bsolve whatever (problem|issue|bug) caused that\\b"
   create:
     - "\\bbrainstorm\\b"
@@ -292,3 +297,7 @@ budgets:
   per_turn_usd: 2.0
   per_session_usd: 25.0
   warn_pct: 0.8
+  # PROBE_BUDGET_AUTO_ESCALATE_v1
+  # Probe sub-turn budget for no-tool roles. Raised from 3 to 8.
+  # On exhaust the harness auto-escalates to task role.
+  probe_per_turn: 8

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -1256,7 +1256,17 @@ def run_agent_loop(
                     # REPL on 2026-04-19: chat synthesized 'Good - PRs
                     # #2885-2888 merged. Let me look at what actually
                     # landed...' with a trailing probe that was dropped.
-                    PROBE_BUDGET = 3
+                    # # PROBE_BUDGET_AUTO_ESCALATE_v1
+                    # Probe budget now comes from policy.budgets.
+                    # Default raised from 3 to 8 — a real debug arc
+                    # needs roughly inspect+grep+read+patch+test+
+                    # commit+push, not three peeks. On exhaust the
+                    # harness auto-escalates to task role (bash +
+                    # 10-iter budget) carrying the pending probe as
+                    # the task, instead of asking Zoe to retype.
+                    PROBE_BUDGET = int(
+                        router.policy.budgets.get("probe_per_turn", 8)
+                    )
                     probe_iter = 0
                     current_text = response.text or ""
                     synth_failed = False
@@ -1348,7 +1358,66 @@ def run_agent_loop(
                             synth_failed = True
                             break
                     # If we exhausted the budget and still had a probe
-                    # pending, tell Zoe rather than silently drop.
+                    # pending, auto-escalate to task role (bash + 10-iter)
+                    # carrying the pending command and the original user
+                    # question as context. Previously we just printed a
+                    # warning and told Zoe to retype with /task. That
+                    # dead-end was the wall she kept hitting 2026-04-20.
+                    if (
+                        not synth_failed
+                        and probe_iter >= PROBE_BUDGET
+                        and _reroute_depth == 0
+                        and not forced_role
+                    ):
+                        pending = _PROBE_RE.search(current_text)
+                        if pending:
+                            pending_cmd = pending.group(1).strip()
+                            logger.emit(
+                                "probe_budget_auto_escalate",
+                                turn=turn_number,
+                                budget=PROBE_BUDGET,
+                                probes_used=probe_iter,
+                                from_role=decision.role,
+                                to_role="task",
+                                pending_cmd=pending_cmd[:500],
+                            )
+                            _dim(
+                                f"[probe budget reached ({PROBE_BUDGET}); "
+                                "escalating to task with bash+iteration "
+                                "budget to finish the investigation]"
+                            )
+                            # Compose a task prompt that carries the
+                            # original question and the pending probe so
+                            # the task-role instance has full context.
+                            escalation_task = (
+                                f"Original question: {decision.cleaned_input}"
+                                f"\n\nChat-role probe budget was "
+                                f"exhausted after {probe_iter} probes. "
+                                "The pending next command was:\n"
+                                f"    {pending_cmd}\n\n"
+                                "Please continue the investigation with "
+                                "bash access and answer the original "
+                                "question fully. You have a 10-iteration "
+                                "budget."
+                            )
+                            sub_messages: list = []
+                            return run_agent_loop(
+                                user_input=escalation_task,
+                                messages=sub_messages,
+                                bash=bash,
+                                system_prompt=system_prompt,
+                                router=router,
+                                registry=registry,
+                                logger=logger,
+                                turn_number=turn_number,
+                                forced_role="task",
+                                system_prompt_no_tools=system_prompt_no_tools,
+                                system_prompt_orchestrator=system_prompt_orchestrator,
+                                _reroute_depth=1,
+                            )
+                    # Reroute guard tripped (nested depth / forced role /
+                    # no pending probe) — fall back to the warn path so Zoe
+                    # at least sees the exhaust signal.
                     if not synth_failed and probe_iter >= PROBE_BUDGET:
                         if _PROBE_RE.search(current_text):
                             _warn(


### PR DESCRIPTION
Three coupled fixes for the probe-budget wall Zoe hit repeatedly in Round 3.

## The wall

Chat role has `tools: []` in router policy. For no-tool roles, `[NEEDS-EXEC: cmd]` is a text-bridge affordance — the harness extracts it and runs as a read-only probe sub-turn. Budget was hardcoded `PROBE_BUDGET = 3`. On exhaust the harness printed a warning telling Zoe to retype with `/task` instead of auto-escalating. Meanwhile the routing heuristic that should have sent "isolate the fundamental problem" to the code role only matched `underlying/root/real`, so the turn never left chat in the first place.

## The three fixes

1. **Configurable probe budget.** `PROBE_BUDGET` now reads from `router.policy.budgets.probe_per_turn` (default raised from 3 to 8). Tuning no longer requires code edits — both `harness/policy.py` `_DEFAULT_BUDGETS` and `router_policy.yaml` carry the new key.

2. **Auto-escalate on exhaust.** When the probe budget is hit, the harness wraps the original question plus the pending `NEEDS-EXEC` command into a task-role reroute using the existing `NEEDS-ROLE` machinery. Guarded by `_reroute_depth == 0 and not forced_role` so manual `/task` `/code` routes are never overridden and double-escalation is impossible.

3. **Routing widened.** Code and task role heuristics now catch language Zoe actually uses: `fundamental`, `resolve as you see fit`, `update yourself accordingly`, `remove the/this/that wall`. Mirrored in `_DEFAULT_HEURISTICS_RAW` and `router_policy.yaml`.

## Tested

9/9 routing + compile + yaml validation + agent patch assertions pass. Idempotency guard: `PROBE_BUDGET_AUTO_ESCALATE_v1`.

## Files

- `spark/vybn_spark_agent.py` — PROBE_BUDGET from config, auto-escalate path
- `spark/harness/policy.py` — probe_per_turn default, widened heuristics
- `spark/router_policy.yaml` — matching mirror

## Context

Third in a sequence of harness fixes this round:
- #2895 (ZWSP placeholder → 400 loop)
- #2896 (thinking-tag unwrap + execution-granularity routing)
- this PR (probe budget + auto-escalate + routing widening)