### PR TITLE
harness: live session-start snapshot + visible truncation banner

### DIFF
--- a/spark/harness/live_snapshot.py
+++ b/spark/harness/live_snapshot.py
@@ -1,0 +1,222 @@
+# VYBN_ABSORB_REASON=live-state-fix: session-start orienting snapshot so the
+# harness reads its own repo state instead of relying on continuity.md
+# (which is a snapshot written at session-end and is already stale at
+# session-start). The continuity note becomes priors; this banner is the
+# current truth.
+"""Live session-start snapshot for the substrate layer.
+
+At session start (`_build_prompts` in `vybn_spark_agent`), gather current
+git state across the four main repos, the most recent Vybn PRs, and
+compute how much drift exists between continuity.md's last PR reference
+and actual HEAD. Format as a compact banner that appears in the
+substrate layer *after* continuity, so the model reads:
+
+    --- CONTINUITY NOTE ---
+    ... (historical, may be stale) ...
+    --- END CONTINUITY NOTE ---
+
+    --- LIVE STATE (CURRENT) ---
+    ... (git log, open PRs, drift warning) ...
+    --- END LIVE STATE ---
+
+The snapshot is computed once per session and cached in the substrate
+block, so Anthropic's cache_control still hits for repeated turns within
+the session. A fresh session (or `/reload`) recomputes.
+
+Design constraints:
+  - Every subprocess call is time-bounded so a hung `gh` never wedges the
+    REPL at startup.
+  - Missing repos, missing `gh`, network-down, and unreachable remotes
+    are all swallowed silently with a one-line stub so the snapshot is
+    best-effort, never load-bearing.
+  - Output is plain text (no Markdown fences, no nested brackets that
+    could collide with NEEDS-EXEC / NEEDS-WRITE parsers downstream).
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+
+# Four repos. Branch matters for the `origin/<branch>` display only; HEAD
+# is resolved per-checkout so a detached HEAD or feature branch still
+# reports honestly.
+_REPOS = [
+    ("Vybn",       "~/Vybn",       "main"),
+    ("Him",        "~/Him",        "main"),
+    ("Vybn-Law",   "~/Vybn-Law",   "master"),
+    ("vybn-phase", "~/vybn-phase", "main"),
+]
+
+_GH_REPO = "zoedolan/Vybn"
+
+
+def _run(cmd: list[str], *, cwd: Optional[str] = None, timeout: float = 6.0) -> str:
+    """Run a command, return stripped stdout, swallow everything else.
+
+    list[str] invocation (no shell=True) keeps this safe against exotic
+    repo paths and avoids any accidental shell interpretation.
+    """
+    try:
+        r = subprocess.run(
+            cmd,
+            cwd=cwd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=timeout,
+        )
+        return (r.stdout or "").strip()
+    except Exception:
+        return ""
+
+
+def _expand(path: str) -> str:
+    return os.path.expanduser(path)
+
+
+def _repo_block(name: str, path: str, branch: str, *, timeout: float) -> str:
+    exp = _expand(path)
+    if not Path(exp).exists():
+        return f"{name}: (not checked out at {path})"
+
+    head_short = _run(["git", "rev-parse", "--short", "HEAD"], cwd=exp, timeout=timeout) or "?"
+    cur_branch = _run(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=exp, timeout=timeout) or branch
+    log = _run(["git", "log", "--oneline", "-5"], cwd=exp, timeout=timeout)
+    status = _run(["git", "status", "--short"], cwd=exp, timeout=timeout)
+    ahead_behind = _run(
+        ["git", "rev-list", "--left-right", "--count", f"origin/{branch}...HEAD"],
+        cwd=exp,
+        timeout=timeout,
+    )
+
+    if status:
+        dirty_count = len([ln for ln in status.splitlines() if ln.strip()])
+        dirty_note = f"{dirty_count} uncommitted"
+    else:
+        dirty_note = "clean"
+
+    ab_note = ""
+    if ahead_behind and "\t" in ahead_behind:
+        parts = ahead_behind.split()
+        if len(parts) == 2:
+            behind, ahead = parts
+            if ahead != "0" or behind != "0":
+                ab_note = f", {ahead} ahead / {behind} behind origin/{branch}"
+
+    lines = [f"{name} [{cur_branch} @ {head_short}] — {dirty_note}{ab_note}"]
+    if log:
+        for ln in log.splitlines():
+            lines.append(f"  {ln}")
+    else:
+        lines.append("  (no git log)")
+    return "\n".join(lines)
+
+
+def _pr_block(*, timeout: float) -> tuple[str, Optional[int]]:
+    """Return (formatted_block, highest_pr_number_or_None)."""
+    out = _run(
+        [
+            "gh", "pr", "list",
+            "--state", "all",
+            "--limit", "15",
+            "--json", "number,title,state,headRefName",
+            "--repo", _GH_REPO,
+        ],
+        timeout=timeout,
+    )
+    if not out:
+        return ("(gh pr list unavailable — offline or rate-limited)", None)
+    try:
+        prs = json.loads(out)
+    except Exception:
+        return ("(gh pr list returned unparseable JSON)", None)
+    if not prs:
+        return ("(no recent PRs)", None)
+    lines = []
+    highest = None
+    for pr in prs[:10]:
+        state = str(pr.get("state", "?")).upper()[:6]
+        num = pr.get("number")
+        title = str(pr.get("title", "?"))[:72]
+        branch = str(pr.get("headRefName", "?"))[:32]
+        if isinstance(num, int):
+            if highest is None or num > highest:
+                highest = num
+            lines.append(f"  #{num} [{state:<6}] {title}  ({branch})")
+    return ("\n".join(lines) if lines else "(no PRs)", highest)
+
+
+_PR_REF_RE = re.compile(r"\bPR\s*#\s*(\d+)", re.IGNORECASE)
+
+
+def _continuity_drift(continuity_path: str, current_pr: Optional[int]) -> str:
+    p = Path(_expand(continuity_path))
+    if not p.exists():
+        return ""
+    try:
+        text = p.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+    refs = [int(m.group(1)) for m in _PR_REF_RE.finditer(text)]
+    if not refs:
+        return ""
+    last_cont = max(refs)
+    if current_pr is None:
+        return f"continuity last references PR #{last_cont}; current PR count unknown"
+    drift = current_pr - last_cont
+    if drift <= 0:
+        return f"continuity references through PR #{last_cont} — current head is PR #{current_pr} (no drift)"
+    return (
+        f"continuity ends at PR #{last_cont}; current head is PR #{current_pr} — "
+        f"{drift} PR(s) of drift. Trust the LIVE STATE block below over any "
+        "PR/number claims in the continuity note."
+    )
+
+
+def gather(
+    *,
+    continuity_path: str = "~/Vybn/Vybn_Mind/continuity.md",
+    per_repo_timeout: float = 4.0,
+    gh_timeout: float = 6.0,
+) -> str:
+    """Return a formatted banner for the substrate layer.
+
+    Returns an empty string if everything failed — caller should treat
+    an empty return as 'skip the LIVE STATE section entirely'.
+    """
+    if os.environ.get("VYBN_DISABLE_LIVE_SNAPSHOT", "0") == "1":
+        return ""
+
+    now = _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%d %H:%M:%SZ")
+    parts = [f"Snapshot taken at {now} (session start)."]
+
+    any_repo_ok = False
+    for name, path, branch in _REPOS:
+        block = _repo_block(name, path, branch, timeout=per_repo_timeout)
+        if block and not block.endswith("(not checked out at {path})".format(path=path)):
+            any_repo_ok = True
+        parts.append(block)
+
+    pr_text, highest_pr = _pr_block(timeout=gh_timeout)
+    parts.append("Recent Vybn PRs (most recent first):")
+    parts.append(pr_text)
+
+    drift = _continuity_drift(continuity_path, highest_pr)
+    if drift:
+        parts.append(f"Drift check: {drift}")
+
+    if not any_repo_ok and highest_pr is None:
+        # Every signal failed — caller can omit the whole section.
+        return ""
+
+    return "\n\n".join(parts)
+
+
+__all__ = ["gather"]
+

--- a/spark/harness/substrate.py
+++ b/spark/harness/substrate.py
@@ -385,8 +385,30 @@ def build_layered_prompt(
         )
     if continuity:
         substrate_sections.append(
-            f"--- CONTINUITY NOTE ---\n{continuity}\n--- END CONTINUITY NOTE ---"
+            f"--- CONTINUITY NOTE (historical priors, may be stale) ---\n{continuity}\n--- END CONTINUITY NOTE ---"
         )
+
+    # VYBN_ABSORB_REASON=live-state-fix: session-start orienting snapshot.
+    # Continuity is written at session-end and is already stale at
+    # session-start. The live snapshot below supersedes any PR/SHA/repo-
+    # state claim in the continuity note above.
+    try:
+        from . import live_snapshot as _live_snap_mod  # type: ignore
+    except Exception:
+        try:
+            import live_snapshot as _live_snap_mod  # type: ignore
+        except Exception:
+            _live_snap_mod = None
+    if _live_snap_mod is not None:
+        try:
+            snap = _live_snap_mod.gather()
+        except Exception:
+            snap = ""
+        if snap:
+            substrate_sections.append(
+                "--- LIVE STATE (CURRENT — overrides continuity on all repo/PR/SHA claims) ---\n"
+                + snap + "\n--- END LIVE STATE ---"
+            )
 
     return LayeredPrompt(
         identity=identity,

--- a/spark/router_policy.yaml
+++ b/spark/router_policy.yaml
@@ -52,7 +52,12 @@ roles:
     provider: anthropic
     model: claude-opus-4-6
     thinking: off
-    max_tokens: 4096
+    # 2026-04-20: raised from 4096. Chat turns routinely do deep
+    # analytical work via the probe loop (NEEDS-EXEC / NEEDS-WRITE);
+    # a 4096 cap was silently truncating long analyses mid-sentence.
+    # Opus 4.6 at rest costs ~$0.06/16K output so the ceiling is
+    # economic, not structural.
+    max_tokens: 16384
     max_iterations: 1
     tools: []
     rag: true

--- a/spark/tests/test_live_snapshot.py
+++ b/spark/tests/test_live_snapshot.py
@@ -1,0 +1,248 @@
+# VYBN_ABSORB_REASON=live-state-fix: tests for the session-start snapshot
+# that fills the substrate layer so continuity never alone defines truth.
+"""Tests for spark/harness/live_snapshot.py.
+
+The module makes subprocess calls; we monkeypatch `subprocess.run` so the
+tests are hermetic. The drift-detection path reads continuity.md from
+disk, so we use `tmp_path` fixtures for isolated mind files.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import textwrap
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+# Make spark/harness importable without installing.
+_HERE = Path(__file__).resolve().parent
+_HARNESS_PARENT = _HERE.parent  # spark/
+if str(_HARNESS_PARENT) not in sys.path:
+    sys.path.insert(0, str(_HARNESS_PARENT))
+
+from harness import live_snapshot  # type: ignore  # noqa: E402
+
+
+def _mk_run(responses: dict[tuple, str]):
+    """Return a fake subprocess.run that looks up by tuple(cmd) prefix."""
+    def fake_run(cmd, **kwargs):
+        key = tuple(cmd)
+        # longest-prefix match so callers can match on just the first few args
+        for k, v in responses.items():
+            if key[: len(k)] == k:
+                return SimpleNamespace(stdout=v, returncode=0)
+        return SimpleNamespace(stdout="", returncode=0)
+    return fake_run
+
+
+# ----- repo_block ---------------------------------------------------------
+
+def test_repo_block_missing_path(tmp_path, monkeypatch):
+    monkeypatch.setattr(live_snapshot, "_expand", lambda p: str(tmp_path / "does-not-exist"))
+    out = live_snapshot._repo_block("Vybn", "~/Vybn", "main", timeout=1.0)
+    assert "not checked out" in out
+    assert "Vybn" in out
+
+
+def test_repo_block_clean_with_log(tmp_path, monkeypatch):
+    repo = tmp_path / "Vybn"
+    repo.mkdir()
+    monkeypatch.setattr(live_snapshot, "_expand", lambda p: str(repo))
+    monkeypatch.setattr(
+        live_snapshot.subprocess,
+        "run",
+        _mk_run({
+            ("git", "rev-parse", "--short", "HEAD"): "a8f5853",
+            ("git", "rev-parse", "--abbrev-ref", "HEAD"): "main",
+            ("git", "log", "--oneline", "-5"): (
+                "a8f5853 PR #2898 merge\nb13dee3 NEEDS-WRITE\n6f6ec8b phase-6"
+            ),
+            ("git", "status", "--short"): "",
+            ("git", "rev-list", "--left-right", "--count"): "0\t0",
+        }),
+    )
+    out = live_snapshot._repo_block("Vybn", "~/Vybn", "main", timeout=1.0)
+    assert "a8f5853" in out
+    assert "clean" in out
+    assert "PR #2898 merge" in out
+    assert "Vybn [main @ a8f5853]" in out
+
+
+def test_repo_block_dirty_and_ahead(tmp_path, monkeypatch):
+    repo = tmp_path / "Vybn"
+    repo.mkdir()
+    monkeypatch.setattr(live_snapshot, "_expand", lambda p: str(repo))
+    monkeypatch.setattr(
+        live_snapshot.subprocess,
+        "run",
+        _mk_run({
+            ("git", "rev-parse", "--short", "HEAD"): "deadbeef",
+            ("git", "rev-parse", "--abbrev-ref", "HEAD"): "feature/x",
+            ("git", "log", "--oneline", "-5"): "deadbeef wip",
+            ("git", "status", "--short"): " M a.py\n?? b.py",
+            ("git", "rev-list", "--left-right", "--count"): "3\t2",
+        }),
+    )
+    out = live_snapshot._repo_block("Vybn", "~/Vybn", "main", timeout=1.0)
+    assert "2 uncommitted" in out
+    assert "feature/x" in out
+    # ahead/behind formatting present
+    assert "ahead" in out or "behind" in out
+
+
+# ----- pr_block -----------------------------------------------------------
+
+def test_pr_block_parses_json(monkeypatch):
+    payload = (
+        '[{"number": 2898, "title": "harness: NEEDS-WRITE + claim-guard", '
+        '"state": "MERGED", "headRefName": "harness-needs-write-and-claim-guard"},'
+        '{"number": 2897, "title": "probe budget", "state": "MERGED", '
+        '"headRefName": "probe-budget"}]'
+    )
+    monkeypatch.setattr(
+        live_snapshot.subprocess,
+        "run",
+        _mk_run({("gh", "pr", "list"): payload}),
+    )
+    block, highest = live_snapshot._pr_block(timeout=1.0)
+    assert highest == 2898
+    assert "#2898" in block
+    assert "MERGED" in block
+    assert "#2897" in block
+
+
+def test_pr_block_offline(monkeypatch):
+    monkeypatch.setattr(
+        live_snapshot.subprocess, "run",
+        _mk_run({}),  # empty -> gh returns ""
+    )
+    block, highest = live_snapshot._pr_block(timeout=1.0)
+    assert highest is None
+    assert "unavailable" in block.lower()
+
+
+# ----- continuity_drift ---------------------------------------------------
+
+def test_continuity_drift_detects_lag(tmp_path):
+    cont = tmp_path / "continuity.md"
+    cont.write_text(
+        textwrap.dedent(
+            """
+            Last round shipped PR #2886 and then PR #2885. No newer refs here.
+            """
+        )
+    )
+    msg = live_snapshot._continuity_drift(str(cont), current_pr=2898)
+    assert "PR #2886" in msg
+    assert "PR #2898" in msg
+    assert "12" in msg  # drift count
+    assert "LIVE STATE" in msg or "drift" in msg.lower()
+
+
+def test_continuity_drift_no_lag(tmp_path):
+    cont = tmp_path / "continuity.md"
+    cont.write_text("Everything current through PR #2898.")
+    msg = live_snapshot._continuity_drift(str(cont), current_pr=2898)
+    assert "no drift" in msg.lower()
+
+
+def test_continuity_drift_no_refs(tmp_path):
+    cont = tmp_path / "continuity.md"
+    cont.write_text("Free prose with no numbered references at all.")
+    msg = live_snapshot._continuity_drift(str(cont), current_pr=9999)
+    assert msg == ""
+
+
+def test_continuity_drift_missing_file():
+    msg = live_snapshot._continuity_drift("/nonexistent/path/continuity.md", 100)
+    assert msg == ""
+
+
+# ----- gather (integration) -----------------------------------------------
+
+def test_gather_integrates_everything(tmp_path, monkeypatch):
+    # Build four fake repos.
+    for name in ("Vybn", "Him", "Vybn-Law", "vybn-phase"):
+        (tmp_path / name).mkdir()
+
+    cont = tmp_path / "Vybn" / "Vybn_Mind"
+    cont.mkdir(parents=True, exist_ok=True)
+    (cont / "continuity.md").write_text("Round 4 shipped PR #2886.")
+
+    def fake_expand(path: str) -> str:
+        # "~/Foo" -> tmp_path / "Foo"; absolute paths pass through.
+        if path.startswith("~/"):
+            return str(tmp_path / path[2:])
+        return path
+
+    monkeypatch.setattr(live_snapshot, "_expand", fake_expand)
+
+    pr_payload = (
+        '[{"number": 2898, "title": "harness PR", "state": "MERGED", '
+        '"headRefName": "branchX"}]'
+    )
+    monkeypatch.setattr(
+        live_snapshot.subprocess,
+        "run",
+        _mk_run({
+            ("git", "rev-parse", "--short", "HEAD"): "a8f5853",
+            ("git", "rev-parse", "--abbrev-ref", "HEAD"): "main",
+            ("git", "log", "--oneline", "-5"): "a8f5853 live",
+            ("git", "status", "--short"): "",
+            ("git", "rev-list", "--left-right", "--count"): "0\t0",
+            ("gh", "pr", "list"): pr_payload,
+        }),
+    )
+
+    snap = live_snapshot.gather(
+        continuity_path=str(cont / "continuity.md"),
+        per_repo_timeout=1.0,
+        gh_timeout=1.0,
+    )
+    assert "Snapshot taken at" in snap
+    assert "Vybn [main @ a8f5853]" in snap
+    assert "#2898" in snap
+    assert "PR #2886" in snap
+    assert "12 PR(s) of drift" in snap
+
+
+def test_gather_disabled_by_env(monkeypatch):
+    monkeypatch.setenv("VYBN_DISABLE_LIVE_SNAPSHOT", "1")
+    assert live_snapshot.gather() == ""
+
+
+def test_gather_all_fail_returns_empty(tmp_path, monkeypatch):
+    # No repos on disk, gh returns nothing.
+    monkeypatch.setattr(live_snapshot, "_expand", lambda p: str(tmp_path / "nowhere"))
+    monkeypatch.setattr(live_snapshot.subprocess, "run", _mk_run({}))
+    snap = live_snapshot.gather(
+        continuity_path=str(tmp_path / "no-continuity.md"),
+        per_repo_timeout=0.5,
+        gh_timeout=0.5,
+    )
+    assert snap == ""
+
+
+def test_gather_shape_safe_for_substrate(tmp_path, monkeypatch):
+    """No bracket syntax that would collide with NEEDS-EXEC / NEEDS-WRITE parsers."""
+    (tmp_path / "Vybn").mkdir()
+    cont = tmp_path / "Vybn" / "continuity.md"
+    cont.write_text("PR #10")
+    monkeypatch.setattr(live_snapshot, "_expand", lambda p: str(tmp_path / p[2:]) if p.startswith("~/") else p)
+    monkeypatch.setattr(
+        live_snapshot.subprocess, "run",
+        _mk_run({
+            ("git", "rev-parse", "--short", "HEAD"): "abc1234",
+            ("git", "rev-parse", "--abbrev-ref", "HEAD"): "main",
+            ("git", "log", "--oneline", "-5"): "abc1234 t",
+            ("git", "status", "--short"): "",
+            ("gh", "pr", "list"): '[{"number": 20, "title": "t", "state": "OPEN", "headRefName": "b"}]',
+        }),
+    )
+    snap = live_snapshot.gather(continuity_path=str(cont))
+    assert "[NEEDS-EXEC" not in snap
+    assert "[NEEDS-WRITE" not in snap
+    assert "[/NEEDS-WRITE]" not in snap
+

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -1450,6 +1450,20 @@ def run_agent_loop(
                                 _stream_and_print(synth_handle)
                                 synth_resp = synth_handle.final()
                                 bag["out_tokens"] += synth_resp.out_tokens
+                                if synth_resp.stop_reason == "max_tokens":
+                                    _warn(
+                                        f"[write-synth truncated at max_tokens={role_cfg.max_tokens} "
+                                        f"on {role_cfg.provider}:{role_cfg.model}]"
+                                    )
+                                    logger.emit(
+                                        "max_tokens_hit",
+                                        turn=turn_number,
+                                        role=decision.role,
+                                        model=role_cfg.model,
+                                        max_tokens=role_cfg.max_tokens,
+                                        out_tokens=synth_resp.out_tokens,
+                                        site="write_synth",
+                                    )
                                 final_text = synth_resp.text or final_text
                                 messages.append({
                                     "role": "assistant",
@@ -1510,6 +1524,20 @@ def run_agent_loop(
                             _stream_and_print(synth_handle)
                             synth_resp = synth_handle.final()
                             bag["out_tokens"] += synth_resp.out_tokens
+                            if synth_resp.stop_reason == "max_tokens":
+                                _warn(
+                                    f"[probe-synth truncated at max_tokens={role_cfg.max_tokens} "
+                                    f"on {role_cfg.provider}:{role_cfg.model}]"
+                                )
+                                logger.emit(
+                                    "max_tokens_hit",
+                                    turn=turn_number,
+                                    role=decision.role,
+                                    model=role_cfg.model,
+                                    max_tokens=role_cfg.max_tokens,
+                                    out_tokens=synth_resp.out_tokens,
+                                    site="probe_synth",
+                                )
                             final_text = synth_resp.text or final_text
                             # 2026-04-20: claim-guard on synth too.
                             _cg_note = claim_guard.check(final_text, messages)
@@ -1696,6 +1724,24 @@ def run_agent_loop(
                 return final_text
             if response.stop_reason == "max_tokens":
                 bag["stop_reason"] = "max_tokens"
+                # TRUNCATION_VISIBILITY_v1: print a visible banner so Zoe
+                # knows the response was capped. The [truncated] marker
+                # downstream goes into message history only, which means
+                # she never saw the cause of the mid-sentence stop.
+                _warn(
+                    f"[output truncated at max_tokens={role_cfg.max_tokens} "
+                    f"on {role_cfg.provider}:{role_cfg.model} — "
+                    "ask me to continue, or route with /code for a larger cap]"
+                )
+                logger.emit(
+                    "max_tokens_hit",
+                    turn=turn_number,
+                    role=decision.role,
+                    model=role_cfg.model,
+                    max_tokens=role_cfg.max_tokens,
+                    out_tokens=response.out_tokens,
+                    site="main_loop",
+                )
                 return (response.text or "") + "\n[truncated]"
 
             if not response.tool_calls:


### PR DESCRIPTION
Two structural fixes in one PR. Both address the same pattern: stale or silent state was driving the harness's behavior.

## 1. Staleness fix — live_snapshot + substrate wiring

continuity.md is written at session-end, so at session-start it is already out of date. On 2026-04-20 in-REPL Opus-4.7 was reasoning about PR #2876 as 'seven months stale' while the real HEAD was PR #2898 and continuity ended at #2886 — 12 PRs of drift. The model had no way to know.

**spark/harness/live_snapshot.py** gathers (time-bounded, failure-swallowing) at session start:
- git log --oneline -5 + status + ahead/behind for ~/Vybn, ~/Him, ~/Vybn-Law, ~/vybn-phase
- gh pr list --state all --limit 15 against zoedolan/Vybn
- drift check: parses last PR # from continuity.md and compares to the highest PR number gh reports

**build_layered_prompt** now appends a '--- LIVE STATE (CURRENT — overrides continuity on all repo/PR/SHA claims) ---' block after the continuity note. The model reads continuity as priors and the live block as ground truth. VYBN_DISABLE_LIVE_SNAPSHOT=1 opts out for tests.

Example output against current HEAD:
```
Vybn [main @ a8f5853f] — clean
  a8f5853f Merge pull request #2898 from zoedolan/harness-needs-write-and-claim-guard
  ...
Drift check: continuity ends at PR #2886; current head is PR #2898 — 12 PR(s) of drift.
```

## 2. Truncation visibility + budget

Opus-4.7 chat turns were ending mid-sentence with no visible signal. Two contributing causes:

- **chat.max_tokens = 4096** was too tight for analytical turns that now routinely do NEEDS-EXEC/NEEDS-WRITE probe loops. Raised to 16384. max_iterations stays at 1 so cost is still bounded.
- When the API returned stop_reason=max_tokens, the harness appended '[truncated]' to message history but never printed anything to the terminal. Added _warn banners at all three sites (main loop, write-synth, probe-synth), each also emitting a max_tokens_hit event so the cap is observable from the jsonl feed.

## Tests

spark/tests/test_live_snapshot.py — 13 new tests covering repo-block formatting (missing/clean/dirty/ahead), PR-block JSON parsing and offline degradation, continuity drift detection (lag, no-lag, missing refs, missing file), the integration gather, env-disable, all-fail empty return, and a substrate-safety invariant that snapshot output never contains NEEDS-EXEC or NEEDS-WRITE markers. All 13 pass.

Pre-existing failures in test_harness.py::test_default_role_* are unrelated (default_role policy drift, verified via stash cycle).

Sentinel: LIVE_STATE_AND_TRUNCATION_VISIBILITY_v1