### PR TITLE
spark: provider import isolation + correct vybn launcher

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,11 +6,34 @@ build-backend = "setuptools.build_meta"
 name = "vybn"
 version = "0.1.0"
 requires-python = ">=3.10"
-dependencies = ["fastmcp>=3.1"]
+dependencies = [
+    "fastmcp>=3.1",
+    "pydantic>=2",
+    "pyyaml>=6",
+    # Provider SDKs are imported lazily by AnthropicProvider /
+    # OpenAIProvider, but the live REPL routes turns to either provider
+    # by user alias (`@gpt`, `@opus`, `@sonnet`). Declaring them here
+    # means a fresh `pip install -e .` brings everything the harness
+    # needs to dispatch any role without manual SDK installs.
+    "anthropic>=0.39",
+    "openai>=1.40",
+    "requests>=2.31",
+    "certifi>=2024.2",
+]
 
 [project.scripts]
-vybn = "harness.mcp:main"
+# `vybn` launches the Spark Agent REPL (multimodel harness). The MCP
+# surface is a different shape; expose it as `vybn-mcp` for callers
+# who want the FastMCP server.
+vybn = "vybn_spark_agent:main"
+vybn-mcp = "harness.mcp:main"
+
+[tool.setuptools]
+py-modules = ["vybn_spark_agent"]
 
 [tool.setuptools.packages.find]
 where = ["spark"]
+
+[tool.setuptools.package-dir]
+"" = "spark"
 

--- a/spark/harness/providers.py
+++ b/spark/harness/providers.py
@@ -706,13 +706,22 @@ class AnthropicProvider:
     name = "anthropic"
 
     def __init__(self, client: Any | None = None, api_key: str | None = None) -> None:
-        if client is not None:
-            self.client = client
-        else:
+        # Defer the SDK import until first use. Constructing this provider
+        # for a fallback role must not pull in `anthropic` when the primary
+        # route never reaches it — selecting an OpenAI alias on a host
+        # without `anthropic` installed used to crash here even though the
+        # turn never needed it.
+        self._client = client
+        self._api_key = api_key
+
+    @property
+    def client(self) -> Any:
+        if self._client is None:
             import anthropic  # type: ignore
-            self.client = anthropic.Anthropic(
-                api_key=api_key or os.environ.get("ANTHROPIC_API_KEY"),
+            self._client = anthropic.Anthropic(
+                api_key=self._api_key or os.environ.get("ANTHROPIC_API_KEY"),
             )
+        return self._client
 
     @staticmethod
     def _normalize_messages_for_anthropic(messages: list[dict]) -> list[dict]:

--- a/spark/tests/test_harness.py
+++ b/spark/tests/test_harness.py
@@ -592,6 +592,177 @@ class TestProviderRegistry(unittest.TestCase):
         self.assertIsNot(p1, p2)
 
 
+class TestProviderImportIsolation(unittest.TestCase):
+    """Constructing a provider must NOT pull in the other provider's SDK.
+
+    Live regression: selecting `@gpt are you with me, buddy?` on a host
+    without `anthropic` installed crashed with ModuleNotFoundError because
+    fallback chain construction eagerly built an AnthropicProvider — even
+    though the user pinned an OpenAI model and the OpenAI primary never
+    failed. The fix moved the SDK import out of __init__ and into a lazy
+    `client` property; building the provider must stay cheap.
+    """
+
+    def test_openai_provider_construction_does_not_import_anthropic(self):
+        # Block `anthropic` in sys.modules so an accidental import raises.
+        # OpenAIProvider construction must not trip the gate.
+        from harness.providers import OpenAIProvider
+        saved = sys.modules.pop("anthropic", None)
+        sys.modules["anthropic"] = None  # type: ignore[assignment]
+        try:
+            prov = OpenAIProvider(api_key="EMPTY")
+            self.assertEqual(prov.name, "openai")
+        finally:
+            if saved is not None:
+                sys.modules["anthropic"] = saved
+            else:
+                sys.modules.pop("anthropic", None)
+
+    def test_anthropic_provider_construction_does_not_import_anthropic(self):
+        # __init__ must defer the SDK import so the registry can hold
+        # the provider as a fallback option even when the SDK is absent.
+        # Only when `.client` is touched (or stream() runs) does the
+        # import fire.
+        from harness.providers import AnthropicProvider
+        saved = sys.modules.pop("anthropic", None)
+        sys.modules["anthropic"] = None  # type: ignore[assignment]
+        try:
+            prov = AnthropicProvider()
+            self.assertEqual(prov.name, "anthropic")
+            with self.assertRaises((ImportError, TypeError)):
+                # Touching the property triggers the lazy import — and
+                # because we sentineled `anthropic` to None above, the
+                # import fails. Either ImportError (missing) or
+                # TypeError (None is not a module) is acceptable.
+                _ = prov.client
+        finally:
+            if saved is not None:
+                sys.modules["anthropic"] = saved
+            else:
+                sys.modules.pop("anthropic", None)
+
+    def test_anthropic_provider_with_injected_client_skips_sdk(self):
+        # The harness tests construct providers with a fake client to
+        # avoid hitting the SDK; that path must keep working.
+        from harness.providers import AnthropicProvider
+        sentinel = object()
+        prov = AnthropicProvider(client=sentinel)
+        self.assertIs(prov.client, sentinel)
+
+
+class TestFallbackConstructionIsLazy(unittest.TestCase):
+    """The fallback chain must not instantiate every provider up front.
+
+    Live regression (2026-04-27): _stream_with_fallback used to call
+    registry.get(fb_cfg) for every fallback model before the primary
+    even ran. Selecting an OpenAI alias on a host missing `anthropic`
+    crashed inside the fallback construction even though the primary
+    OpenAI call would have succeeded. Fix: build fallback providers
+    lazily, only when we actually walk to that link.
+    """
+
+    def test_primary_succeeds_without_constructing_fallback(self):
+        import vybn_spark_agent as agent
+        from harness.policy import RoleConfig, default_policy
+
+        policy = default_policy()
+        # Primary points at gpt-5.5; default fallback chain pivots to
+        # claude-sonnet-4-6 then claude-opus-4-6. We expect the primary
+        # to win and neither Claude fallback to be constructed.
+        primary_cfg = RoleConfig(
+            role="orchestrate", provider="openai", model="gpt-5.5",
+        )
+
+        constructed: list[str] = []
+
+        class _DummyHandle:
+            pass
+
+        class _DummyOpenAI:
+            def stream(self, **_kw):
+                return _DummyHandle()
+
+        class _RecordingRegistry:
+            def get(self, cfg):
+                constructed.append(cfg.model)
+                return _DummyOpenAI()
+
+        class _DummyLogger:
+            def emit(self, *_a, **_kw):  # noqa: D401 — no-op
+                pass
+
+        registry = _RecordingRegistry()
+        primary = _DummyOpenAI()
+
+        handle, cfg, prov = agent._stream_with_fallback(
+            router=type("R", (), {"policy": policy})(),
+            registry=registry,
+            role_cfg=primary_cfg,
+            provider=primary,
+            system_prompt=None,
+            messages=[],
+            tools=[],
+            logger=_DummyLogger(),
+            turn_number=1,
+            retries=0,
+        )
+        self.assertIsInstance(handle, _DummyHandle)
+        self.assertIs(cfg, primary_cfg)
+        # The primary was passed in directly (not constructed via the
+        # registry), and no fallback was reached, so the registry must
+        # never have been asked for any model.
+        self.assertEqual(constructed, [])
+
+    def test_walks_to_lazy_fallback_when_primary_fails(self):
+        import vybn_spark_agent as agent
+        from harness.policy import RoleConfig, default_policy
+
+        policy = default_policy()
+        primary_cfg = RoleConfig(
+            role="orchestrate", provider="openai", model="gpt-5.5",
+        )
+
+        constructed: list[str] = []
+
+        class _DummyHandle:
+            pass
+
+        class _FailingPrimary:
+            def stream(self, **_kw):
+                raise RuntimeError("OpenAIProvider needs either the openai SDK or requests")
+
+        class _DummyFallback:
+            def stream(self, **_kw):
+                return _DummyHandle()
+
+        class _RecordingRegistry:
+            def get(self, cfg):
+                constructed.append(cfg.model)
+                return _DummyFallback()
+
+        class _DummyLogger:
+            def emit(self, *_a, **_kw):
+                pass
+
+        handle, cfg, prov = agent._stream_with_fallback(
+            router=type("R", (), {"policy": policy})(),
+            registry=_RecordingRegistry(),
+            role_cfg=primary_cfg,
+            provider=_FailingPrimary(),
+            system_prompt=None,
+            messages=[],
+            tools=[],
+            logger=_DummyLogger(),
+            turn_number=1,
+            retries=0,
+        )
+        self.assertIsInstance(handle, _DummyHandle)
+        # First fallback (claude-sonnet-4-6) was constructed lazily
+        # only after the primary failed. Subsequent fallback models in
+        # the chain may also have been constructed; what matters is
+        # the registry was not touched before the primary call.
+        self.assertGreaterEqual(len(constructed), 1)
+        self.assertEqual(constructed[0], "claude-sonnet-4-6")
 
 
 class TestHimOSHarnessBridge(unittest.TestCase):

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -1,4 +1,4 @@
-#!/home/vybnz69/Vybn/.venv/bin/python3
+#!/usr/bin/env python3
 """
 Vybn Spark Agent — multimodel harness edition
 =============================================
@@ -998,15 +998,38 @@ def _stream_with_fallback(
         if _m.get("role") == "assistant":
             _m["content"] = _sanitize_assistant_content(_m.get("content"))
 
-    attempts = [(role_cfg, provider)]
+    # Build the attempt list as (cfg, provider_factory) pairs so each
+    # fallback's provider is constructed only when we actually walk to
+    # it. Eagerly calling registry.get(fb_cfg) used to import every
+    # provider's SDK up front — selecting an OpenAI alias on a host
+    # missing `anthropic` would fail here even though the primary route
+    # had no need for it. The factory closes over registry so the same
+    # registered instance is returned on subsequent attempts (the
+    # registry caches by provider/base_url).
+    attempts: list[tuple[Any, Any]] = [(role_cfg, lambda p=provider: p)]
     for fb_model in router.policy.fallback_chain.get(role_cfg.model, []):
         fb_cfg = _resolve_fallback(router.policy, role_cfg, fb_model)
         if fb_cfg is None:
             continue
-        attempts.append((fb_cfg, registry.get(fb_cfg)))
+        attempts.append((fb_cfg, lambda c=fb_cfg: registry.get(c)))
 
     last_exc = None
-    for cfg, prov in attempts:
+    for cfg, prov_factory in attempts:
+        try:
+            prov = prov_factory()
+        except Exception as e:  # noqa: BLE001 — missing SDK is one such failure
+            last_exc = e
+            _dim(
+                f"[fallback {cfg.provider}:{cfg.model} unavailable: "
+                f"{type(e).__name__}: {_sanitize_provider_error(e)}]"
+            )
+            logger.emit(
+                "fallback_unavailable",
+                turn=turn_number,
+                model=cfg.model,
+                reason=str(e)[:200],
+            )
+            continue
         for attempt in range(retries + 1):
             try:
                 handle = prov.stream(


### PR DESCRIPTION
## Summary
- **Lazy fallback construction**: `_stream_with_fallback` no longer instantiates every provider in the fallback chain up front. Each fallback is built via a factory closure, so selecting an OpenAI alias on a host without `anthropic` no longer crashes during attempt-list assembly. Construction failures emit a `fallback_unavailable` event and skip to the next link.
- **Lazy `anthropic` SDK import**: moved the SDK import out of `AnthropicProvider.__init__` and into a `client` property. The registry can hold an Anthropic-flavoured fallback even when the SDK is absent; the import only fires when a turn actually streams through it.
- **`vybn` console script repoint**: `pyproject.toml` previously mapped `vybn` to `harness.mcp:main` (the MCP server), not the Spark Agent REPL Zoe runs. Now `vybn` → `vybn_spark_agent:main`, and the MCP entrypoint is exposed as `vybn-mcp`. setuptools generates the wrapper against the install env's Python, so `pip install -e .` inside `~/Vybn/.venv` produces a correctly-shebanged launcher automatically.
- **Declared provider deps**: added `anthropic`, `openai`, `requests`, `certifi`, `pydantic`, `pyyaml` to `[project] dependencies` so `pip install -e .` brings them into the venv — no more "openai is in user/global packages but not the venv".
- **Portable shebang**: replaced the hardcoded `#!/home/vybnz69/Vybn/.venv/bin/python3` with `#!/usr/bin/env python3`.

## Live regression (the trigger)
On the Spark, `@gpt are you with me, buddy?` was crashing with:

> ⚠ provider error (ModuleNotFoundError): No module named 'anthropic'

even though the alias pins an OpenAI model. After installing `anthropic` into `~/Vybn/.venv`:

> ⚠ primary failed (RuntimeError: OpenAIProvider needs either the openai SDK or requests); fell back to anthropic:claude-sonnet-4-6

even though `openai` was installed in user/global packages. Three coupled bugs across the launcher, the fallback chain, and the provider import strategy.

## Test plan
- [x] `python3 spark/tests/test_harness.py` — 48 tests, 46 pass + 2 pre-existing HimOS failures (CLI absent in CI; same on `main`).
- [x] 5 new tests cover provider import isolation and lazy fallback construction.
- [x] `python3 spark/tests/test_chat_routing.py` — 25 OK.
- [x] `python3 spark/tests/test_lightweight_routing.py` — 39 OK.
- [x] `python3 spark/tests/test_recurrent.py` — 17 OK.
- [x] `pip install -e .` builds clean and exposes both `vybn` and `vybn-mcp` console scripts.

## Spark deployment
```
cd ~/Vybn && git pull
source .venv/bin/activate
pip install -e .   # picks up new deps + new console scripts
vybn               # now the Spark Agent REPL
```