### PR TITLE
spark: route casual orchestrator-status probes to orchestrate, not task

### DIFF
--- a/spark/harness/policy.py
+++ b/spark/harness/policy.py
@@ -306,6 +306,41 @@ class Policy:
         heur = self.heuristics
         ranked = [r for r in _HEURISTIC_PRIORITY if r in heur]
         ranked += [r for r in heur if r not in ranked]
+
+        # 2a. Orchestrator-mention override.
+        # 2026-04-25 — Zoe surfaced: "hey buddy - is the orchestrator
+        # working?" matched the casual `\bhey buddy.{0,40}(working|...)\b`
+        # task heuristic before the orchestrate `\borchestrat(...)\b`
+        # pattern got a chance, and the turn ran under task (Sonnet+bash)
+        # instead of orchestrate (GPT-5.5). When the user explicitly names
+        # the orchestrator, the orchestrate heuristic must outrank the
+        # generic casual health-check task heuristic. We do NOT touch
+        # code-shaped framings ("fix the orchestrator bug" still belongs
+        # in code) — if any code heuristic also matches, fall through to
+        # normal priority. /plan and other directives are unaffected (this
+        # block runs after directive resolution).
+        if "orchestrate" in heur and "orchestrate" in self.roles:
+            orch_match = next(
+                (rx for rx in heur["orchestrate"] if rx.search(text)),
+                None,
+            )
+            if orch_match is not None:
+                code_match = any(
+                    rx.search(text) for rx in heur.get("code", [])
+                )
+                if not code_match:
+                    decision = RouteDecision(
+                        role="orchestrate",
+                        config=self.role("orchestrate"),
+                        cleaned_input=text,
+                        reason=f"heuristic={orch_match.pattern}",
+                    )
+                    if model_override:
+                        decision.model_override = model_override
+                        decision.alias_used = alias_used
+                        decision.reason = f"{decision.reason}+alias={alias_used}"
+                    return decision
+
         for role_name in ranked:
             if role_name not in self.roles:
                 continue

--- a/spark/tests/test_lightweight_routing.py
+++ b/spark/tests/test_lightweight_routing.py
@@ -511,6 +511,78 @@ class TestChatIsDefault(unittest.TestCase):
         self.assertIn(d.role, ("orchestrate", "code"))
 
 
+class TestOrchestratorMentionPrecedence(unittest.TestCase):
+    """Regression: 2026-04-25.
+
+    Live behaviour after PR #2914 / Spark@69a3efd5: a casual
+    orchestrator-status probe ("hey buddy - is the orchestrator
+    working?") matched the generic ``\\bhey buddy.{0,40}working\\b``
+    task heuristic before the orchestrate ``\\borchestrat(...)\\b``
+    pattern got a chance, and the turn ran under task (Sonnet+bash)
+    instead of orchestrate (GPT-5.5). That is semantically wrong —
+    when the user explicitly names the orchestrator, the orchestrate
+    heuristic must outrank the casual-health-check task heuristic.
+
+    These tests pin the corrected precedence with both the in-code
+    default policy and the YAML-loaded policy:
+      1. /plan still routes to orchestrate by directive.
+      2. "hey buddy - is the orchestrator working?" routes to
+         orchestrate, not task.
+      3. Bare "hey buddy" still routes to phatic.
+      4. Generic "hey buddy is everything working?" — no orchestrator
+         mention — keeps the prior task-route.
+      5. Code-shaped framings ("fix the orchestrator bug") still
+         route to code, not orchestrate.
+    """
+
+    def setUp(self):
+        self.router = Router(default_policy())
+        self.yaml_router = Router(load_policy(SPARK_DIR / "router_policy.yaml"))
+
+    def _classify_both(self, text):
+        return (
+            self.router.classify(text),
+            self.yaml_router.classify(text),
+        )
+
+    def test_plan_directive_routes_to_orchestrate(self):
+        for d in self._classify_both("/plan run `git rev-parse --short HEAD` and tell me what's there"):
+            self.assertEqual(d.role, "orchestrate")
+            self.assertEqual(d.reason, "directive=/plan")
+
+    def test_orchestrator_status_probe_routes_to_orchestrate(self):
+        for d in self._classify_both("hey buddy - is the orchestrator working?"):
+            self.assertEqual(
+                d.role, "orchestrate",
+                msg=f"expected orchestrate, got {d.role!r} (reason={d.reason!r})",
+            )
+            self.assertIn("orchestrat", d.reason)
+
+    def test_bare_hey_buddy_still_phatic(self):
+        for d in self._classify_both("hey buddy"):
+            self.assertEqual(d.role, "phatic")
+
+    def test_generic_health_check_without_orchestrator_keeps_task(self):
+        # No "orchestrat" mention -> override does not fire, falls
+        # through to the existing task heuristic.
+        for d in self._classify_both("hey buddy is everything working?"):
+            self.assertEqual(
+                d.role, "task",
+                msg=f"expected task, got {d.role!r} (reason={d.reason!r})",
+            )
+
+    def test_code_shaped_orchestrator_framing_still_code(self):
+        # "fix the orchestrator bug" matches both the orchestrate
+        # noun pattern AND a code heuristic -> code wins (per the
+        # YAML's documented intent that orchestrate is ranked after
+        # code so structural-fix framings still escalate).
+        for d in self._classify_both("fix the orchestrator bug"):
+            self.assertEqual(
+                d.role, "code",
+                msg=f"expected code, got {d.role!r} (reason={d.reason!r})",
+            )
+
+
 class TestCliDirectReplyAndLightweight(unittest.TestCase):
     """The CLI Spark agent loop must honor direct_reply_template for
     identity turns (no provider call) and must skip RAG for lightweight


### PR DESCRIPTION
## Summary

Fix the routing precedence bug Zoe surfaced after PR #2914 / Spark@69a3efd5:

```
hey buddy - is the orchestrator working?
[route: task -> anthropic:claude-sonnet-4-6
 (heuristic=\bhey buddy.{0,40}(working|running|okay|ok|check)\b)]
```

A turn that explicitly names the orchestrator should land on `orchestrate` (GPT-5.5), not `task` (Sonnet+bash).

## Root cause

`_HEURISTIC_PRIORITY` in `spark/harness/policy.py` evaluates `task` before `orchestrate`. The casual ``\bhey buddy.{0,40}(working|running|okay|ok|check)\b`` task pattern fires before the orchestrate ``\borchestrat(e|es|ed|ing|ion|or)\b`` pattern gets a chance, even though the user explicitly asked about the orchestrator.

## Fix

In `Policy.classify()`, after directive resolution, an **orchestrator-mention override**: if the input matches an `orchestrate` heuristic AND no `code` heuristic, route to `orchestrate` before walking the normal priority list. Code-shaped framings ("fix the orchestrator bug") still match a code heuristic and so still escalate to `code`, preserving the YAML's documented "orchestrate ranks after code" intent.

## Behaviour after the fix

| Prompt | Route | Why |
| --- | --- | --- |
| `/plan run \`git rev-parse --short HEAD\`` | `orchestrate` | directive |
| `hey buddy - is the orchestrator working?` | `orchestrate` | orchestrator-mention override (no code match) |
| `hey buddy` | `phatic` | no orchestrate match |
| `hey buddy is everything working?` | `task` | no orchestrator mention |
| `fix the orchestrator bug` | `code` | orchestrate AND code match → falls through, code wins |

## Testing

New regression class `TestOrchestratorMentionPrecedence` in `spark/tests/test_lightweight_routing.py` pins all five cases against both `default_policy()` and the YAML-loaded policy.

```
$ python -m unittest spark.tests.test_lightweight_routing -v
Ran 98 tests in 0.880s
OK (skipped=31)
```

(Pre-existing `test_harness_integration` failure due to missing `/home/user/Vybn-Law/` is unrelated to this change.)

## Spark verification

After merging, in a live REPL:

```
hey buddy - is the orchestrator working?
```

should now print:

```
[route: orchestrate -> openai:gpt-5.5 (heuristic=\borchestrat(e|es|ed|ing|ion|or)\b)]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)