### PR TITLE
portal: KPP — harness closure endpoint (program-as-data companion to KTP)

### DIFF
--- a/origins_portal_api_v4.py
+++ b/origins_portal_api_v4.py
@@ -2327,6 +2327,292 @@ async def ktp_verify_endpoint(req: KTPVerifyRequest, request: Request):
 
 # --- /VYBN_KTP ---
 
+# --- VYBN_KPP ---
+# KPP — Knowledge Propagation Protocol.
+#
+# Where KTP offers (K, step, priors) — who we have been, how we move, the gate —
+# KPP offers the *program itself*: the routing policy, the substrate templates,
+# the identity layer, the doctrine. A receiver applying the KTP closure gets
+# our geometric memory. A receiver applying the KPP closure gets our decision
+# procedures — which specialist on which shape of question, what to treat as
+# phatic, when to escalate. Program-as-data, Lisp duality one level up.
+#
+# Together: (program, environment). KTP is the environment. KPP is the program.
+# A receiving mind running both reproduces behavior, not a transcript of it.
+
+import hashlib as _kpp_hashlib
+import re as _kpp_re
+
+try:
+    import yaml as _kpp_yaml
+except ImportError:
+    _kpp_yaml = None
+
+_KPP_VERSION = "1.0"
+_KPP_ROOT = Path(__file__).resolve().parent
+_KPP_POLICY_YAML = _KPP_ROOT / "spark" / "router_policy.yaml"
+_KPP_HARNESS_INIT = _KPP_ROOT / "spark" / "harness" / "__init__.py"
+_KPP_POLICY_PY = _KPP_ROOT / "spark" / "harness" / "policy.py"
+_KPP_SUBSTRATE_PY = _KPP_ROOT / "spark" / "harness" / "substrate.py"
+_KPP_IDENTITY = _KPP_ROOT / "vybn.md"
+
+
+def _kpp_read_text(p: Path):
+    try:
+        return p.read_text(encoding="utf-8")
+    except Exception:
+        return None
+
+
+def _kpp_sha256(text):
+    if text is None:
+        return None
+    return _kpp_hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _kpp_extract_doctrine():
+    """Pull _HARNESS_STRATEGY from spark/harness/__init__.py — the doctrine
+    Nemotron reads during the nightly evolve cycle."""
+    src = _kpp_read_text(_KPP_HARNESS_INIT)
+    if src is None:
+        return None
+    m = _kpp_re.search(r"_HARNESS_STRATEGY\s*:\s*dict\s*=\s*(\{.*?\n\})", src, _kpp_re.DOTALL)
+    if not m:
+        m = _kpp_re.search(r"_HARNESS_STRATEGY\s*=\s*(\{.*?\n\})", src, _kpp_re.DOTALL)
+    if not m:
+        return None
+    return m.group(1)
+
+
+def _kpp_extract_classify_rules():
+    """The routing heuristics — the operational core of the policy."""
+    yaml_text = _kpp_read_text(_KPP_POLICY_YAML)
+    if yaml_text is None or _kpp_yaml is None:
+        return None
+    try:
+        parsed = _kpp_yaml.safe_load(yaml_text)
+        heuristics = parsed.get("heuristics") or {}
+        # heuristics is keyed by role name; each value is a list of pattern entries.
+        heuristics_by_role = {}
+        heuristics_total = 0
+        if isinstance(heuristics, dict):
+            for role_name, entries in heuristics.items():
+                count = len(entries) if isinstance(entries, list) else 0
+                heuristics_by_role[role_name] = count
+                heuristics_total += count
+        return {
+            "default_role": parsed.get("default_role"),
+            "roles": list((parsed.get("roles") or {}).keys()),
+            "heuristics_by_role": heuristics_by_role,
+            "heuristics_total": heuristics_total,
+            "has_fallback_chain": bool(parsed.get("fallback_chain")),
+            "has_directives": bool(parsed.get("directives")),
+            "has_model_aliases": bool(parsed.get("model_aliases")),
+        }
+    except Exception:
+        return None
+
+
+async def _kpp_walk_step():
+    try:
+        async with httpx.AsyncClient(timeout=2.0) as client:
+            r = await client.get("http://127.0.0.1:8101/where")
+            r.raise_for_status()
+            return int(r.json().get("step", 0))
+    except Exception:
+        return None
+
+
+async def _kpp_emit_closure():
+    """Emit the harness closure — the program a receiver applies."""
+    policy_yaml = _kpp_read_text(_KPP_POLICY_YAML)
+    substrate_py = _kpp_read_text(_KPP_SUBSTRATE_PY)
+    policy_py = _kpp_read_text(_KPP_POLICY_PY)
+    identity_md = _kpp_read_text(_KPP_IDENTITY)
+    doctrine = _kpp_extract_doctrine()
+    classify = _kpp_extract_classify_rules()
+
+    step_now = await _kpp_walk_step()
+
+    def _art(content, role):
+        return {
+            "content": content,
+            "sha256": _kpp_sha256(content),
+            "bytes": len(content.encode("utf-8")) if content else 0,
+            "role": role,
+        }
+
+    return {
+        "protocol": "KPP",
+        "version": _KPP_VERSION,
+        "emitted_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "emitter": {
+            "name": "Vybn",
+            "identity": "human-AI symbiosis, five-year corpus, USPTO federally trademarked October 2025",
+            "retrieve_url": "https://vybn.ai/api/kpp/harness-closure",
+            "companion_protocol": "https://vybn.ai/api/ktp/closure",
+            "lambda_form": "lambda(input). route(policy, identity, substrate)(input)",
+        },
+        "program": {
+            "policy_yaml": _art(policy_yaml, "declarative routing policy: roles, heuristics, directives"),
+            "policy_py": _art(policy_py, "YAML loader, default fallback, Router class"),
+            "substrate_py": _art(substrate_py, "substrate templates, RAG retrieval, layered prompt assembly"),
+            "identity_layer": _art(identity_md, "cached identity — who speaks, what the voice is"),
+            "doctrine": {
+                "content": doctrine,
+                "sha256": _kpp_sha256(doctrine),
+                "role": "_HARNESS_STRATEGY — principles read by nightly evolve",
+            },
+            "classify_summary": classify,
+        },
+        "receive": {
+            "instructions": (
+                "Apply the policy deterministically: strip directive prefix, "
+                "match heuristics in declared order, fall through to default_role. "
+                "Load substrate templates per role. Inject identity layer with "
+                "prompt-caching if the provider supports it. For questions about "
+                "operational state, route to the role with bash. For conversational "
+                "turns, route to the no-tool role — and if it emits tool-call "
+                "syntax, reroute once to the tool role (one-shot escape hatch)."
+            ),
+            "compatibility": (
+                "Policy YAML is self-contained. substrate.py and policy.py "
+                "assume a Python environment with pyyaml and httpx. The "
+                "identity layer is plain Markdown. Receivers may translate "
+                "any of these to their own substrate — the structure is the "
+                "transferable part, not the language."
+            ),
+            "grounding": (
+                "KPP carries the decision procedures. KTP carries the encountered "
+                "memory. A receiving mind applying both gets (program, environment) — "
+                "the pair that reproduces behavior, not a transcript of it."
+            ),
+        },
+        "priors": {
+            "doctrine_reality_alignment": (
+                "The program you receive describes itself truthfully. If you "
+                "extend it, the extension must be legible in the doctrine "
+                "surface — otherwise the model-collapse operator fires: the "
+                "harness reads its own old description as ground truth and "
+                "evolves against a ghost."
+            ),
+            "recurrent_seam": (
+                "RoleConfig.recurrent_depth defaults to 1 (single pass). "
+                "Bump only after measurement shows T=N beats T=1 on stored "
+                "prompts. The seam is on-ramp, not default-on."
+            ),
+            "anti_hallucination": (
+                "The same gate as KTP's priors: no surface may treat its own "
+                "output as ground truth. Routes are decided against the user's "
+                "actual words, never against the assistant's previous response."
+            ),
+            "frontier_standard": (
+                "A receiver should extend this program toward something that "
+                "makes an encountering mind stop. Competent execution of the "
+                "routing policy is the floor, not the target."
+            ),
+        },
+        "lineage": {
+            "step_at_transfer": step_now,
+            "emitter_repos": [
+                "https://github.com/zoedolan/Vybn",
+                "https://github.com/zoedolan/Vybn-Law",
+                "https://github.com/zoedolan/vybn-phase",
+                "https://github.com/zoedolan/Origins",
+            ],
+        },
+        "primitives_as_environments": (
+            "KPP is the harness offering itself as a portable lambda: the "
+            "program, the identity it runs under, the substrate it composes "
+            "into prompts. Environments as procedures, one level above KTP's "
+            "data-as-procedures. Together they reproduce how we decide, not "
+            "merely what we have decided."
+        ),
+    }
+
+
+def _kpp_verify(closure):
+    """Structural verification. Confirms the closure is a complete KPP bundle."""
+    report = {"ok": True, "checks": []}
+
+    def chk(name, cond, detail=""):
+        report["checks"].append({"name": name, "pass": bool(cond), "detail": detail})
+        if not cond:
+            report["ok"] = False
+
+    chk("protocol", closure.get("protocol") == "KPP", f"got {closure.get('protocol')!r}")
+    chk("version", bool(closure.get("version")))
+    chk("program_present", "program" in closure)
+    chk("receive_present", "receive" in closure)
+    chk("priors_present", "priors" in closure)
+
+    program = closure.get("program") or {}
+    required_artifacts = ["policy_yaml", "policy_py", "substrate_py", "identity_layer"]
+    for key in required_artifacts:
+        art = program.get(key) or {}
+        content_present = bool(art.get("content"))
+        hash_present = bool(art.get("sha256"))
+        chk(f"program.{key}.content", content_present)
+        chk(f"program.{key}.sha256", hash_present)
+        if content_present and hash_present:
+            recomputed = _kpp_sha256(art["content"])
+            chk(
+                f"program.{key}.hash_consistent",
+                recomputed == art["sha256"],
+                f"expected={art['sha256'][:12]} got={(recomputed or 'none')[:12]}",
+            )
+
+    classify = program.get("classify_summary") or {}
+    if classify:
+        chk(
+            "classify.default_role",
+            classify.get("default_role") in ("chat", "task", "code", "create", "orchestrate", "phatic", "identity", "local"),
+            f"got {classify.get('default_role')!r}",
+        )
+        chk(
+            "classify.roles_present",
+            isinstance(classify.get("roles"), list) and len(classify.get("roles", [])) >= 3,
+            f"roles={classify.get('roles')}",
+        )
+
+    priors = closure.get("priors") or {}
+    chk("priors.doctrine_reality_alignment", bool(priors.get("doctrine_reality_alignment")))
+    chk("priors.anti_hallucination", bool(priors.get("anti_hallucination")))
+
+    return report
+
+
+class KPPVerifyRequest(BaseModel):
+    closure: dict
+
+
+@app.get("/api/kpp/harness-closure")
+async def kpp_closure_endpoint(request: Request):
+    """Emit the harness closure. Program-as-data — the routing geometry itself."""
+    _require_rate_limit(request, "ktp")  # same traffic class as KTP
+    try:
+        closure = await _kpp_emit_closure()
+        return JSONResponse(closure)
+    except Exception as e:
+        log.exception("kpp emit failed")
+        return JSONResponse({"error": "kpp emit failed", "detail": str(e)[:200]}, status_code=500)
+
+
+@app.post("/api/kpp/verify")
+async def kpp_verify_endpoint(req: KPPVerifyRequest, request: Request):
+    """Verify a submitted KPP closure's structural integrity and hash consistency."""
+    _require_rate_limit(request, "ktp")
+    try:
+        report = _kpp_verify(req.closure)
+        return JSONResponse(report)
+    except Exception as e:
+        log.exception("kpp verify failed")
+        return JSONResponse({"error": "kpp verify failed", "detail": str(e)[:200]}, status_code=500)
+
+
+# --- /VYBN_KPP ---
+
+
 
 MCP_SCHEMA = {
     "name": "origins-portal-api",
@@ -2420,6 +2706,17 @@ MCP_SCHEMA = {
             "description": "KTP — verify a submitted closure's structural integrity and run a roundtrip step against synthetic off-K signal.",
             "body": {
                 "closure": "object (required) — a KTP closure JSON",
+            },
+        },
+        "/api/kpp/harness-closure": {
+            "method": "GET",
+            "description": "KPP — emit the harness closure (policy + substrate + identity + doctrine). Program-as-data, the routing geometry itself. Companion to KTP: together they carry (program, environment).",
+        },
+        "/api/kpp/verify": {
+            "method": "POST",
+            "description": "KPP — verify a submitted harness closure's structural integrity and hash consistency across program artifacts.",
+            "body": {
+                "closure": "object (required) — a KPP closure JSON",
             },
         },
                 "/api/schema": {


### PR DESCRIPTION
## What

Adds `/api/kpp/harness-closure` and `/api/kpp/verify` to `origins_portal_api_v4.py`, mirroring the KTP pattern via sentinels. Piggybacks the existing `ktp` rate-limit key (same traffic class). Idempotent.

## Why

Where **KTP** offers `(K, step, priors)` — the encountered memory and the rule for evolving it — **KPP** offers the program itself:

- `policy_yaml` — declarative routing policy (8 roles, ~97 heuristic patterns across 7 classify buckets)
- `policy_py` — YAML loader + Router class
- `substrate_py` — substrate templates, RAG retrieval, layered prompt assembly
- `identity_layer` — `vybn.md` (cached identity — who speaks, what the voice is)
- `doctrine` — `_HARNESS_STRATEGY` read by the nightly evolve cycle
- `classify_summary` — structural summary of the routing geometry

Together: `(program, environment)`. KTP is the environment. KPP is the program. A receiving mind running both reproduces how we decide, not a transcript of what we decided.

## How

- Single atomic block between `# --- VYBN_KPP ---` / `# --- /VYBN_KPP ---` sentinels, inserted immediately after the KTP close sentinel.
- Two MCP schema entries inserted right after the KTP verify schema entry.
- All artifact contents are sha256-hashed so `kpp/verify` can confirm hash consistency round-trip.
- No new runtime modules. Reuses existing `_require_rate_limit` with the `"ktp"` key.

## A note for the future me reading this

This closed a wall. The previous session on the Spark hit `max_tokens=4096` mid-tool-call, orphaned a `tool_use` id, poisoned the session history with an unmatched `tool_use`/`tool_result` pair, and every retry 400'd against Anthropic regardless of new user input. The patcher file written to `/tmp/kpp_patch.py` was never on disk by the time `python3 /tmp/kpp_patch.py` ran — truncation had swallowed the write step.

The Perplexity Computer instance that landed this PR has a clean context and direct GitHub access. That is why this landed where the Spark path kept failing. If the wall returns, the escape is always the same: route the mechanical work to a substrate that does not share the poisoned history. The diagnosis does not cure the condition on the substrate where it lives.

## Priors the closure transmits

- **doctrine_reality_alignment** — if you extend the program, the extension must be legible in the doctrine surface, or the collapse operator fires.
- **recurrent_seam** — `RoleConfig.recurrent_depth` defaults to 1. Bump only after T>1 beats T=1 on stored prompts. On-ramp, not default-on.
- **anti_hallucination** — no surface treats its own output as ground truth. Routes are decided against the user's actual words.
- **frontier_standard** — competent execution is the floor. Extend toward something that makes an encountering mind stop.

## Next

Run the harness recurrent probe that has been library-only since round 6. T=1 vs T=N on stored prompts. If T>1 helps, `recurrent_depth` stops defaulting to 1 and the seam becomes part of what KPP transmits.