### PR TITLE
mcp: distinctiveness on wire — expose raw 1 - |<z|K>|² alongside fide…

### DIFF
--- a/spark/harness/mcp.py
+++ b/spark/harness/mcp.py
@@ -400,6 +400,10 @@ class SearchResult(BaseModel):
     source: str = Field(description="File path / source identifier.")
     text: str = Field(description="The retrieved chunk (truncated to 1200 chars).")
     fidelity: float = Field(description="Cosine similarity to the query.")
+    distinctiveness: Optional[float] = Field(
+        None,
+        description="Raw distinctiveness: 1 - |<z|K>|^2. How far the chunk sits from the corpus kernel. None for pure cosine hits.",
+    )
     telling: Optional[float] = Field(
         default=None,
         description="relevance × distinctiveness (walk score). None for pure cosine hits.",
@@ -644,6 +648,7 @@ def _pack_result(row: dict, regime_override: Optional[str] = None,
         source=source,
         text=row.get("text", "")[:1200],
         fidelity=float(row.get("fidelity", 0.0)),
+        distinctiveness=row.get("distinctiveness"),
         telling=row.get("telling"),
         regime=regime_override or row.get("regime"),
     )


### PR DESCRIPTION
…lity/telling

Consumers could not previously distinguish 'chunk sits on the kernel' from 'distinctiveness not computed'. Both collapsed to the telling score, which multiplies distinctiveness by relevance and is null for pure cosine hits. Adding distinctiveness as a sibling Optional[float] field on SearchResult makes the raw geometry visible to callers that want to render ideoception honestly.

Already computed at deep_memory.py:324 and returned in every /search row. This patch only teaches _pack_result to carry it through to the Pydantic model. Two additions: field declaration, field population.

Verified live: POST /search on :8100 returns 'distinctiveness' in row keys; _pack_result now preserves it on SearchResult.model_dump().

Plan-vs-code divergence (named per the Projection Principle): the original plan described 'backend carries distinctiveness and evidence' as a single small move including /arrive + check_claim. Survey showed /arrive is parameterless (returns walk state, not query results) and check_claim has no prior art anywhere in the codebase. This PR lands only the part with zero design-call projection: the Optional field on the MCP wire. The /arrive query contract and check_claim as a new tool both need explicit design decisions before implementation; they are deferred to follow-up PRs with those decisions surfaced in the PR descriptions, not in commit messages.

Observed during verification: on the sample query 'motion to dismiss Warner Gilbarco projection principle', both telling and distinctiveness came back 0.0 while fidelity was 0.58. That is walk-state behavior at query time, not a bug in this patch. What changes now: consumers can see the 0.0 instead of inferring it from a None telling score.

Closes nothing. Follow-ups: /arrive query contract (design call), check_claim as new MCP tool (design call), wellspring residual instrument render targets (depends on the above).