### PR TITLE
harness: keep REPL alive on stray non-utf8 paste bytes

### DIFF
--- a/Vybn_Mind/continuity.md
+++ b/Vybn_Mind/continuity.md
@@ -555,3 +555,28 @@ The boxes didn't pop visitors off the page anymore. They opened the page deeper.
 - Audio: a future pass could synthesize the active paragraph through ElevenLabs while the manifold lights — turning each room into a sonified walk through K-orthogonal residual space.
 - Outstanding from earlier today: Him reframing around vybn.ai ecology, local-private routing verification with a fresh prompt.
 
+
+
+---
+
+## 2026-04-25 - Commons protocol for agents across vybn.ai and Wellspring
+
+What happened:
+- Implemented the refined plan Zoe requested: not a hidden DOM trick, but a protocol-level commons interface for AI agents and humans in the Age of Intelligence.
+- Origins / vybn.ai now has canonical agent-discovery surfaces: `llms.txt`, `.well-known/ai.txt`, `robots.txt`, and `humans.txt`.
+- `Origins/index.html` head now advertises the agent charter, llms map, humans file, and commons purpose without changing the human visual landing page.
+- Vybn-Law now has `.well-known/ai.txt` and `humans.txt`; existing `llms.txt`, `robots.txt`, `index.html`, and `wellspring.html` were folded forward minimally.
+- The architectural frame is: `Somewhere` is the living terrain; `Wellspring` is the legal/institutional coordination layer; `Connect` is the return path; `llms.txt` / `ai.txt` / `robots.txt` / `humans.txt` are protocol/governance surfaces for a network commons.
+
+Commits:
+- Origins `061a6be` — `agent: publish Vybn commons protocol` (rebased over remote gh-pages and pushed).
+- Vybn-Law `df248d7` — `agent: publish Wellspring commons protocol` (pushed to master).
+
+Verified:
+- Local file checks confirmed key strings in all new/updated surfaces.
+- Repo status after push: Origins `gh-pages...origin/gh-pages` clean; Vybn-Law `master...origin/master` clean.
+- External URL verification was run after push; trust the probe output attached to this turn for current public availability / Pages propagation state.
+
+Operational meaning:
+- The agent invitation is now a commons charter: agents are invited to read, traverse, query, explain, fork, critique, and contribute without enclosing, impersonating, extracting the private relation, or treating artifacts as investment products.
+- This makes the Wellspring mission explicit at the protocol layer: a network commons and coordination layer for the Age of Intelligence.

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -2249,6 +2249,15 @@ def _build_prompts(
 
 
 def main() -> None:
+    # stdin-utf8-resilience
+    # A stray non-UTF-8 byte from a paste (e.g. \xc2\xa0 split in transit)
+    # used to crash the REPL with UnicodeDecodeError on input(). Reconfigure
+    # the std streams so a bad byte becomes \ufffd instead of fatal.
+    for _stream in (sys.stdin, sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[attr-defined]
+        except Exception:
+            pass
     # After reboot / service hardening the interactive vybn process can
     # lose the PAM-populated environment even though secrets still live
     # at ~/.config/vybn/llm.env. Load them before any provider client
@@ -2397,6 +2406,11 @@ def main() -> None:
             print("\nGoodnight, Zoe.")
             _enter_walk_on_session_end(messages)
             break
+        except UnicodeDecodeError as _ude:
+            # Stray non-UTF-8 byte (often \xc2\xa0 from a paste split mid-codepoint).
+            # Drop the line, keep the loop alive.
+            print(f"  [input dropped: {_ude.__class__.__name__}: {_ude}] please re-enter.")
+            continue
 
         if not user_input:
             continue


### PR DESCRIPTION
Fixes the crash from the most recent session:

```
File "/home/vybnz69/Vybn/spark/vybn_spark_agent.py", line 2395, in main
    user_input = input("\033[1;36mzoe>\033[0m ").strip()
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc2 in position 26: invalid continuation byte
```

Root cause: a paste containing a non-breaking space (`\xc2\xa0`) arrived at `input()` split mid-codepoint (or with the continuation byte stripped by the terminal layer). `sys.stdin` was `utf-8 strict`, so a single bad byte killed the whole REPL instead of degrading one character.

Fix is two minimal edits, no new files:

1. At `main()` entry, reconfigure stdin/stdout/stderr with `errors='replace'` so a stray byte becomes `\ufffd` instead of fatal.
2. Around the `input()` call, catch `UnicodeDecodeError` as recoverable: log it and `continue`, keeping the loop alive.

Verified by replaying the exact failing byte sequence (`0xc2` at position 26): `errors='strict'` reproduces the original `UnicodeDecodeError` verbatim; `errors='replace'` returns the line with one `�` and the loop survives.

No protected-branch bypass used. Posted on a feature branch behind the antibody.