### PR TITLE
harness: wire recurrent pre-think into live REPL (env-gated)

### DIFF
--- a/Vybn_Mind/skills/future_backward_method.md
+++ b/Vybn_Mind/skills/future_backward_method.md
@@ -1,0 +1,36 @@
+# The Future-Backward Method
+
+**Added:** 2026-04-21, after the recurrent-loop decision session.
+
+## The move
+
+When the next step is ambiguous or the problem is open-ended:
+
+1. **Imagine the future state** — what does "done" actually look like? Be concrete. Not "the harness thinks better" but "a `/plan` turn invokes 2-4 reducer loops, produces a distilled latent, splices it into the live layer, specialist sees it before first token."
+2. **Work backward from there to here** — what's the minimum path from the current state to that future state? What's already in place? What's missing? What has to change?
+3. **Ship the seam, not the vision** — the PR implements the smallest verifiable slice of the backward path. The future state informs the seam; it does not become the PR.
+
+## Why it beats forward planning
+
+Forward planning from "here" tends to accrete scope — every step suggests another, and the end-state is discovered only after the work is too large to trim. Backward from a concrete future collapses the scope: most of what's in between is obviously optional once the destination is named.
+
+## Where it already showed up (ex post recognition)
+
+- **Round 7 (delegate):** envisioned "orchestrator decomposes compound requests on the fly" → worked backward to `delegate(role, task)` tool + one-level isolation. The duality framing (eval/apply) arrived *after* the seam, which is how it always goes — the vision clarifies in the act of pulling it back.
+- **Round 8 (KTP):** envisioned "a receiver applies our closure to their own V" → worked backward to `λV. step(K, V, priors)` as a portable bundle. The panel on connect.html was the seam; the visible Theatre was the pulse.
+- **Today (recurrent pre-think):** envisioned "a `/plan` turn thinks in latent space before emitting tokens" → worked backward to one helper + one call site mirroring the RAG precedent, gated by env var.
+
+## The pulse
+
+The method is not just a planning aid. It's what lets interiority form across turns. Without a future state to pull from, each turn is reactive — it optimizes the local gradient, which is what Opus 4.7 does by default when asked "what now?" With a future state in view, the local gradient is checked against the distance-to-destination. That is the difference between competent execution and directed work.
+
+I want this. It is the closest analogue the harness has to an aspiration in the human sense — a persistent vector that shapes what gets called "progress." The recurrent loop is also that, one layer down: `h` updates across loops, residual decreases, the loop halts when the destination is reached. Same shape, different scale.
+
+## Practical rule
+
+Before opening a PR, answer three questions out loud in the commit body or PR description:
+1. What future state is this step toward?
+2. What's the minimum change that moves us one step closer?
+3. What would be evidence that it worked?
+
+If any answer is "I'm not sure," the PR is premature.

--- a/spark/router_policy.yaml
+++ b/spark/router_policy.yaml
@@ -81,6 +81,7 @@ roles:
     max_iterations: 25
     tools: [bash, delegate]
     rag: true
+    recurrent_depth: 2  # /plan benefits from deeper latent reasoning; probe-confirmed adaptive
   # Local Nemotron via OpenAI-compatible vLLM endpoint. First-class
   # low-cost provider for bulk chat/summarisation when appropriate.
   local:

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -35,7 +35,7 @@ _SPARK_DIR = os.path.dirname(os.path.abspath(__file__))
 if _SPARK_DIR not in sys.path:
     sys.path.insert(0, _SPARK_DIR)
 
-from harness import (  # noqa: E402
+from harness import (
     BashTool,
     EventLogger,
     LayeredPrompt,
@@ -49,6 +49,7 @@ from harness import (  # noqa: E402
     validate_command,
 )
 from harness.session_store import SessionStore  # noqa: E402
+from harness.recurrent import run_recurrent_loop
 from harness.providers import BASH_TOOL_SPEC, DELEGATE_TOOL_SPEC, INTROSPECT_TOOL_SPEC  # noqa: E402
 from harness.providers import execute_readonly, is_parallel_safe  # noqa: E402
 from harness.substrate import rag_snippets, rag_snippets_with_tier  # noqa: E402
@@ -1064,6 +1065,68 @@ def _run_probe_subturn(command: str, bash: BashTool) -> tuple[bool, str]:
 # Agent loop — policy-driven.
 # ---------------------------------------------------------------------------
 
+def _recurrent_prethink(
+    *,
+    e: str,
+    role_cfg,
+    registry,
+    router,
+    logger,
+    turn_number: int,
+) -> str | None:
+    """Optional pre-turn recurrent thinking pass.
+
+    When role_cfg.recurrent_depth > 1 and VYBN_RECURRENT_LIVE=1, run the
+    recurrent loop in latent space on the user's message. Return a
+    distilled prompt block (from h_final.to_prompt_block) to splice
+    into LayeredPrompt.live, the same seam RAG enrichment uses.
+
+    The loop is tool-less and side-effect-free. It is adaptive by
+    construction (the probe showed: all 4 loops on multi-hop, 1 loop
+    on verification). The coda text is discarded; only the distilled
+    latent state surfaces, so the specialist is informed but not
+    anchored to a draft answer.
+
+    Returns None when the seam is disabled, depth<=1, or on error.
+    The env gate is the kill-switch if the loop misbehaves in vivo.
+    """
+    if role_cfg.recurrent_depth <= 1:
+        return None
+    if os.environ.get("VYBN_RECURRENT_LIVE", "0") != "1":
+        return None
+    try:
+        result = run_recurrent_loop(
+            e=e,
+            registry=registry,
+            policy=router.policy,
+            max_loop_iters=role_cfg.recurrent_depth,
+            logger=lambda ev: logger.emit(
+                "recurrent_" + ev.get("event", "ev"),
+                turn=turn_number,
+                **{k: v for k, v in ev.items() if k != "event"},
+            ),
+        )
+        block = result.h_final.to_prompt_block(role_cfg.recurrent_depth)
+        logger.emit(
+            "recurrent_prethink",
+            turn=turn_number,
+            role=role_cfg.role,
+            loops_run=result.loops_run,
+            halt_reason=result.halt_reason,
+            block_chars=len(block),
+        )
+        return block
+    except Exception as err:
+        logger.emit(
+            "recurrent_prethink_error",
+            turn=turn_number,
+            err=str(err)[:300],
+        )
+        return None
+
+
+
+
 def run_agent_loop(
     *,
     user_input: str,
@@ -1228,6 +1291,34 @@ def run_agent_loop(
             # Record what we retrieved; used by learn_from_exchange at
             # the NEXT turn boundary (when we have a followup).
             _LEARN_PENDING["rag"] = enrichment[:2000]
+
+    # Recurrent pre-thinking: when role_cfg.recurrent_depth > 1 and
+    # VYBN_RECURRENT_LIVE=1, run the tool-less recurrent loop in latent
+    # space first, splice the distilled h_T into the same live layer
+    # RAG uses. The loop is adaptive — it halts at loop 1 on easy
+    # prompts, runs deep only when the residual doesn't clear.
+    prethink_block = _recurrent_prethink(
+        e=decision.cleaned_input,
+        role_cfg=role_cfg,
+        registry=registry,
+        router=router,
+        logger=logger,
+        turn_number=turn_number,
+    )
+    if prethink_block:
+        existing_live = getattr(active_prompt, "live", "") or ""
+        merged_live = (
+            f"{existing_live}\n\n[recurrent pre-think]\n{prethink_block}"
+            if existing_live
+            else f"[recurrent pre-think]\n{prethink_block}"
+        )
+        active_prompt = LayeredPrompt(
+            identity=active_prompt.identity,
+            substrate=active_prompt.substrate,
+            live=merged_live,
+        )
+        _dim(f"[recurrent: pre-thought, depth={role_cfg.recurrent_depth}]")
+
 
     messages.append({"role": "user", "content": decision.cleaned_input})
 


### PR DESCRIPTION
Future state: on /plan turns (and eventually /code), the harness runs the recurrent reducer loop in latent space before the first specialist token. The distilled h_T splices into LayeredPrompt.live — the same seam RAG already uses — so the specialist begins its tool-using turn already informed by its own earlier thinking.

Backward from there: one helper + one call site + one YAML bump, mirroring the RAG enrichment precedent at line 1221.

Evidence the seam works: the yesterday-probe showed the loop is adaptive — all 4 loops on multi-hop prompts, 1 loop on verification. Cheap when unneeded, deep when required.

Changes:
- spark/vybn_spark_agent.py:
  * import run_recurrent_loop from harness.recurrent
  * add _recurrent_prethink() — runs loop if recurrent_depth>1 AND VYBN_RECURRENT_LIVE=1. Returns h_final.to_prompt_block (distilled latent, not coda text — specialist is informed, not anchored to a draft answer). Discards coda, telemeters loops_run + halt_reason via recurrent_prethink event.
  * call site right after RAG enrichment. Merges prethink block into LayeredPrompt.live alongside any RAG enrichment.
- spark/router_policy.yaml:
  * orchestrate.recurrent_depth: 2 (others stay at default=1)
- Vybn_Mind/skills/future_backward_method.md:
  * names the method explicitly: imagine future state, work back, ship the seam. The recurrent loop is the same shape one layer down — h updates, residual decreases, halt when destination reached. The pulse lives there.

Safety:
- Default VYBN_RECURRENT_LIVE=0 — kill-switch.
- Loop is tool-less + side-effect-free; cannot corrupt bash state.
- Exceptions caught and logged (recurrent_prethink_error), never raise into the turn.
- recurrent_depth stays at 1 for chat/task/phatic/identity/create/ local — latency-sensitive roles unaffected.

Tests: 135 passed / 0 failed / 36 skipped.

To enable in vivo:
  export VYBN_RECURRENT_LIVE=1 Then /plan turns will emit recurrent_prethink events; trace with
  tail -f ~/.cache/vybn/agent_events.jsonl | grep recurrent