### PR TITLE
test-suite: finish round 6 — zero failures / zero errors

### DIFF
--- a/spark/tests/test_chat_routing.py
+++ b/spark/tests/test_chat_routing.py
@@ -44,6 +44,11 @@ def _load_chat_api(env_overrides: dict | None = None):
     except Exception:
         return None
     path = SPARK_DIR / "vybn_chat_api.py"
+    # spark/vybn_chat_api.py was archived 2026-04-18 (see _archive/README.md).
+    # These routing-shape tests apply to the archived surface only; when the
+    # file is absent, skip cleanly rather than raising FileNotFoundError.
+    if not path.exists():
+        return None
 
     saved: dict[str, str | None] = {}
     if env_overrides:

--- a/spark/tests/test_harness_integration.py
+++ b/spark/tests/test_harness_integration.py
@@ -288,11 +288,21 @@ class TestRagSnippetsDefensive(unittest.TestCase):
     def test_returns_empty_when_deep_memory_missing(self):
         # Point vybn_phase_dir at a directory that does not contain
         # deep_memory.py — the function must silently return "".
-        out = rag_snippets(
-            "anything",
-            vybn_phase_dir="/no/such/path",
-            timeout=1.0,
-        )
+        # Mask the HTTP tier (live daemon on :8100 would otherwise
+        # answer regardless of the local path) so we exercise the
+        # defensive fallback path under test.
+        with mock.patch(
+            "harness.substrate._rag_http",
+            side_effect=Exception("no daemon"),
+        ), mock.patch(
+            "harness.substrate._load_deep_memory",
+            return_value=None,
+        ):
+            out = rag_snippets(
+                "anything",
+                vybn_phase_dir="/no/such/path",
+                timeout=1.0,
+            )
         self.assertEqual(out, "")
 
 

--- a/spark/tests/test_lightweight_routing.py
+++ b/spark/tests/test_lightweight_routing.py
@@ -50,6 +50,11 @@ def _load_chat_api(env_overrides: dict | None = None):
     except Exception:
         return None
     path = SPARK_DIR / "vybn_chat_api.py"
+    # spark/vybn_chat_api.py was archived 2026-04-18 (see _archive/README.md).
+    # The chat-api-coupled tests apply to the archived surface only; when the
+    # file is absent, skip cleanly rather than raising FileNotFoundError.
+    if not path.exists():
+        return None
 
     saved: dict[str, str | None] = {}
     if env_overrides:
@@ -524,11 +529,11 @@ class TestCliDirectReplyAndLightweight(unittest.TestCase):
 
         class _FakeProvider:
             def stream(_s, *, system, messages, tools, role):
+                captured["role_cfg"] = role
                 return _FakeHandle()
 
         class _FakeRegistry:
             def get(_s, cfg):
-                captured["role_cfg"] = cfg
                 return _FakeProvider()
 
         class _FakeLogger:

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -396,7 +396,7 @@ def _sanitize_assistant_content(content):
     if isinstance(content, str):
         if _is_effectively_empty_text(content):
             return _EMPTY_PLACEHOLDER
-        scrubbed = _strip_thinking_tags(content)
+        scrubbed = _strip_thinking_tags(content, allow_unwrap=False)
         return scrubbed if not _is_effectively_empty_text(scrubbed) else _EMPTY_PLACEHOLDER
 
     # Anthropic-style: list of content blocks. Each block may be an SDK
@@ -412,7 +412,7 @@ def _sanitize_assistant_content(content):
                 if text is None and isinstance(block, dict):
                     text = block.get("text", "")
                 if not _is_effectively_empty_text(text or ""):
-                    scrubbed = _strip_thinking_tags(text)
+                    scrubbed = _strip_thinking_tags(text, allow_unwrap=False)
                     if scrubbed and not _is_effectively_empty_text(scrubbed):
                         # Rewrite the block with scrubbed text. Preserve
                         # dict vs. SDK-object shape so callers that
@@ -712,7 +712,7 @@ _THINK_OPEN_CLOSE_RE = _re.compile(
 )
 
 
-def _strip_thinking_tags(text: str) -> str:
+def _strip_thinking_tags(text: str, allow_unwrap: bool = True) -> str:
     """Remove complete <thinking>...</thinking> blocks.
     Leaves incomplete openings alone — the stream splitter holds those
     back from display until the closing tag arrives.
@@ -727,9 +727,18 @@ def _strip_thinking_tags(text: str) -> str:
     if not text:
         return text
     stripped = _THINK_COMPLETE_RE.sub("", text)
-    # If we removed everything but the original had substance, the
-    # <thinking> wrapping IS the answer — unwrap rather than drop.
-    if not stripped.strip() and text.strip():
+    # If we removed everything but the original had substance AND there
+    # was exactly one <thinking> block, the model wrapped its entire
+    # answer in <thinking> tags — unwrap rather than drop. Only fires on
+    # the display path (allow_unwrap=True); the store path passes
+    # allow_unwrap=False so multi-block or fully-thinking payloads drop
+    # cleanly out of history instead of replaying as prose.
+    if (
+        allow_unwrap
+        and not stripped.strip()
+        and text.strip()
+        and len(_THINK_COMPLETE_RE.findall(text)) == 1
+    ):
         unwrapped = _THINK_OPEN_CLOSE_RE.sub("", text)
         if unwrapped.strip():
             return unwrapped


### PR DESCRIPTION
Round 6 shipped incomplete. The harness rearchitecture PR landed with the suite at 10 failed / 131 passed / 25 errors. You merged on trust, then called out the gap. Round 7 closes it.

## What changed

**Zombie tests for archived `spark/vybn_chat_api.py` converted to skips.** The archived routing module (_archive/spark__vybn_chat_api.py, 2026-04-18) left 25 errors and 6 failures behind in tests that still tried to load it. `_load_chat_api` in both test files now checks `path.exists()` and returns None, producing clean skips rather than errors.

**`test_phatic_skips_rag_enrichment` — capture moved to stream time.** `_stream_with_fallback` pre-builds the fallback chain eagerly, calling `registry.get(fb_cfg)` for each provider. That overwrote the captured phatic RoleConfig with the create-role fallback before the primary stream ever ran. Fix: capture the role at `_FakeProvider.stream` instead of `_FakeRegistry.get`.

**`_strip_thinking_tags` — `allow_unwrap` parameter added.** The opus-4-7 unwrap fix (c29f636d) fired unconditionally whenever stripping left nothing behind — wrong for multi-block payloads (stripped 'a<thinking>x</thinking>b<thinking>y</thinking>' to 'ab' instead of ''), and wrong for the store path where fully-thinking content should drop out of history rather than replay as prose. The unwrap now fires only when allow_unwrap=True AND exactly one `<thinking>` block is present. Display path (`_split_before_probe`) keeps the old behavior. `_sanitize_assistant_content` passes `allow_unwrap=False` on both string and text-block paths.

**`test_returns_empty_when_deep_memory_missing` — defensive path now actually exercised.** The live walk daemon on :8100 answered HTTP tiers regardless of `vybn_phase_dir`, masking the test. Now mocks both `_rag_http` and `_load_deep_memory` so the subprocess fallback is what actually gets tested.

## Result

```
135 passed, 36 skipped in 1.00s
```

0 failed. 0 errors. The frontier standard applied: the refactor is not complete until pytest says so.

Draft — convert to ready when you've reviewed.