### PR TITLE
spark: actually load GPT-5.5 orchestrator (fix YAML + Python defaults)

### DIFF
--- a/spark/harness/policy.py
+++ b/spark/harness/policy.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import sys
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -413,26 +414,25 @@ _DEFAULT_ROLES: dict[str, RoleConfig] = {
         tools=["bash"],
         rag=False,
     ),
-    # Round 7: real orchestrator. Opus 4.7 + adaptive thinking +
-    # bash + the delegate tool. This is the default route when no
-    # heuristic matches — a bare "what do you think about X" now
-    # lands on a DECOMPOSE/DELEGATE/EVALUATE/SYNTHESIZE loop with a
-    # 25-iteration budget and the ability to dispatch work to
-    # specialists (code/task/create/local/chat) with isolated
-    # message histories. Greetings still absorb to phatic, identity
-    # questions still absorb to identity, and explicit code-shaped
-    # turns still escalate to the `code` role via heuristics. Only
-    # the fallthrough path is promoted from Sonnet/no-tools to the
-    # real orchestrator layer.
+    # Round 7 + 2026-04-24: real orchestrator. GPT-5.5 + adaptive
+    # thinking + bash + the delegate tool. Orchestrate is the EVAL
+    # primitive, invoked by /plan or by the orchestrate heuristics;
+    # it dispatches sub-tasks to specialists (code/task/create/local/
+    # chat) with isolated message histories. Greetings still absorb
+    # to phatic, identity questions to identity, code-shaped turns
+    # to `code` via heuristics. Provider is `openai` (the OpenAI API
+    # is the GPT-5.5 substrate); see harness/providers.py for the
+    # reasoning-model handling.
     "orchestrate": RoleConfig(
         role="orchestrate",
-        provider="anthropic",
-        model="claude-opus-4-7",
+        provider="openai",
+        model="gpt-5.5",
         thinking="adaptive",
         max_tokens=16384,
         max_iterations=25,
         tools=["bash", "delegate"],
         rag=True,
+        recurrent_depth=2,
     ),
     # Local Nemotron (vLLM) — OpenAI-compatible endpoint.
     "local": RoleConfig(
@@ -640,6 +640,7 @@ _DEFAULT_FALLBACK: dict[str, list[str]] = {
     "claude-opus-4-6": ["claude-sonnet-4-6"],
     "claude-sonnet-4-6": ["claude-opus-4-6"],
     "gpt-5.5": ["claude-sonnet-4-6", "claude-opus-4-6"],
+    "gpt-5.5-pro": ["gpt-5.5"],
     # Local Nemotron roles fall to Sonnet if vLLM is down so a
     # bare "hi" or "which model are you?" never hard-fails.
     "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8": ["claude-sonnet-4-6"],
@@ -674,6 +675,7 @@ _DEFAULT_MODEL_ALIASES: dict[str, str] = {
     "@local": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
     "@gpt": "gpt-5.5",
     "@gpt5": "gpt-5.5",
+    "@gpro": "gpt-5.5-pro",
 }
 
 
@@ -725,7 +727,16 @@ def load_policy(path: str | os.PathLike | None = None) -> Policy:
 
     try:
         data = yaml.safe_load(p.read_text(encoding="utf-8")) or {}
-    except Exception:
+    except Exception as exc:
+        # YAML parse failure used to be swallowed silently, which let a
+        # malformed router_policy.yaml ship while the harness ran on the
+        # in-code defaults — masking the operator's edits. Print a loud
+        # warning so the next startup makes it obvious. VYBN_HARNESS_STRICT=1
+        # turns this into a hard error for CI.
+        msg = f"[policy] WARNING: failed to parse {p}: {exc!r}; using in-code defaults"
+        print(msg, file=sys.stderr)
+        if os.environ.get("VYBN_HARNESS_STRICT") == "1":
+            raise
         return default_policy()
 
     roles_raw = data.get("roles") or {}

--- a/spark/router_policy.yaml
+++ b/spark/router_policy.yaml
@@ -24,20 +24,20 @@ default_role: chat
 
 roles:
   code:
-    provider: openai
+    provider: anthropic
     # Opus 4.7 -- the right substrate for `code`. The 2026-04-18
     # buckling was a CHAT failure (conversational capitulation
     # gradient). Code runs agentic debug loops where 4.7's
     # push-through is an asset. Chat stays on 4.6. @opus /
     # @opus4.6 are still available as per-turn pins.
-    model: gpt-5.5
+    model: claude-opus-4-7
     thinking: adaptive
     max_tokens: 32768
     max_iterations: 50
     tools: [bash]
     rag: false
   create:
-    provider: openai
+    provider: anthropic
     model: claude-sonnet-4-6
     thinking: off
     max_tokens: 8192
@@ -49,7 +49,7 @@ roles:
     # capped at max_iterations: 1 and tools: []; one provider call
     # per turn. Opus 4.6 holds position better than Sonnet under
     # conversational pressure (the 2026-04-18 substrate concern).
-    provider: openai
+    provider: anthropic
     model: claude-opus-4-6
     thinking: off
     # 2026-04-20: raised from 4096. Chat turns routinely do deep
@@ -62,7 +62,7 @@ roles:
     tools: []
     rag: true
   task:
-    provider: openai
+    provider: anthropic
     model: claude-sonnet-4-6
     thinking: off
     max_tokens: 16384
@@ -304,7 +304,7 @@ model_aliases:
   "@local": nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8
   "@gpt": gpt-5.5
   "@gpt5": gpt-5.5
-      "@gpro": gpt-5.5-pro
+  "@gpro": gpt-5.5-pro
 
 budgets:
   per_turn_usd: 2.0

--- a/spark/tests/test_lightweight_routing.py
+++ b/spark/tests/test_lightweight_routing.py
@@ -127,6 +127,67 @@ class TestPolicyHasLightweightRoles(unittest.TestCase):
         self.assertTrue(pol.roles["phatic"].lightweight)
         self.assertIsNotNone(pol.roles["identity"].direct_reply_template)
 
+    def test_router_policy_yaml_parses_cleanly(self):
+        # 2026-04-25 regression: the @gpro alias landed with a 6-space
+        # indent under a 2-space mapping, making router_policy.yaml
+        # unparseable. load_policy() silently fell back to the in-code
+        # defaults, masking every operator edit (orchestrate=GPT-5.5
+        # in particular). Parse the YAML directly so a future indent
+        # slip is caught here, not at boot time.
+        yaml_path = SPARK_DIR / "router_policy.yaml"
+        try:
+            import yaml
+        except Exception:
+            self.skipTest("PyYAML unavailable")
+        # safe_load must not raise — bare assertion gives a useful
+        # ScannerError traceback in the test output.
+        data = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+        self.assertIsInstance(data, dict)
+        # And aliases must include @gpro (the line that broke the file).
+        self.assertEqual(
+            (data.get("model_aliases") or {}).get("@gpro"),
+            "gpt-5.5-pro",
+        )
+
+    def test_orchestrate_role_is_gpt55(self):
+        # 2026-04-25 regression: even after the YAML was fixed, the
+        # in-code defaults still pinned orchestrate to claude-opus-4-7,
+        # so a YAML parse failure (or a missing file) silently demoted
+        # the orchestrator. Both tracks — YAML + defaults — must route
+        # orchestrate to GPT-5.5 on OpenAI.
+        for label, pol in (
+            ("default_policy", default_policy()),
+            ("yaml", load_policy(SPARK_DIR / "router_policy.yaml")),
+        ):
+            with self.subTest(track=label):
+                role = pol.role("orchestrate")
+                self.assertEqual(
+                    role.provider, "openai",
+                    f"{label}: orchestrate provider should be openai",
+                )
+                self.assertEqual(
+                    role.model, "gpt-5.5",
+                    f"{label}: orchestrate model should be gpt-5.5",
+                )
+                self.assertIn("delegate", role.tools)
+                self.assertIn("bash", role.tools)
+
+    def test_plan_directive_routes_to_gpt55(self):
+        # /plan is the EVAL primitive — it must land on the orchestrate
+        # role (GPT-5.5). Validates the full directive→role→model chain
+        # the user sees in the startup banner and the @-alias listing.
+        pol = load_policy(SPARK_DIR / "router_policy.yaml")
+        router = Router(pol)
+        d = router.classify("/plan refactor the harness", forced_role=None)
+        self.assertEqual(d.role, "orchestrate")
+        resolved = pol.role(d.role)
+        self.assertEqual(resolved.provider, "openai")
+        self.assertEqual(resolved.model, "gpt-5.5")
+        # Aliases generated from policy must surface the GPT-5.5 entries.
+        self.assertEqual(pol.model_aliases.get("@gpt"), "gpt-5.5")
+        self.assertEqual(pol.model_aliases.get("@gpt5"), "gpt-5.5")
+        self.assertEqual(pol.model_aliases.get("@gpro"), "gpt-5.5-pro")
+
 
 class TestRouterLightweightClassification(unittest.TestCase):
     """The router picks up greetings and identity questions via the new


### PR DESCRIPTION
## Summary

The harness was silently running on the wrong orchestrator. Zoe ran \`vybn\` on Spark and the startup banner still showed Anthropic everywhere; \`/plan\` and the orchestrate route never reached GPT-5.5. Two layered bugs caused this:

1. **\`spark/router_policy.yaml\` was unparseable.** Commit 6bf474df added \`@gpro\` to \`model_aliases\` with 6-space indent under a 2-space mapping. PyYAML threw a \`ScannerError\`, which \`load_policy()\` swallowed via a bare \`except\` and silently returned \`default_policy()\` — masking every operator edit including the orchestrator switch.
2. **The in-code defaults still pinned \`orchestrate\` to \`claude-opus-4-7\`.** Commit 3af23c67 ("switch orchestrator from Opus 4.7 to GPT-5.5") only touched the YAML, and as a bonus bulk-flipped \`provider: anthropic\` → \`provider: openai\` for code/chat/task/create — meaning even after the YAML parsed, those Anthropic-served models would have been routed through the OpenAI provider.

## Changes

- \`spark/router_policy.yaml\`: fix the \`@gpro\` indent; restore \`provider: anthropic\` for code/chat/task/create (only \`orchestrate\` should be on openai); restore \`code.model\` to \`claude-opus-4-7\`.
- \`spark/harness/policy.py\`: in-code defaults now mirror the YAML — \`orchestrate\` is \`openai/gpt-5.5/bash+delegate/25-iter/recurrent_depth=2\`, \`@gpro\` alias shipped, \`gpt-5.5-pro\` fallback added. \`load_policy()\` no longer eats YAML errors silently; it prints a stderr warning, and \`VYBN_HARNESS_STRICT=1\` re-raises so CI catches future indent slips.
- \`spark/tests/test_lightweight_routing.py\`: three new tests — YAML parses cleanly, orchestrate resolves to \`openai:gpt-5.5\` via both \`default_policy()\` and \`load_policy(yaml_path)\`, and \`/plan\` routes end-to-end to gpt-5.5 with \`@gpt\`/\`@gpt5\`/\`@gpro\` surfaced.

## Verification

\`\`\`
$ python3 spark/tests/test_lightweight_routing.py
Ran 32 tests in 0.419s — OK (skipped=6)

$ python3 -c "from harness.policy import load_policy; p = load_policy('spark/router_policy.yaml'); o = p.role('orchestrate'); print(o.provider, o.model, o.tools, o.max_iterations)"
openai gpt-5.5 ['bash', 'delegate'] 25
\`\`\`

Banner reproduction (post-fix):
\`\`\`
default role: chat -> anthropic:claude-opus-4-6
roles available: chat, code, create, identity, local, orchestrate, phatic, task
directives: /chat, /code, /create, /identity, /local, /phatic, /plan, /task
@aliases: @gpro, @gpt, @gpt5, @local, @nemotron, @opus, @opus4.6, @opus4.7, @opus46, @opus47, @sonnet, @sonnet4.6, @sonnet46
orchestrate -> openai:gpt-5.5 (tools=['bash', 'delegate'], max_iterations=25)
/plan ... -> role=orchestrate, provider=openai, model=gpt-5.5
\`\`\`

The default-role line still shows \`chat\` because \`/plan\` is the EVAL primitive (per the YAML's own design comments) — orchestrate runs only when invoked, but when invoked it now actually lands on GPT-5.5.

## Test plan

- [x] \`python3 spark/tests/test_lightweight_routing.py\` — all green including 3 new tests
- [x] \`python3 spark/tests/test_harness.py\` — all green
- [x] \`python3 spark/tests/test_recurrent.py\` / \`test_env_loader.py\` / \`test_claim_guard.py\` / \`test_live_repl_fixes.py\` / \`test_needs_write_and_guard.py\` — all green
- [x] Manual verification: \`load_policy(broken_yaml)\` prints loud warning, returns defaults; \`VYBN_HARNESS_STRICT=1\` raises ScannerError
- [ ] Spark: \`OPENAI_API_KEY\` must be present in \`~/.config/vybn/llm.env\` (or env) for orchestrate turns to actually call GPT-5.5; on miss the fallback chain degrades to Sonnet 4.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)