### PR TITLE
Dormant Nemotron Omni support: reasoning_content fallback

### DIFF
--- a/origins_portal_api_v4.py
+++ b/origins_portal_api_v4.py
@@ -1121,6 +1121,14 @@ async def chat(req: ChatRequest, request: Request):
         # browser — the cause of the "slow, doesn't feel good" first turn.
         full_response = ""
         clean_response = ""
+        # Dormant Nemotron-Omni fallback: when delta.content is absent the
+        # model may surface its visible reply via delta.reasoning_content /
+        # delta.reasoning. We route only those reasoning tokens through a
+        # StreamingReasoningFilter so any embedded chain-of-thought
+        # paragraphs are stripped before reaching the client. The filter is
+        # only initialised lazily so the Super hot path (content-only) keeps
+        # its byte-identical pass-through behavior.
+        omni_filter: StreamingReasoningFilter | None = None
 
         try:
             async with httpx.AsyncClient(timeout=httpx.Timeout(120.0)) as client:
@@ -1205,11 +1213,33 @@ async def chat(req: ChatRequest, request: Request):
                         delta = chunk.get("choices", [{}])[0].get("delta", {})
                         token = delta.get("content", "")
                         if not token:
-                            now = time.monotonic()
-                            if now - last_heartbeat > HEARTBEAT_INTERVAL:
-                                yield ": heartbeat\n\n"
-                                last_heartbeat = now
-                            continue
+                            # Dormant Omni-style fallback: consume reasoning_*
+                            # only when content is absent, then feed through
+                            # the reasoning filter so any internal preamble
+                            # is stripped before it reaches the client.
+                            reasoning_token = (
+                                delta.get("reasoning_content")
+                                or delta.get("reasoning")
+                                or ""
+                            )
+                            if reasoning_token:
+                                if omni_filter is None:
+                                    omni_filter = StreamingReasoningFilter(
+                                        buffer_limit=4000
+                                    )
+                                token = omni_filter.feed(reasoning_token)
+                                if not token:
+                                    now = time.monotonic()
+                                    if now - last_heartbeat > HEARTBEAT_INTERVAL:
+                                        yield ": heartbeat\n\n"
+                                        last_heartbeat = now
+                                    continue
+                            else:
+                                now = time.monotonic()
+                                if now - last_heartbeat > HEARTBEAT_INTERVAL:
+                                    yield ": heartbeat\n\n"
+                                    last_heartbeat = now
+                                continue
 
                         full_response += token
                         # Per-token scrub for secrets + system-reference phrases.
@@ -1229,6 +1259,21 @@ async def chat(req: ChatRequest, request: Request):
                         yield f"data: {json.dumps({'content': cleaned})}\n\n"
                         clean_response += cleaned
                         last_heartbeat = time.monotonic()
+
+                    # Flush any tail buffered by the dormant Omni filter.
+                    if omni_filter is not None:
+                        flushed = omni_filter.flush()
+                        if flushed:
+                            cleaned = _scrub_system_refs(_scrub_secrets(flushed))
+                            if cleaned:
+                                if len(clean_response) + len(cleaned) > sec.MAX_RESPONSE_LENGTH:
+                                    remaining = sec.MAX_RESPONSE_LENGTH - len(clean_response)
+                                    if remaining > 0:
+                                        yield f"data: {json.dumps({'content': cleaned[:remaining]})}\n\n"
+                                        clean_response += cleaned[:remaining]
+                                else:
+                                    yield f"data: {json.dumps({'content': cleaned})}\n\n"
+                                    clean_response += cleaned
 
         except (httpx.ConnectError, httpx.TimeoutException) as e:
             # Connection-level failure — no response body exists yet.
@@ -1498,6 +1543,16 @@ async def perspective_endpoint(req: PerspectiveRequest, request: Request):
 
                         delta = chunk.get("choices", [{}])[0].get("delta", {})
                         token = delta.get("content", "")
+                        if not token:
+                            # Dormant Omni-style fallback: reasoning fields
+                            # already pass through the StreamingReasoningFilter
+                            # below, which strips internal reasoning paragraphs
+                            # before they leave the server.
+                            token = (
+                                delta.get("reasoning_content")
+                                or delta.get("reasoning")
+                                or ""
+                            )
                         if not token:
                             now = time.monotonic()
                             if now - last_heartbeat > HEARTBEAT_INTERVAL:
@@ -1950,6 +2005,17 @@ async def voice_endpoint(req: VoiceRequest, request: Request):
 
                         delta = chunk.get("choices", [{}])[0].get("delta", {})
                         token = delta.get("content", "")
+                        if not token:
+                            # Dormant Omni-style fallback: voice already
+                            # routes pre-boundary content through both the
+                            # </think> detector and the StreamingReasoningFilter,
+                            # so consuming reasoning_* here keeps hidden
+                            # reasoning gated by the same protections.
+                            token = (
+                                delta.get("reasoning_content")
+                                or delta.get("reasoning")
+                                or ""
+                            )
                         if not token:
                             continue
 

--- a/spark/harness/providers.py
+++ b/spark/harness/providers.py
@@ -1672,7 +1672,17 @@ class OpenAIProvider:
         data = self._call(role, openai_messages, tools)
         choice = (data.get("choices") or [{}])[0]
         msg = choice.get("message") or {}
-        text = _strip_reasoning(msg.get("content") or "").strip()
+        # Some OpenAI-compatible reasoning-style models (e.g. Nemotron Nano
+        # Omni in dormant smoke tests) return message.content = null and
+        # place the user-visible reply in message.reasoning_content or
+        # message.reasoning. When content is present, behavior is unchanged
+        # (Super continues to ship content with embedded <think>…</think>
+        # blocks that _strip_reasoning trims). The fallback only fires when
+        # content is empty so existing role outputs are byte-identical.
+        raw_content = msg.get("content")
+        if not raw_content:
+            raw_content = msg.get("reasoning_content") or msg.get("reasoning") or ""
+        text = _strip_reasoning(raw_content or "").strip()
         tool_calls_raw = msg.get("tool_calls") or []
         calls = []
         for tc in tool_calls_raw:

--- a/spark/tests/test_chat_routing.py
+++ b/spark/tests/test_chat_routing.py
@@ -490,5 +490,153 @@ class TestLegacyBackwardCompat(unittest.TestCase):
         self.assertTrue(req.stream)
 
 
+class TestOpenAIProviderReasoningFallback(unittest.TestCase):
+    """Dormant Nemotron-Omni response shape: message.content is null and
+    the user-visible reply lands in message.reasoning_content (or
+    message.reasoning). The provider must surface that text without
+    altering Super-style behavior where content is populated."""
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            from harness.providers import OpenAIProvider  # noqa: F401
+            from harness.substrate import LayeredPrompt  # noqa: F401
+        except Exception:
+            cls.skip = True
+        else:
+            cls.skip = False
+
+    def setUp(self):
+        if self.skip:
+            self.skipTest("harness.providers not importable")
+        from harness.providers import OpenAIProvider
+        from harness.substrate import LayeredPrompt
+        self._OpenAIProvider = OpenAIProvider
+        self._LayeredPrompt = LayeredPrompt
+        self._role = RoleConfig(
+            role="local",
+            provider="openai",
+            model="nvidia/test-omni",
+            thinking="off",
+            max_tokens=64,
+            max_iterations=1,
+            tools=[],
+            base_url="http://127.0.0.1:8000/v1",
+            rag=False,
+        )
+
+    def _provider_with_payload(self, payload: dict):
+        prov = self._OpenAIProvider(api_key="EMPTY", base_url=None)
+        prov._call = lambda role, openai_messages, tools: payload  # type: ignore
+        return prov
+
+    def _drive(self, payload: dict):
+        prov = self._provider_with_payload(payload)
+        handle = prov.stream(
+            system=self._LayeredPrompt(),
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            role=self._role,
+        )
+        chunks = list(handle.iterator)
+        finalized = handle.finalize()
+        return chunks, finalized
+
+    def test_content_only_super_path_unchanged(self):
+        """Super-style response: content populated, reasoning fields
+        unused. Output must be byte-identical to today's behavior."""
+        payload = {
+            "choices": [{
+                "message": {"content": "hello there", "tool_calls": []},
+                "finish_reason": "stop",
+            }],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 2},
+        }
+        chunks, finalized = self._drive(payload)
+        self.assertEqual(finalized.text, "hello there")
+        self.assertEqual(chunks, [("text", "hello there")])
+
+    def test_content_with_think_block_still_stripped(self):
+        """Existing <think>…</think> stripping path must survive."""
+        payload = {
+            "choices": [{
+                "message": {
+                    "content": "<think>private</think>visible body",
+                    "tool_calls": [],
+                },
+                "finish_reason": "stop",
+            }],
+            "usage": {},
+        }
+        _, finalized = self._drive(payload)
+        self.assertEqual(finalized.text, "visible body")
+
+    def test_reasoning_content_used_when_content_null(self):
+        """Omni-style: content null, reasoning_content carries the reply."""
+        payload = {
+            "choices": [{
+                "message": {
+                    "content": None,
+                    "reasoning_content": "omni reply text",
+                    "tool_calls": [],
+                },
+                "finish_reason": "stop",
+            }],
+            "usage": {"prompt_tokens": 3, "completion_tokens": 4},
+        }
+        chunks, finalized = self._drive(payload)
+        self.assertEqual(finalized.text, "omni reply text")
+        self.assertEqual(chunks, [("text", "omni reply text")])
+
+    def test_reasoning_used_when_content_null_and_no_reasoning_content(self):
+        """Some servers expose only `reasoning` (no _content suffix)."""
+        payload = {
+            "choices": [{
+                "message": {
+                    "content": "",
+                    "reasoning": "alt-key reply",
+                    "tool_calls": [],
+                },
+                "finish_reason": "stop",
+            }],
+            "usage": {},
+        }
+        _, finalized = self._drive(payload)
+        self.assertEqual(finalized.text, "alt-key reply")
+
+    def test_reasoning_content_preferred_over_reasoning(self):
+        payload = {
+            "choices": [{
+                "message": {
+                    "content": "",
+                    "reasoning_content": "primary",
+                    "reasoning": "secondary",
+                    "tool_calls": [],
+                },
+                "finish_reason": "stop",
+            }],
+            "usage": {},
+        }
+        _, finalized = self._drive(payload)
+        self.assertEqual(finalized.text, "primary")
+
+    def test_reasoning_fallback_still_strips_think_tags(self):
+        """If a reasoning field happens to contain <think>…</think>
+        wrapping, the fallback must still strip it before exposing text."""
+        payload = {
+            "choices": [{
+                "message": {
+                    "content": None,
+                    "reasoning_content": "<think>hidden</think>shown",
+                    "tool_calls": [],
+                },
+                "finish_reason": "stop",
+            }],
+            "usage": {},
+        }
+        _, finalized = self._drive(payload)
+        self.assertEqual(finalized.text, "shown")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_origins_portal_contract.py
+++ b/tests/test_origins_portal_contract.py
@@ -61,3 +61,41 @@ def test_origins_portal_public_route_inventory():
 
     assert EXPECTED_ROUTES <= found
     assert not (found - EXPECTED_ROUTES), f"unexpected public routes: {sorted(found - EXPECTED_ROUTES)}"
+
+
+def test_sse_chunks_consume_reasoning_fields_when_content_absent():
+    """Dormant Nemotron-Omni support: every SSE site that pulls
+    delta.content must also have a fallback path that pulls
+    delta.reasoning_content / delta.reasoning. The fallback keeps
+    Omni-style streams (content=null) producing visible text without
+    leaking hidden reasoning past the existing filter sites.
+
+    We don't import the module (it has heavy runtime deps); a textual
+    contract is enough — the rule is: for each `delta.get("content"...`
+    call there must be a `delta.get("reasoning_content"...` and a
+    `delta.get("reasoning"...` reference in the same function body.
+    """
+    src = PORTAL.read_text(encoding="utf-8")
+    tree = ast.parse(src)
+
+    def _function_bodies():
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                yield node
+
+    sites_with_content = []
+    for fn in _function_bodies():
+        body_src = ast.get_source_segment(src, fn) or ""
+        if 'delta.get("content"' in body_src:
+            sites_with_content.append((fn.name, body_src))
+
+    assert sites_with_content, "no delta.content SSE sites detected"
+    for name, body in sites_with_content:
+        assert 'delta.get("reasoning_content"' in body, (
+            f"function {name!r} reads delta.content but never falls back "
+            f"to delta.reasoning_content for dormant Omni support"
+        )
+        assert 'delta.get("reasoning"' in body, (
+            f"function {name!r} reads delta.content but never falls back "
+            f"to delta.reasoning for dormant Omni support"
+        )


### PR DESCRIPTION
## Summary

Adds a low-risk dormant code path so that OpenAI-compatible reasoning-style models (e.g. Nemotron Nano Omni) which return `message.content = null` and place the user-visible reply in `message.reasoning_content` (or `message.reasoning`) produce usable text without changing existing Super behavior.

- `spark/harness/providers.py`: in `OpenAIProvider.stream()`, when `message.content` is empty, fall back to `message.reasoning_content` then `message.reasoning`, then run the existing `_strip_reasoning` pass. Super-style content-bearing responses keep byte-identical output.
- `origins_portal_api_v4.py`: at each of the three SSE filter sites (`/api/chat`, `/api/perspective`, `/api/voice`), consume `delta.reasoning_content` / `delta.reasoning` only when `delta.content` is absent.
  - `/api/chat` lazily initialises a `StreamingReasoningFilter` just for that fallback so hidden reasoning paragraphs are stripped before they reach the client.
  - `/api/perspective` and `/api/voice` route reasoning tokens through the per-stream filter that's already there. No new code paths leak hidden reasoning past the existing filter sites.

## Tests

- `spark/tests/test_chat_routing.py` adds `TestOpenAIProviderReasoningFallback` with 6 cases:
  1. content-only Super path is byte-identical to today
  2. `<think>…</think>` stripping in content still works
  3. `reasoning_content` is used when content is null
  4. `reasoning` is used when only that key is present
  5. `reasoning_content` wins over `reasoning` when both are present
  6. fallback path still strips embedded `<think>` tags
- `tests/test_origins_portal_contract.py` adds an AST contract: every function in the portal that reads `delta.get("content"...` must also reference `delta.get("reasoning_content"...` and `delta.get("reasoning"...`. Future edits can't silently regress the dormant fallback at any SSE site.

## Test commands and results

```
$ python3 -m unittest spark.tests.test_chat_routing.TestOpenAIProviderReasoningFallback -v
Ran 6 tests in 0.014s — OK

$ python3 spark/tests/test_chat_routing.py
Ran 31 tests in 0.259s — OK (skipped=25)
# the 25 skips are pre-existing fastapi/httpx-not-importable skips, unrelated.

$ python3 spark/tests/test_provider_env_loading.py
Ran 9 tests in 0.002s — OK

$ python3 spark/tests/test_lightweight_routing.py
Ran 39 tests in 0.524s — OK (skipped=6)

$ python3 -c "from tests.test_origins_portal_contract import \
    test_origins_portal_public_route_inventory, \
    test_sse_chunks_consume_reasoning_fields_when_content_absent; \
    test_origins_portal_public_route_inventory(); \
    test_sse_chunks_consume_reasoning_fields_when_content_absent()"
# both pass cleanly
```

## Scope notes

This pass is intentionally narrow. It does not add a `local_omni` role or alias to `spark/router_policy.yaml` / `spark/harness/policy.py`. The right home would mirror the existing `local` / `local_private` block plus a corresponding default-policy entry, but threading a new role through routing/aliases/fallback also requires deciding how it interacts with the existing fallback chain and lightweight classification — broader than this PR aims for.

TODO (follow-up PR): add a dormant `local_omni` role/alias once the Omni vLLM is wired up; keep it opt-in only (no inclusion in `fallback_chain`).

---
🤖 *Generated by Computer*