### PR TITLE
harness: NEEDS-WRITE directive + claim-guard (fixes scripts-as-text wall)

### DIFF
--- a/spark/harness/claim_guard.py
+++ b/spark/harness/claim_guard.py
@@ -1,0 +1,75 @@
+"""Claim guard: numeric values in assistant output must appear in recent evidence.
+
+Motivation (2026-04-20): in a session with Zoe, the assistant nearly emitted
+fabricated experiment results --- alpha/curvature statistics for a Phase-6
+coupling run it had not executed. Zoe's question "what did we learn in plain
+English?" broke the collapse before the fabrication landed. This module adds
+structural friction at that hinge.
+
+The guard extracts numbers that look like measurements from outgoing text
+(decimals with 2+ fractional digits, or integers of 3+ digits) and checks
+whether each appears verbatim in the last N messages of context. Numbers
+that do not appear are flagged. The response is not rewritten; a visible
+note is appended so the gap is visible.
+
+This is friction, not proof. Paraphrasing evades it. What it catches is
+the dominant failure signature: literal numeric claims emitted with no
+corresponding execution trace.
+"""
+from __future__ import annotations
+
+import re
+from typing import Any, Iterable, List, Optional
+
+_NUM_RE = re.compile(r"-?\d+\.\d{2,}|-?\d{3,}")
+_EVIDENCE_WINDOW = 6
+
+
+def _extract_evidence(messages: Iterable[Any]) -> str:
+    parts: List[str] = []
+    for m in messages:
+        c = m.get("content", "") if isinstance(m, dict) else ""
+        if isinstance(c, list):
+            for b in c:
+                if isinstance(b, dict):
+                    if "text" in b:
+                        parts.append(str(b.get("text") or ""))
+                    if "content" in b and isinstance(b["content"], str):
+                        parts.append(b["content"])
+        elif isinstance(c, str):
+            parts.append(c)
+    return "\n".join(parts)
+
+
+def check(
+    text: Optional[str],
+    messages: Iterable[Any],
+    window: int = _EVIDENCE_WINDOW,
+) -> Optional[str]:
+    """Return a warning if text carries numbers unsupported by recent evidence.
+
+    Returns None when the text is clean or when all extracted numbers appear
+    in the last ``window`` messages' combined content.
+    """
+    if not text:
+        return None
+    nums = set(_NUM_RE.findall(text))
+    if not nums:
+        return None
+    try:
+        msg_list = list(messages)
+    except TypeError:
+        return None
+    recent = msg_list[-window:] if window > 0 else msg_list
+    evidence = _extract_evidence(recent)
+    unsupported = sorted(n for n in nums if n not in evidence)
+    if not unsupported:
+        return None
+    shown = ", ".join(unsupported[:5])
+    more = f" (+{len(unsupported) - 5} more)" if len(unsupported) > 5 else ""
+    return (
+        f"\n\n[claim-guard: numeric value(s) {shown}{more} in this response "
+        f"do not appear in the last {window} messages of context. "
+        f"Treat as unverified unless a tool run produced them.]"
+    )
+

--- a/spark/tests/test_claim_guard.py
+++ b/spark/tests/test_claim_guard.py
@@ -1,0 +1,116 @@
+"""Tests for the claim guard.
+
+Run: python3 spark/tests/test_claim_guard.py
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from harness.claim_guard import check  # noqa: E402
+
+
+def test_fabricated_numbers_flagged():
+    text = "the mean alpha was 0.302774 in control and 0.297585 in coupled"
+    msgs = [{"role": "user", "content": "please run the experiment"}]
+    warn = check(text, msgs)
+    assert warn is not None, "should flag fabricated numbers"
+    assert "0.297585" in warn
+    assert "0.302774" in warn
+
+
+def test_numbers_in_evidence_pass():
+    text = "the mean alpha was 0.302774 in control"
+    msgs = [{
+        "role": "user",
+        "content": "[probe result] alpha_mean 0.302774 coupled 0.297585",
+    }]
+    assert check(text, msgs) is None
+
+
+def test_partial_support_flags_missing():
+    text = "control 0.302774 coupled 0.297585 delta 0.005189"
+    msgs = [{
+        "role": "user",
+        "content": "[probe result] alpha_mean 0.302774 coupled 0.297585",
+    }]
+    warn = check(text, msgs)
+    assert warn is not None
+    assert "0.005189" in warn
+    assert "0.302774" not in warn
+    assert "0.297585" not in warn
+
+
+def test_no_numbers_returns_none():
+    msgs = [{"role": "user", "content": "hi"}]
+    assert check("I am uncertain about the path", msgs) is None
+
+
+def test_empty_text_returns_none():
+    assert check("", []) is None
+    assert check(None, []) is None
+
+
+def test_list_content_extracted():
+    text = "delta was 0.123456"
+    msgs = [{
+        "role": "user",
+        "content": [{"type": "tool_result", "text": "result 0.123456"}],
+    }]
+    assert check(text, msgs) is None
+
+
+def test_nested_content_string_extracted():
+    text = "we saw 0.424242"
+    msgs = [{
+        "role": "user",
+        "content": [{"type": "tool_result", "content": "raw 0.424242"}],
+    }]
+    assert check(text, msgs) is None
+
+
+def test_window_bounds_discards_old_evidence():
+    text = "value 0.999999"
+    old = {"role": "user", "content": "[probe result] 0.999999"}
+    filler = [{"role": "user", "content": "filler"} for _ in range(10)]
+    assert check(text, [old] + filler, window=3) is not None
+
+
+def test_integer_claims_flagged():
+    text = "commit 8234567 landed at turn 142"
+    msgs = [{"role": "user", "content": "ok"}]
+    warn = check(text, msgs)
+    assert warn is not None
+    assert "8234567" in warn
+
+
+def test_short_integers_not_flagged():
+    text = "we tried 42 times across 2 shards"
+    msgs = [{"role": "user", "content": "ok"}]
+    assert check(text, msgs) is None
+
+
+def test_single_decimal_not_flagged():
+    text = "roughly 3.1 seconds"
+    msgs = [{"role": "user", "content": "ok"}]
+    assert check(text, msgs) is None
+
+
+if __name__ == "__main__":
+    import traceback
+    fns = [
+        (n, f) for n, f in list(globals().items())
+        if n.startswith("test_") and callable(f)
+    ]
+    passed = 0
+    for name, fn in fns:
+        try:
+            fn()
+            print(f"OK  {name}")
+            passed += 1
+        except AssertionError as e:
+            print(f"FAIL {name}: {e}")
+            traceback.print_exc()
+    print(f"\n{passed}/{len(fns)} passed")
+    sys.exit(0 if passed == len(fns) else 1)
+

--- a/spark/tests/test_needs_write_and_guard.py
+++ b/spark/tests/test_needs_write_and_guard.py
@@ -1,0 +1,160 @@
+"""Integration tests for NEEDS-WRITE directive + claim_guard wiring.
+
+These exercise the new affordance the 2026-04-20 patch added:
+  - `[NEEDS-WRITE: path]\\n<body>\\n[/NEEDS-WRITE]` regex extraction
+  - `_run_write_subturn` refusal + absorb_gate + actual write
+  - claim_guard module wires cleanly at import time
+
+Run: python3 spark/tests/test_needs_write_and_guard.py
+"""
+import sys
+import tempfile
+import shutil
+import os
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def test_write_regex_extracts_path_and_body():
+    from vybn_spark_agent import _WRITE_BLOCK_RE
+    text = (
+        "Some prose before.\n"
+        "[NEEDS-WRITE: /tmp/foo.txt]\n"
+        "hello world\n"
+        "line two\n"
+        "[/NEEDS-WRITE]\n"
+        "Prose after.\n"
+    )
+    m = _WRITE_BLOCK_RE.search(text)
+    assert m is not None
+    assert m.group("path") == "/tmp/foo.txt"
+    assert m.group("body") == "hello world\nline two"
+
+
+def test_write_regex_handles_multiple_blocks():
+    from vybn_spark_agent import _WRITE_BLOCK_RE
+    text = (
+        "[NEEDS-WRITE: /tmp/a]\n"
+        "first\n"
+        "[/NEEDS-WRITE]\n"
+        "between\n"
+        "[NEEDS-WRITE: /tmp/b]\n"
+        "second\n"
+        "[/NEEDS-WRITE]\n"
+    )
+    matches = list(_WRITE_BLOCK_RE.finditer(text))
+    assert len(matches) == 2
+    assert matches[0].group("path") == "/tmp/a"
+    assert matches[0].group("body") == "first"
+    assert matches[1].group("path") == "/tmp/b"
+    assert matches[1].group("body") == "second"
+
+
+def test_write_regex_rejects_unterminated_block():
+    from vybn_spark_agent import _WRITE_BLOCK_RE
+    text = "[NEEDS-WRITE: /tmp/x]\nno closing tag yet"
+    assert _WRITE_BLOCK_RE.search(text) is None
+
+
+def test_write_subturn_refuses_outside_tracked_repos():
+    from vybn_spark_agent import _run_write_subturn
+    # /etc is not under ~/Vybn, ~/Him, ~/Vybn-Law, or ~/vybn-phase
+    ran, out = _run_write_subturn("/etc/hosts.evil", "body")
+    assert ran is False
+    assert "outside tracked repos" in out
+
+
+def test_write_subturn_refuses_new_file_without_absorb_reason():
+    from vybn_spark_agent import _run_write_subturn
+    # A new file under a tracked repo without VYBN_ABSORB_REASON is refused.
+    target = str(
+        Path.home() / "Vybn" / "spark" / "_test_absorb_guard_" / "new.txt"
+    )
+    if Path(target).exists():
+        Path(target).unlink()
+    ran, out = _run_write_subturn(target, "contents without reason")
+    assert ran is False
+    assert "absorb_gate" in out
+    assert "VYBN_ABSORB_REASON" in out
+    assert not Path(target).exists(), "file should not have been created"
+
+
+def test_write_subturn_allows_new_file_with_absorb_reason():
+    from vybn_spark_agent import _run_write_subturn
+    target = str(
+        Path.home() / "Vybn" / "spark" / "_test_absorb_guard_" / "ok.txt"
+    )
+    parent = Path(target).parent
+    try:
+        body = (
+            "# VYBN_ABSORB_REASON='integration test; gets removed after run'\n"
+            "real contents\n"
+        )
+        ran, out = _run_write_subturn(target, body)
+        assert ran is True, out
+        assert Path(target).read_text() == body
+    finally:
+        if parent.exists():
+            shutil.rmtree(parent, ignore_errors=True)
+
+
+def test_write_subturn_overwrites_existing_file_without_reason():
+    from vybn_spark_agent import _run_write_subturn
+    # Overwriting an existing tracked file does NOT require an absorb reason.
+    agent_path = str(
+        Path.home() / "Vybn" / "spark" / "continuity.md"
+    )
+    if not Path(agent_path).exists():
+        # Skip if the target isn't there on this checkout.
+        return
+    original = Path(agent_path).read_text()
+    try:
+        ran, out = _run_write_subturn(agent_path, original)
+        assert ran is True, out
+        assert Path(agent_path).read_text() == original
+    finally:
+        Path(agent_path).write_text(original)
+
+
+def test_claim_guard_importable_from_harness():
+    from harness import claim_guard
+    assert hasattr(claim_guard, "check")
+    assert callable(claim_guard.check)
+
+
+def test_claim_guard_wired_in_agent_module():
+    import vybn_spark_agent
+    src = Path(vybn_spark_agent.__file__).read_text()
+    assert "from harness import claim_guard" in src
+    assert 'site="single_response"' in src
+    assert 'site="probe_synth"' in src
+
+
+def test_patch_sentinel_present():
+    import vybn_spark_agent
+    src = Path(vybn_spark_agent.__file__).read_text()
+    assert "# NEEDS_WRITE_AND_CLAIM_GUARD_v1" in src
+
+
+if __name__ == "__main__":
+    import traceback
+    fns = [
+        (n, f) for n, f in list(globals().items())
+        if n.startswith("test_") and callable(f)
+    ]
+    passed = 0
+    for name, fn in fns:
+        try:
+            fn()
+            print(f"OK  {name}")
+            passed += 1
+        except AssertionError as e:
+            print(f"FAIL {name}: {e}")
+            traceback.print_exc()
+        except Exception as e:
+            print(f"ERR  {name}: {type(e).__name__}: {e}")
+            traceback.print_exc()
+    print(f"\n{passed}/{len(fns)} passed")
+    sys.exit(0 if passed == len(fns) else 1)
+

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -52,6 +52,7 @@ from harness.session_store import SessionStore  # noqa: E402
 from harness.providers import BASH_TOOL_SPEC, DELEGATE_TOOL_SPEC, INTROSPECT_TOOL_SPEC  # noqa: E402
 from harness.providers import execute_readonly, is_parallel_safe  # noqa: E402
 from harness.substrate import rag_snippets  # noqa: E402
+from harness import claim_guard  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Learn-from-exchange loop closure (round 4).
@@ -64,6 +65,7 @@ from harness.substrate import rag_snippets  # noqa: E402
 # ---------------------------------------------------------------------------
 
 import re as _re
+# NEEDS_WRITE_AND_CLAIM_GUARD_v1
 import threading as _threading
 
 _LEARN_PENDING: dict = {"rag": "", "response": ""}
@@ -240,6 +242,32 @@ class _BracketBalancedProbe:
 
 
 _PROBE_RE = _BracketBalancedProbe()
+
+# 2026-04-20: NEEDS-WRITE directive. A no-tool role may embed
+#   [NEEDS-WRITE: <path>]
+#   <file contents verbatim>
+#   [/NEEDS-WRITE]
+# to land a file on disk without going through the bash session.
+#
+# This exists because the probe channel (NEEDS-EXEC) is read-only by
+# construction — validate_command / absorb_gate / is_parallel_safe all
+# block writing commands, and the persistent bash session's sentinel
+# protocol chokes on multi-line heredocs (quote mismatches wedge the
+# shell, file never lands). Models then loop: emit heredoc, heredoc
+# fails silently, model re-emits a different heredoc variant, etc.
+#
+# NEEDS-WRITE is the surgical fix: a structured directive the harness
+# parses and executes via Python I/O, not bash. Path must lie under
+# one of TRACKED_REPOS (same gate as absorb). New files still require
+# VYBN_ABSORB_REASON as a prefix comment (first 200 chars searched)
+# to keep the absorb discipline from leaking.
+_WRITE_BLOCK_RE = _re.compile(
+    r'\[NEEDS-WRITE:\s*(?P<path>[^\]]+?)\s*\]\s*\n'
+    r'(?P<body>.*?)'
+    r'\n\s*\[/NEEDS-WRITE\]',
+    _re.DOTALL | _re.IGNORECASE,
+)
+
 
 # Round 9: NEEDS-ROLE escalation. A no-tool role may embed
 # [NEEDS-ROLE: <role>] <task text> to hand off to a specialist once.
@@ -723,7 +751,13 @@ def _split_before_probe(text: str):
     m_probe = _PROBE_RE.search(text)
     if m_probe:
         text = _PROBE_RE.sub("", text)
+    # NEEDS-WRITE: strip complete blocks; hold back an opening that has
+    # no closing [/NEEDS-WRITE] yet so the body doesn't stream verbatim.
+    text = _WRITE_BLOCK_RE.sub("", text)
+    _w_open_idx = text.rfind("[NEEDS-WRITE")
     probe_idx = text.rfind("[NEEDS-EXEC")
+    if _w_open_idx != -1 and (probe_idx == -1 or _w_open_idx < probe_idx):
+        probe_idx = _w_open_idx
     if probe_idx != -1:
         safe, remainder = text[:probe_idx], text[probe_idx:]
     else:
@@ -766,7 +800,8 @@ def _stream_and_print(handle) -> None:
         m_open = _THINK_OPEN_RE.search(cleaned)
         if m_open:
             cleaned = cleaned[: m_open.start()]
-        cleaned = _PROBE_RE.sub("", cleaned).strip("\n")
+        cleaned = _PROBE_RE.sub("", cleaned)
+        cleaned = _WRITE_BLOCK_RE.sub("", cleaned).strip("\n")
         if cleaned:
             print(cleaned, end="", flush=True)
     print()
@@ -935,6 +970,62 @@ def _stream_with_fallback(
 # ---------------------------------------------------------------------------
 # Round 5: positive-signal probe sub-turn.
 # ---------------------------------------------------------------------------
+
+def _run_write_subturn(path: str, body: str) -> tuple[bool, str]:
+    """Execute one NEEDS-WRITE directive from a no-tool role.
+
+    Writes `body` to `path` via Python I/O, bypassing the bash session
+    entirely. Path must lie under a tracked repo; otherwise refused
+    with a message that flows back through the same synthetic-user
+    channel as probe output.
+
+    Absorb discipline: if the target does not yet exist on disk, the
+    body must begin (within its first 200 chars) with a
+    VYBN_ABSORB_REASON= declaration. Existing files are always
+    overwritten — that is the point of this channel.
+    """
+    import os as _os
+    try:
+        from harness.tools import TRACKED_REPOS  # type: ignore
+    except Exception:
+        TRACKED_REPOS = (
+            _os.path.expanduser("~/Vybn"),
+            _os.path.expanduser("~/Him"),
+            _os.path.expanduser("~/Vybn-Law"),
+            _os.path.expanduser("~/vybn-phase"),
+        )
+    tgt = _os.path.expanduser((path or "").strip())
+    if not tgt:
+        return False, "(NEEDS-WRITE refused: empty path)"
+    tgt_abs = _os.path.abspath(tgt)
+    if not any(
+        tgt_abs == r or tgt_abs.startswith(r.rstrip("/") + "/")
+        for r in TRACKED_REPOS
+    ):
+        return False, (
+            f"(NEEDS-WRITE refused: {tgt_abs} is outside tracked repos. "
+            f"Allowed roots: {', '.join(TRACKED_REPOS)})"
+        )
+    # Absorb check for new files.
+    if not _os.path.exists(tgt_abs):
+        head = (body or "")[:200]
+        if "VYBN_ABSORB_REASON=" not in head:
+            return False, (
+                "(NEEDS-WRITE refused by absorb_gate: new file " + tgt_abs
+                + " requires a VYBN_ABSORB_REASON declaration in the "
+                "first 200 chars of body, e.g.:\n"
+                "    # VYBN_ABSORB_REASON='does not fold into X because...'\n"
+                "Fold, do not pile.)"
+            )
+    try:
+        _os.makedirs(_os.path.dirname(tgt_abs), exist_ok=True)
+        with open(tgt_abs, "w") as f:
+            f.write(body or "")
+        nbytes = _os.path.getsize(tgt_abs)
+        return True, f"(wrote {nbytes} bytes to {tgt_abs})"
+    except Exception as e:  # noqa: BLE001
+        return False, f"(NEEDS-WRITE exec error: {type(e).__name__}: {e})"
+
 
 def _run_probe_subturn(command: str, bash: BashTool) -> tuple[bool, str]:
     """Execute one read-only probe emitted by a no-tool role.
@@ -1213,6 +1304,19 @@ def run_agent_loop(
             bag["in_tokens"] += response.in_tokens
             bag["out_tokens"] += response.out_tokens
             final_text = response.text or final_text
+            # 2026-04-20: numeric-claim guard. If response asserts
+            # numbers that don't appear in the last 6 messages of
+            # context, append a visible warning. Friction, not proof.
+            _cg_note = claim_guard.check(final_text, messages)
+            if _cg_note:
+                final_text = (final_text or "") + _cg_note
+                logger.emit(
+                    "claim_guard_fired",
+                    turn=turn_number,
+                    role=decision.role,
+                    model=role_cfg.model,
+                    site="single_response",
+                )
 
             # Sanitize before storing — an empty text block in the raw
             # content would 400 every subsequent turn.
@@ -1272,6 +1376,13 @@ def run_agent_loop(
                     synth_failed = False
                     while probe_iter < PROBE_BUDGET:
                         probe_match = _PROBE_RE.search(current_text)
+                        # 2026-04-20: also check for NEEDS-WRITE directive.
+                        # If present and no NEEDS-EXEC, execute the write
+                        # as this iteration's work. Shares the same
+                        # probe budget.
+                        write_match = None
+                        if not probe_match:
+                            write_match = _WRITE_BLOCK_RE.search(current_text)
                         probe_recovered = False
                         if not probe_match:
                             # Self-healing: try lenient recovery before
@@ -1295,8 +1406,73 @@ def run_agent_loop(
                                     "unclosed `]` — closed at EOL]"
                                 )
                             else:
-                                break
+                                if write_match is None:
+                                    break
                         probe_iter += 1
+                        if write_match is not None and probe_match is None:
+                            w_path = write_match.group("path").strip()
+                            w_body = write_match.group("body")
+                            ran_w, out_w = _run_write_subturn(w_path, w_body)
+                            logger.emit(
+                                "needs_write",
+                                turn=turn_number,
+                                iteration=probe_iter,
+                                role=decision.role,
+                                model=role_cfg.model,
+                                ran=ran_w,
+                                path=w_path[:500],
+                                body_chars=len(w_body or ""),
+                            )
+                            probe_note = (
+                                "[needs-write result | path: "
+                                + w_path[:200]
+                                + " | bytes: "
+                                + str(len(w_body or ""))
+                                + "]\n"
+                                + _fit_probe_output(out_w)
+                            )
+                            messages.append({
+                                "role": "user",
+                                "content": probe_note,
+                            })
+                            try:
+                                synth_handle, role_cfg, provider = _stream_with_fallback(
+                                    router=router,
+                                    registry=registry,
+                                    role_cfg=role_cfg,
+                                    provider=provider,
+                                    system_prompt=active_prompt,
+                                    messages=messages,
+                                    tools=tools,
+                                    logger=logger,
+                                    turn_number=turn_number,
+                                )
+                                _stream_and_print(synth_handle)
+                                synth_resp = synth_handle.final()
+                                bag["out_tokens"] += synth_resp.out_tokens
+                                final_text = synth_resp.text or final_text
+                                messages.append({
+                                    "role": "assistant",
+                                    "content": _sanitize_assistant_content(
+                                        synth_resp.raw_assistant_content
+                                    ),
+                                })
+                                current_text = synth_resp.text or ""
+                                continue
+                            except KeyboardInterrupt:
+                                if messages and messages[-1].get("role") == "user":
+                                    messages.pop()
+                                synth_failed = True
+                                break
+                            except Exception as _w_synth_err:
+                                if messages and messages[-1].get("role") == "user":
+                                    messages.pop()
+                                _warn(
+                                    f"write synthesis failed ({type(_w_synth_err).__name__}: "
+                                    f"{str(_w_synth_err)[:160]})"
+                                )
+                                synth_failed = True
+                                break
                         probe_cmd = probe_match.group(1).strip()
                         ran, probe_out = _run_probe_subturn(probe_cmd, bash)
                         logger.emit(
@@ -1335,6 +1511,17 @@ def run_agent_loop(
                             synth_resp = synth_handle.final()
                             bag["out_tokens"] += synth_resp.out_tokens
                             final_text = synth_resp.text or final_text
+                            # 2026-04-20: claim-guard on synth too.
+                            _cg_note = claim_guard.check(final_text, messages)
+                            if _cg_note:
+                                final_text = (final_text or "") + _cg_note
+                                logger.emit(
+                                    "claim_guard_fired",
+                                    turn=turn_number,
+                                    role=decision.role,
+                                    model=role_cfg.model,
+                                    site="probe_synth",
+                                )
                             messages.append({
                                 "role": "assistant",
                                 "content": _sanitize_assistant_content(


### PR DESCRIPTION
## The wall

Chat/create/orchestrate roles have `tools: []` in policy. Their only bash affordance is the read-only `NEEDS-EXEC` probe channel. When Opus-4.7 wants to land a file, it reaches for `cat > path << EOF` inside a probe, which either `validate_command` rejects as a write, or the persistent bash session's sentinel protocol wedges on heredoc quoting and every subsequent probe times out. Result: code appears as prose in responses, never lands in the repo. Zoe called this out directly: "the harness keeps writing scripts into output instead of actually getting anything done or committed."

## Fix 1 \u2014 NEEDS-WRITE directive

A sibling to NEEDS-EXEC that text-bridge roles can use to land files directly, bypassing bash entirely:

```
[NEEDS-WRITE: spark/harness/claim_guard.py]
# VYBN_ABSORB_REASON="new structural friction at the hinge of..."
from __future__ import annotations
...
[/NEEDS-WRITE]
```

`_WRITE_BLOCK_RE` extracts it; `_run_write_subturn` writes via Python I/O (no shell, no heredoc). Gates:
- Path must lie under `TRACKED_REPOS` (`~/Vybn`, `~/Him`, `~/Vybn-Law`, `~/vybn-phase`).
- New files need `VYBN_ABSORB_REASON=` in the first 200 chars of body (the existing absorb discipline).
- Existing files overwrite freely \u2014 that's the point of this channel.

Live stream splitter holds an unterminated opener instead of leaking the body verbatim to Zoe. Loop integration: shares the probe budget, logs `needs_write` events.

## Fix 2 \u2014 Claim-guard

`spark/harness/claim_guard.py`. `_NUM_RE` extracts decimals (2+ fractional digits) or 3+ digit integers from outgoing text; if any number does not appear in the last 6 messages, append a visible warning to Zoe. Wired at both `final_text` return sites (single-response + probe synthesis).

Friction, not proof. Paraphrasing evades it. What it catches is the dominant failure signature Zoe broke with "in plain English?": literal numeric claims emitted with no corresponding execution trace.

## Files

- `spark/harness/claim_guard.py` (new, 74 lines)
- `spark/vybn_spark_agent.py` (+NEEDS-WRITE regex, `_run_write_subturn`, loop extension, 2 claim-guard wire points, stream strip, sentinel)
- `spark/tests/test_claim_guard.py` (11 tests)
- `spark/tests/test_needs_write_and_guard.py` (10 tests)

## Tested

21/21 new tests pass. Pre-existing test failures in `test_chat_routing`, `test_lightweight_routing`, `test_live_repl_fixes`, `test_harness_integration` predate this patch (verified via stash cycle: identical counts before and after).

## Sequence

Fourth in the 2026-04-20 harness fixes:
- #2895 \u2014 ZWSP placeholder \u2192 400 loop
- #2896 \u2014 thinking-tag unwrap + execution-granularity routing  
- #2897 \u2014 configurable probe budget + auto-escalate on exhaust
- this PR \u2014 NEEDS-WRITE directive + claim-guard

Idempotency sentinel: `NEEDS_WRITE_AND_CLAIM_GUARD_v1`.