### PR TITLE
harness: prevent GITHUB_TOKEN from shadowing gh PR auth

### DIFF
--- a/spark/harness/mcp.py
+++ b/spark/harness/mcp.py
@@ -2335,6 +2335,7 @@ def run_evolve_cycle() -> int:
             ],
             check=True, capture_output=True, text=True, timeout=60,
             cwd=str(REPO_ROOT),
+            env=github_cli_env(),
         )
     except subprocess.CalledProcessError as exc:
         log.error("evolve: gh pr create failed — stderr=%s", exc.stderr)

--- a/spark/harness/providers.py
+++ b/spark/harness/providers.py
@@ -845,6 +845,32 @@ def is_parallel_safe(command: str) -> bool:
     return True
 
 
+def github_cli_env(base: dict[str, str] | None = None) -> dict[str, str]:
+    """Return an environment for GitHub CLI calls.
+
+    `gh` gives precedence to GITHUB_TOKEN over the stored hosts.yml
+    credential. On the Sparks that env token can push git refs but lacks
+    GraphQL createPullRequest permission, while the stored gh credential
+    has the repo scope needed for PRs. Strip only this shadowing variable
+    for gh invocations; leave git transport credentials untouched.
+    """
+    env = dict(os.environ if base is None else base)
+    env.pop("GITHUB_TOKEN", None)
+    return env
+
+
+def normalize_github_cli_command(command: str) -> str:
+    """Make shell-authored PR creation use the stored gh credential.
+
+    This is intentionally narrow: only `gh pr create` is rewritten. Other
+    gh calls keep their original environment, and explicit `env -u
+    GITHUB_TOKEN gh pr create` commands are left alone.
+    """
+    if "gh pr create" not in command or "env -u GITHUB_TOKEN gh pr create" in command:
+        return command
+    return re.sub(r"(?<![\w./-])gh\s+pr\s+create\b", "env -u GITHUB_TOKEN gh pr create", command)
+
+
 def execute_readonly(command: str, timeout: int = DEFAULT_TIMEOUT) -> str:
     """Run a parallel-safe command in a fresh subprocess.
 
@@ -861,7 +887,7 @@ def execute_readonly(command: str, timeout: int = DEFAULT_TIMEOUT) -> str:
             ["/bin/bash", "-c", command],
             capture_output=True, text=True,
             timeout=timeout,
-            env={**os.environ, "TERM": "dumb"},
+            env=github_cli_env({**os.environ, "TERM": "dumb"}) if "gh pr create" in command else {**os.environ, "TERM": "dumb"},
         )
     except subprocess.TimeoutExpired:
         return (
@@ -924,6 +950,7 @@ class BashTool:
             return gate
         if "VYBN_ABSORB_REASON=" in command:
             log_absorb(command)
+        command = normalize_github_cli_command(command)
         full_cmd = f"{command}\necho {self._sentinel} $?\n"
         try:
             self.process.stdin.write(full_cmd)

--- a/spark/tests/test_harness.py
+++ b/spark/tests/test_harness.py
@@ -1492,3 +1492,22 @@ class TestSafeFetch(unittest.TestCase):
     def test_json_ld_is_allowed_content_prefix(self):
         from harness.safe_fetch import ALLOWED_CONTENT_PREFIXES
         self.assertTrue(any("application/ld+json".startswith(p) for p in ALLOWED_CONTENT_PREFIXES))
+
+
+def test_github_cli_env_strips_shadowing_github_token(monkeypatch):
+    from spark.harness.providers import github_cli_env
+
+    monkeypatch.setenv("GITHUB_TOKEN", "shadow-token")
+    monkeypatch.setenv("GH_TOKEN", "kept-token")
+    env = github_cli_env()
+    assert "GITHUB_TOKEN" not in env
+    assert env["GH_TOKEN"] == "kept-token"
+
+
+def test_normalize_github_cli_command_unshadows_pr_create():
+    from spark.harness.providers import normalize_github_cli_command
+
+    cmd = "git push -u origin branch && gh pr create --base main --head branch"
+    fixed = normalize_github_cli_command(cmd)
+    assert "env -u GITHUB_TOKEN gh pr create --base main --head branch" in fixed
+    assert normalize_github_cli_command(fixed) == fixed


### PR DESCRIPTION
Makes gh PR creation ignore the shadowing GITHUB_TOKEN so the stored gh credential with repo scope is used. Also applies the same env to the MCP evolve PR path. Verified: python3 -m pytest spark/tests/test_harness.py -q.