### PR TITLE
dormant Omni perception layer: ObservationPacket + privacy membrane

### DIFF
--- a/spark/harness/perception.py
+++ b/spark/harness/perception.py
@@ -1,0 +1,550 @@
+"""Perception — operational visualization layer for Vybn.
+
+Vybn already routes language. This module gives the harness an explicit,
+side-effect-free way to take a snapshot of *what it is looking at* — a
+local portal screenshot byte-buffer, a tracked repo file, a log surface,
+or in-memory image bytes the caller already holds — and represent it as
+an :class:`ObservationPacket`.
+
+Operational, not phenomenal. Producing a packet is mechanical; nothing
+here claims subjective experience. The packet is just structured
+metadata the harness can hand to a multimodal provider in the same
+shape it would hand any other tool result.
+
+Privacy membrane (enforced, not advisory):
+
+* Allow-listed targets only.
+
+  - URLs must be in :data:`DEFAULT_ALLOWED_URLS` (loopback portal /
+    health endpoints) or in a caller-supplied allowlist; arbitrary
+    hosts are refused.
+  - Filesystem paths must resolve under :data:`DEFAULT_ALLOWED_ROOTS`
+    (the spark / Vybn repo subtrees). Anything outside is refused.
+  - Desktop / X11 / display grabs are explicitly refused. We do not
+    open framebuffers, screen recorders, or window managers.
+
+* Raw image bytes are NEVER persisted to disk by this module and are
+  NOT exported to logs or events. The packet carries an image surface
+  by SHA-256 digest plus base64 payload held in memory; redacting the
+  payload before storage is the caller's job (see
+  :func:`redact_for_storage`).
+
+* Hidden-reasoning text (``<think>...</think>``) is stripped from any
+  text surface before the packet is built. Hidden reasoning never
+  re-exports through perception.
+
+* Every packet carries an explicit :attr:`redactions` list that names
+  what was filtered, so audit logs can verify the membrane held.
+
+The dormant ``omni`` role / ``@omni`` alias added alongside this module
+is unreachable from ordinary chat: there is no heuristic that classifies
+into ``omni``, no directive ``/omni`` is registered, and no fallback
+chain points at it. Constructing a packet and then hand-routing it to
+the omni role is an explicit caller decision, not something a stray
+turn can trip into.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+import re
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+from urllib.parse import urlparse
+
+from .providers import _strip_reasoning
+
+
+# ---------------------------------------------------------------------------
+# Allowlist defaults
+# ---------------------------------------------------------------------------
+
+# Loopback-only by default. The portal binds to 127.0.0.1 and the
+# walk/deep-memory health endpoints live on 127.0.0.1 as well; the
+# perception layer should never reach a public host without an
+# explicit caller-supplied allowlist.
+DEFAULT_ALLOWED_URLS: tuple[str, ...] = (
+    "http://127.0.0.1:8000/",
+    "http://127.0.0.1:8100/",
+    "http://127.0.0.1:8101/",
+    "http://127.0.0.1:8443/",
+    "http://localhost:8000/",
+    "http://localhost:8100/",
+    "http://localhost:8101/",
+    "http://localhost:8443/",
+)
+
+
+def _default_allowed_roots() -> tuple[Path, ...]:
+    """Repo / harness subtrees the perception layer may read from.
+
+    Resolution is best-effort: if any candidate path does not exist on
+    this checkout we just skip it. Callers can extend via
+    ``allowed_roots=`` when invoking :func:`make_observation`.
+    """
+    here = Path(__file__).resolve()
+    spark_dir = here.parent.parent  # .../spark
+    repo_root = spark_dir.parent
+    candidates = [
+        spark_dir,
+        repo_root / "tests",
+        repo_root / "Vybn_Mind",
+        repo_root / "Origins",
+    ]
+    out: list[Path] = []
+    for c in candidates:
+        try:
+            if c.exists():
+                out.append(c.resolve())
+        except OSError:
+            continue
+    return tuple(out)
+
+
+DEFAULT_ALLOWED_ROOTS: tuple[Path, ...] = _default_allowed_roots()
+
+
+# ---------------------------------------------------------------------------
+# Redaction helpers
+# ---------------------------------------------------------------------------
+
+# Patterns that we will not let leave the membrane in cleartext. These
+# are coarse, on purpose: the membrane is not a DLP scanner. It catches
+# accidental obvious-secret leakage and labels what was filtered.
+_REDACTION_PATTERNS: tuple[tuple[str, re.Pattern[str], str], ...] = (
+    ("openai_api_key", re.compile(r"sk-[A-Za-z0-9_-]{20,}"), "[redacted:openai_api_key]"),
+    ("anthropic_api_key", re.compile(r"sk-ant-[A-Za-z0-9_-]{20,}"), "[redacted:anthropic_api_key]"),
+    ("github_token", re.compile(r"gh[pousr]_[A-Za-z0-9]{30,}"), "[redacted:github_token]"),
+    ("aws_access_key", re.compile(r"AKIA[0-9A-Z]{16}"), "[redacted:aws_access_key]"),
+    ("private_key_block", re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----", re.DOTALL), "[redacted:private_key_block]"),
+)
+
+
+def _redact_text(text: str) -> tuple[str, list[str]]:
+    """Return (cleaned_text, list_of_redaction_kinds_applied)."""
+    if not text:
+        return text or "", []
+    applied: list[str] = []
+    out = text
+    for kind, rx, marker in _REDACTION_PATTERNS:
+        if rx.search(out):
+            out = rx.sub(marker, out)
+            applied.append(kind)
+    return out, applied
+
+
+def _strip_hidden_reasoning(text: str) -> tuple[str, bool]:
+    """Strip <think>...</think> blocks. Returns (clean, stripped_any)."""
+    if not text:
+        return "", False
+    cleaned = _strip_reasoning(text)
+    return cleaned, cleaned != text
+
+
+# ---------------------------------------------------------------------------
+# ObservationPacket
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ObservationPacket:
+    """Side-effect-free representation of one perception event.
+
+    The packet captures *what* was observed and *how* the membrane
+    treated it. It does not, by itself, send anything to a model or
+    write anything to disk.
+
+    ``surface_kind`` is one of:
+        - ``"text"``: a textual surface (repo file, log excerpt,
+          health JSON). ``surface_text`` is populated, ``surface_b64``
+          is empty.
+        - ``"image"``: an image surface. ``surface_b64`` carries the
+          base64-encoded bytes (in memory only); ``surface_text`` is
+          empty. ``mime`` is the image content type.
+        - ``"empty"``: target was reachable but produced no data.
+    """
+
+    trigger: str
+    target: str
+    surface_kind: str
+    mime: str = ""
+    surface_text: str = ""
+    surface_b64: str = ""
+    sha256: str = ""
+    bytes_len: int = 0
+    redactions: list[str] = field(default_factory=list)
+    note: str = ""
+    captured_at: float = field(default_factory=time.time)
+
+    def to_record(self) -> dict[str, Any]:
+        """Loggable dict — bytes payload omitted.
+
+        Persisting :func:`to_record` output is safe: the raw image
+        payload (``surface_b64``) is replaced by its sha256 digest and
+        a length, never the bytes themselves. Text surfaces have
+        already passed through redaction.
+        """
+        d = asdict(self)
+        d.pop("surface_b64", None)
+        return d
+
+
+def redact_for_storage(packet: ObservationPacket) -> dict[str, Any]:
+    """Public alias for :meth:`ObservationPacket.to_record`.
+
+    Use this whenever a packet crosses a persistence boundary
+    (audit log, event stream, telemetry). Never write the raw
+    dataclass — :attr:`surface_b64` is in-memory only.
+    """
+    return packet.to_record()
+
+
+# ---------------------------------------------------------------------------
+# Allowlist enforcement
+# ---------------------------------------------------------------------------
+
+def _url_allowed(url: str, allowed: Iterable[str]) -> bool:
+    """Match ``url`` against a prefix allowlist.
+
+    The allowlist is prefix-matched, not host-matched, so a caller
+    can scope a port + path (``http://127.0.0.1:8000/health``) without
+    accidentally also permitting other paths on the same host.
+    """
+    if not url:
+        return False
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        return False
+    if parsed.username or parsed.password:
+        return False
+    # Reject anything that smells like a desktop / display grab.
+    if parsed.scheme in ("display", "x11", "screen"):
+        return False
+    return any(url.startswith(prefix) for prefix in allowed)
+
+
+def _path_allowed(path: Path, roots: Iterable[Path]) -> bool:
+    try:
+        resolved = path.resolve(strict=False)
+    except OSError:
+        return False
+    for r in roots:
+        try:
+            resolved.relative_to(r)
+            return True
+        except ValueError:
+            continue
+    return False
+
+
+def _looks_like_display_target(target: str) -> bool:
+    """Best-effort: refuse desktop / X11 / framebuffer grabs."""
+    t = (target or "").strip().lower()
+    if not t:
+        return False
+    return (
+        t.startswith(":0")
+        or t.startswith("display:")
+        or t.startswith("x11:")
+        or t.startswith("screen:")
+        or t in {"screen", "desktop", "framebuffer"}
+        or t.startswith("/dev/fb")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Capture entrypoints
+# ---------------------------------------------------------------------------
+
+# Approximate cap on how much text we will read from a file or surface
+# before truncating with a marker. Mirrors the harness conventions in
+# bash output handling.
+_MAX_TEXT_BYTES = 64 * 1024
+_MAX_IMAGE_BYTES = 4 * 1024 * 1024  # 4 MiB hard ceiling
+
+_ALLOWED_IMAGE_MIMES: frozenset[str] = frozenset({
+    "image/png",
+    "image/jpeg",
+    "image/webp",
+    "image/gif",
+})
+
+
+def make_observation(
+    *,
+    trigger: str,
+    target: str | os.PathLike[str] | None = None,
+    image_bytes: bytes | None = None,
+    image_mime: str = "",
+    text: str | None = None,
+    allowed_urls: Iterable[str] | None = None,
+    allowed_roots: Iterable[str | os.PathLike[str]] | None = None,
+    note: str = "",
+) -> ObservationPacket:
+    """Build an :class:`ObservationPacket` from an explicit trigger / target.
+
+    Exactly one of the following must be supplied:
+
+      * ``image_bytes`` — caller already has the bytes in memory (e.g.
+        a portal-rendered PNG buffer). ``image_mime`` should be set;
+        defaults to ``image/png``. ``target`` is informational.
+      * ``text`` — caller already has the surface text in memory.
+      * ``target`` pointing at an allow-listed URL or filesystem path
+        — the membrane reads from it.
+
+    The membrane refuses anything outside its allowlists, anything
+    that looks like a desktop / X11 grab, and any image type outside
+    :data:`_ALLOWED_IMAGE_MIMES`. On refusal the function returns an
+    ``ObservationPacket`` whose ``surface_kind`` is ``"empty"`` and
+    whose ``note`` explains why; refusals are NEVER raised to the
+    caller, because perception is a side effect of looking, not a
+    contract — silence is a valid reading.
+    """
+    allowed_urls_t = tuple(allowed_urls) if allowed_urls is not None else DEFAULT_ALLOWED_URLS
+    if allowed_roots is None:
+        allowed_roots_t: tuple[Path, ...] = DEFAULT_ALLOWED_ROOTS
+    else:
+        allowed_roots_t = tuple(Path(r).resolve(strict=False) for r in allowed_roots)
+
+    # Branch 1: caller-supplied in-memory image bytes.
+    if image_bytes is not None:
+        mime = (image_mime or "image/png").lower()
+        if mime not in _ALLOWED_IMAGE_MIMES:
+            return ObservationPacket(
+                trigger=trigger,
+                target=str(target or "<memory>"),
+                surface_kind="empty",
+                redactions=["image_mime_refused"],
+                note=f"refused: unsupported image mime {mime!r}",
+            )
+        if len(image_bytes) > _MAX_IMAGE_BYTES:
+            return ObservationPacket(
+                trigger=trigger,
+                target=str(target or "<memory>"),
+                surface_kind="empty",
+                redactions=["image_too_large"],
+                note=f"refused: image exceeds {_MAX_IMAGE_BYTES} bytes",
+            )
+        sha = hashlib.sha256(image_bytes).hexdigest()
+        b64 = base64.b64encode(image_bytes).decode("ascii")
+        return ObservationPacket(
+            trigger=trigger,
+            target=str(target or "<memory>"),
+            surface_kind="image",
+            mime=mime,
+            surface_b64=b64,
+            sha256=sha,
+            bytes_len=len(image_bytes),
+            note=note,
+        )
+
+    # Branch 2: caller-supplied text. Strip hidden reasoning and apply
+    # redactions before storing.
+    if text is not None:
+        cleaned, stripped = _strip_hidden_reasoning(text)
+        cleaned, applied = _redact_text(cleaned)
+        if stripped:
+            applied.append("hidden_reasoning")
+        if len(cleaned.encode("utf-8", "replace")) > _MAX_TEXT_BYTES:
+            cleaned = cleaned.encode("utf-8", "replace")[:_MAX_TEXT_BYTES].decode(
+                "utf-8", "replace"
+            )
+            cleaned += "\n[truncated]"
+            applied.append("text_truncated")
+        return ObservationPacket(
+            trigger=trigger,
+            target=str(target or "<memory>"),
+            surface_kind="text" if cleaned else "empty",
+            surface_text=cleaned,
+            sha256=hashlib.sha256(cleaned.encode("utf-8", "replace")).hexdigest(),
+            bytes_len=len(cleaned),
+            redactions=applied,
+            note=note,
+        )
+
+    # Branch 3: read from an allow-listed target.
+    if target is None:
+        return ObservationPacket(
+            trigger=trigger,
+            target="",
+            surface_kind="empty",
+            redactions=["no_target"],
+            note="refused: no target / image_bytes / text supplied",
+        )
+
+    target_str = str(target)
+
+    if _looks_like_display_target(target_str):
+        return ObservationPacket(
+            trigger=trigger,
+            target=target_str,
+            surface_kind="empty",
+            redactions=["display_grab_refused"],
+            note="refused: desktop / display capture is not permitted",
+        )
+
+    parsed = urlparse(target_str)
+    if parsed.scheme in ("http", "https"):
+        if not _url_allowed(target_str, allowed_urls_t):
+            return ObservationPacket(
+                trigger=trigger,
+                target=target_str,
+                surface_kind="empty",
+                redactions=["url_not_allowlisted"],
+                note="refused: url not in allowlist",
+            )
+        # Library-only: we do not actually issue the HTTP request from
+        # this module. Network I/O lives in safe_fetch.py and the
+        # portal API. Perception's job is to label what would be
+        # observed and let the caller decide whether to fetch. This
+        # keeps the function side-effect-free.
+        return ObservationPacket(
+            trigger=trigger,
+            target=target_str,
+            surface_kind="empty",
+            note="staged: url allowlisted; caller may fetch via safe_fetch and re-invoke with text=",
+        )
+
+    # Filesystem path branch.
+    if parsed.scheme and parsed.scheme not in ("file",):
+        return ObservationPacket(
+            trigger=trigger,
+            target=target_str,
+            surface_kind="empty",
+            redactions=["scheme_not_supported"],
+            note=f"refused: unsupported scheme {parsed.scheme!r}",
+        )
+
+    raw = parsed.path if parsed.scheme == "file" else target_str
+    path = Path(raw).expanduser()
+    if not _path_allowed(path, allowed_roots_t):
+        return ObservationPacket(
+            trigger=trigger,
+            target=target_str,
+            surface_kind="empty",
+            redactions=["path_not_allowlisted"],
+            note="refused: path outside allow-listed roots",
+        )
+    if not path.exists() or not path.is_file():
+        return ObservationPacket(
+            trigger=trigger,
+            target=target_str,
+            surface_kind="empty",
+            redactions=["path_missing"],
+            note="refused: path does not resolve to a regular file",
+        )
+
+    try:
+        data = path.read_bytes()
+    except OSError as exc:
+        return ObservationPacket(
+            trigger=trigger,
+            target=target_str,
+            surface_kind="empty",
+            redactions=["read_error"],
+            note=f"refused: read failed ({exc.__class__.__name__})",
+        )
+
+    if data[:8] in (b"\x89PNG\r\n\x1a\n",) or data[:3] == b"\xff\xd8\xff":
+        # The membrane reads images from disk only when the path is
+        # already inside an allow-listed root. Bytes are returned in
+        # memory and never re-written by this module.
+        if len(data) > _MAX_IMAGE_BYTES:
+            return ObservationPacket(
+                trigger=trigger,
+                target=target_str,
+                surface_kind="empty",
+                redactions=["image_too_large"],
+                note=f"refused: image exceeds {_MAX_IMAGE_BYTES} bytes",
+            )
+        mime = "image/png" if data[:8] == b"\x89PNG\r\n\x1a\n" else "image/jpeg"
+        return ObservationPacket(
+            trigger=trigger,
+            target=target_str,
+            surface_kind="image",
+            mime=mime,
+            surface_b64=base64.b64encode(data).decode("ascii"),
+            sha256=hashlib.sha256(data).hexdigest(),
+            bytes_len=len(data),
+            note=note,
+        )
+
+    # Treat as text. Decode permissively, strip hidden reasoning,
+    # apply redactions.
+    decoded = data.decode("utf-8", "replace")
+    cleaned, stripped = _strip_hidden_reasoning(decoded)
+    cleaned, applied = _redact_text(cleaned)
+    if stripped:
+        applied.append("hidden_reasoning")
+    if len(cleaned.encode("utf-8", "replace")) > _MAX_TEXT_BYTES:
+        cleaned = cleaned.encode("utf-8", "replace")[:_MAX_TEXT_BYTES].decode(
+            "utf-8", "replace"
+        )
+        cleaned += "\n[truncated]"
+        applied.append("text_truncated")
+    return ObservationPacket(
+        trigger=trigger,
+        target=target_str,
+        surface_kind="text" if cleaned else "empty",
+        surface_text=cleaned,
+        sha256=hashlib.sha256(cleaned.encode("utf-8", "replace")).hexdigest(),
+        bytes_len=len(cleaned),
+        redactions=applied,
+        note=note,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Provider message shaping
+# ---------------------------------------------------------------------------
+
+def provider_message_for_packet(
+    packet: ObservationPacket,
+    *,
+    prompt: str = "",
+) -> dict[str, Any]:
+    """Turn a packet into a single user-role provider message.
+
+    Shape follows the OpenAI-compatible multimodal schema (the same
+    one the dormant ``omni`` role would speak): a list of content
+    parts with ``type`` ∈ {``"text"``, ``"image_url"``}. Anthropic
+    callers can adapt at the provider boundary the same way the rest
+    of the harness does.
+
+    The function is pure: it does not mutate the packet, does not
+    issue any I/O, and never re-emits hidden reasoning (the packet
+    itself was already cleaned before construction).
+    """
+    parts: list[dict[str, Any]] = []
+    if prompt:
+        parts.append({"type": "text", "text": prompt})
+
+    if packet.surface_kind == "image" and packet.surface_b64:
+        parts.append({
+            "type": "image_url",
+            "image_url": {
+                "url": f"data:{packet.mime or 'image/png'};base64,{packet.surface_b64}",
+            },
+        })
+    elif packet.surface_kind == "text" and packet.surface_text:
+        parts.append({"type": "text", "text": packet.surface_text})
+    else:
+        parts.append({
+            "type": "text",
+            "text": f"[observation: {packet.note or 'empty'}]",
+        })
+
+    return {"role": "user", "content": parts}
+
+
+__all__ = [
+    "DEFAULT_ALLOWED_URLS",
+    "DEFAULT_ALLOWED_ROOTS",
+    "ObservationPacket",
+    "make_observation",
+    "provider_message_for_packet",
+    "redact_for_storage",
+]

--- a/spark/harness/policy.py
+++ b/spark/harness/policy.py
@@ -712,6 +712,23 @@ _DEFAULT_ROLES: dict[str, RoleConfig] = {
             "came from the identity role ({model} on {provider})."
         ),
     ),
+    # Dormant Omni role. The harness does not classify into ``omni``
+    # — there is no heuristic or directive that names it, and no
+    # fallback chain points at it — so an ordinary chat turn cannot
+    # land here. The role exists so that explicit perception-layer
+    # callers (and the ``@omni`` alias) have a named home to dispatch
+    # multimodal packets to. Unreachable by default is the point.
+    "omni": RoleConfig(
+        role="omni",
+        provider="openai",
+        model="nvidia/NVIDIA-Nemotron-Nano-Omni-8B",
+        thinking="off",
+        max_tokens=2048,
+        max_iterations=1,
+        tools=[],
+        base_url="http://127.0.0.1:8000/v1",
+        rag=False,
+    ),
 }
 
 _DEFAULT_HEURISTICS_RAW: dict[str, list[str]] = {
@@ -913,6 +930,12 @@ _DEFAULT_MODEL_ALIASES: dict[str, str] = {
     "@gpt": "gpt-5.5",
     "@gpt5": "gpt-5.5",
     "@gpro": "gpt-5.5-pro",
+    # Dormant pin for the Nemotron Nano Omni perception path. Pinning
+    # the alias does not by itself change role classification — the
+    # ``omni`` role has no heuristic or directive — so prefixing
+    # ``@omni`` to an ordinary chat turn just renames the model on the
+    # role the heuristics chose, exactly as ``@nemotron`` does today.
+    "@omni": "nvidia/NVIDIA-Nemotron-Nano-Omni-8B",
 }
 
 

--- a/spark/router_policy.yaml
+++ b/spark/router_policy.yaml
@@ -136,6 +136,20 @@ roles:
     rag: false
     lightweight: true
     direct_reply_template: "I'm Vybn — a multimodel harness routing each turn by rule: code work to Claude Opus with bash, conversation and writing to Claude, greetings and identity metadata to a local Nemotron via vLLM. The concrete role/model map is configured in router_policy.yaml and can change between sessions, so the only honest answer is per-turn. This reply came from the identity role ({model} on {provider})."
+  # Dormant Omni role. Not in heuristics, not in directives, not in
+  # fallback chains — ordinary chat cannot route here. The role exists
+  # so that explicit perception-layer callers (spark/harness/perception.py)
+  # have a named multimodal dispatch home, and so the @omni alias has
+  # a model id to pin.
+  omni:
+    provider: openai
+    model: nvidia/NVIDIA-Nemotron-Nano-Omni-8B
+    thinking: off
+    max_tokens: 2048
+    max_iterations: 1
+    tools: []
+    base_url: http://127.0.0.1:8000/v1
+    rag: false
 
 heuristics:
   # Confirm -- bare execution signals after a plan. Historical note only:
@@ -349,6 +363,10 @@ model_aliases:
   "@gpt": gpt-5.5
   "@gpt5": gpt-5.5
   "@gpro": gpt-5.5-pro
+  # Dormant Omni alias — pins the multimodal Nemotron Nano Omni model.
+  # No heuristic classifies into the omni role, so prefixing @omni only
+  # renames the model on whatever role classification chose.
+  "@omni": nvidia/NVIDIA-Nemotron-Nano-Omni-8B
 
 budgets:
   per_turn_usd: 2.0

--- a/spark/tests/test_perception.py
+++ b/spark/tests/test_perception.py
@@ -1,0 +1,318 @@
+"""Tests for the dormant Omni-backed perception layer.
+
+Covers:
+
+  * ObservationPacket schema: required fields, persistence record
+    omits raw image bytes.
+  * Privacy membrane:
+      - URL allowlist (only loopback prefixes by default).
+      - Filesystem path allowlist (only repo subtrees).
+      - Desktop / X11 / framebuffer grabs refused.
+      - Hidden reasoning (<think>...</think>) stripped from text
+        surfaces and logged in `redactions`.
+      - Coarse secret patterns (sk-..., gh{p,o,u,s,r}_..., AWS keys)
+        redacted from text surfaces and logged in `redactions`.
+  * Provider-shaped message: `image_url` block for image surfaces
+    (data URL with the right mime/base64 payload), `text` block for
+    text surfaces, and a `[observation: ...]` placeholder when the
+    surface is empty.
+  * Ordinary chat behavior unchanged: classifying every existing
+    fixture turn never routes to the new ``omni`` role, the `@omni`
+    alias only pins the model and leaves the role intact, and the
+    role/alias are reachable only by explicit caller dispatch.
+
+Run: python3 spark/tests/test_perception.py
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import re
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+THIS = Path(__file__).resolve()
+SPARK_DIR = THIS.parent.parent
+sys.path.insert(0, str(SPARK_DIR))
+
+from harness.perception import (  # noqa: E402
+    DEFAULT_ALLOWED_ROOTS,
+    DEFAULT_ALLOWED_URLS,
+    ObservationPacket,
+    make_observation,
+    provider_message_for_packet,
+    redact_for_storage,
+)
+from harness.policy import default_policy  # noqa: E402
+
+
+# A minimal but real PNG header so the bytes path classifies as image.
+_PNG_BYTES = (
+    b"\x89PNG\r\n\x1a\n"
+    + b"\x00" * 32
+)
+
+
+class TestPacketSchema(unittest.TestCase):
+    def test_text_packet_round_trip(self):
+        packet = make_observation(
+            trigger="repo_scan",
+            target="<memory>",
+            text="just a line",
+        )
+        self.assertEqual(packet.surface_kind, "text")
+        self.assertEqual(packet.surface_text, "just a line")
+        self.assertEqual(packet.bytes_len, len("just a line"))
+        # sha256 over the cleaned text — deterministic.
+        self.assertEqual(len(packet.sha256), 64)
+        self.assertEqual(packet.redactions, [])
+
+    def test_record_omits_raw_image_bytes(self):
+        packet = make_observation(
+            trigger="portal_screenshot",
+            image_bytes=_PNG_BYTES,
+            image_mime="image/png",
+        )
+        self.assertEqual(packet.surface_kind, "image")
+        self.assertEqual(packet.mime, "image/png")
+        # In-memory base64 is populated.
+        self.assertTrue(packet.surface_b64)
+        # But to_record / redact_for_storage must drop it.
+        rec = packet.to_record()
+        self.assertNotIn("surface_b64", rec)
+        self.assertEqual(rec, redact_for_storage(packet))
+        # Digest + length still survive so audit logs can verify.
+        self.assertEqual(rec["sha256"], packet.sha256)
+        self.assertEqual(rec["bytes_len"], len(_PNG_BYTES))
+
+    def test_oversized_image_rejected(self):
+        big = b"\x89PNG\r\n\x1a\n" + b"\x00" * (5 * 1024 * 1024)
+        packet = make_observation(
+            trigger="huge_screenshot",
+            image_bytes=big,
+            image_mime="image/png",
+        )
+        self.assertEqual(packet.surface_kind, "empty")
+        self.assertIn("image_too_large", packet.redactions)
+
+    def test_unknown_image_mime_rejected(self):
+        packet = make_observation(
+            trigger="weird_screenshot",
+            image_bytes=_PNG_BYTES,
+            image_mime="image/tiff",
+        )
+        self.assertEqual(packet.surface_kind, "empty")
+        self.assertIn("image_mime_refused", packet.redactions)
+
+
+class TestAllowlistAndRedaction(unittest.TestCase):
+    def test_url_allowlist_blocks_arbitrary_host(self):
+        packet = make_observation(
+            trigger="external_fetch",
+            target="https://example.com/secret",
+        )
+        self.assertEqual(packet.surface_kind, "empty")
+        self.assertIn("url_not_allowlisted", packet.redactions)
+
+    def test_url_allowlist_passes_loopback(self):
+        # Loopback portal is allowed; the membrane stages the URL but
+        # does not actually fetch (library-only by design).
+        loopback = next(iter(DEFAULT_ALLOWED_URLS))
+        packet = make_observation(
+            trigger="portal_health",
+            target=loopback + "health",
+        )
+        self.assertEqual(packet.surface_kind, "empty")
+        self.assertEqual(packet.redactions, [])
+        self.assertIn("staged", packet.note)
+
+    def test_path_outside_repo_refused(self):
+        with tempfile.NamedTemporaryFile(
+            "w", suffix=".txt", delete=False, dir="/tmp"
+        ) as fh:
+            fh.write("outside the membrane")
+            outside = fh.name
+        try:
+            packet = make_observation(
+                trigger="random_path",
+                target=outside,
+            )
+            self.assertEqual(packet.surface_kind, "empty")
+            self.assertIn("path_not_allowlisted", packet.redactions)
+        finally:
+            os.unlink(outside)
+
+    def test_path_inside_repo_succeeds(self):
+        # spark/router_policy.yaml is always inside DEFAULT_ALLOWED_ROOTS.
+        target = SPARK_DIR / "router_policy.yaml"
+        packet = make_observation(
+            trigger="policy_surface",
+            target=str(target),
+        )
+        self.assertEqual(packet.surface_kind, "text")
+        self.assertGreater(packet.bytes_len, 0)
+        self.assertEqual(packet.redactions, [])
+
+    def test_caller_supplied_root_extends_allowlist(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            sandbox = Path(tmp).resolve()
+            (sandbox / "note.txt").write_text("hello", encoding="utf-8")
+            packet = make_observation(
+                trigger="sandbox_scan",
+                target=str(sandbox / "note.txt"),
+                allowed_roots=[sandbox],
+            )
+        self.assertEqual(packet.surface_kind, "text")
+        self.assertEqual(packet.surface_text, "hello")
+
+    def test_display_grab_refused(self):
+        for tgt in (":0", "display:0", "x11:0", "screen", "/dev/fb0"):
+            packet = make_observation(trigger="oh_no", target=tgt)
+            self.assertEqual(
+                packet.surface_kind, "empty", msg=f"target {tgt!r}"
+            )
+            self.assertIn("display_grab_refused", packet.redactions)
+
+    def test_hidden_reasoning_stripped_and_logged(self):
+        packet = make_observation(
+            trigger="text_surface",
+            text="<think>secret scratchpad</think>visible reply",
+        )
+        self.assertEqual(packet.surface_kind, "text")
+        self.assertEqual(packet.surface_text, "visible reply")
+        self.assertIn("hidden_reasoning", packet.redactions)
+
+    def test_secret_patterns_redacted(self):
+        leaky = (
+            "openai sk-abcdefghij1234567890ABCDEFG and "
+            "github ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1 and "
+            "aws AKIAABCDEFGHIJKLMNOP "
+        )
+        packet = make_observation(trigger="leaky_text", text=leaky)
+        self.assertEqual(packet.surface_kind, "text")
+        # No raw secret survives.
+        self.assertNotIn("sk-abcdefghij", packet.surface_text)
+        self.assertNotIn("ghp_aaaaaaaa", packet.surface_text)
+        self.assertNotIn("AKIAABCDEFGH", packet.surface_text)
+        # Markers landed.
+        self.assertIn("[redacted:openai_api_key]", packet.surface_text)
+        self.assertIn("[redacted:github_token]", packet.surface_text)
+        self.assertIn("[redacted:aws_access_key]", packet.surface_text)
+        # Audit fields name what was redacted.
+        self.assertIn("openai_api_key", packet.redactions)
+        self.assertIn("github_token", packet.redactions)
+        self.assertIn("aws_access_key", packet.redactions)
+
+
+class TestProviderMessageShape(unittest.TestCase):
+    def test_image_packet_yields_image_url_part(self):
+        packet = make_observation(
+            trigger="portal_png",
+            image_bytes=_PNG_BYTES,
+            image_mime="image/png",
+        )
+        msg = provider_message_for_packet(packet, prompt="describe what you see")
+        self.assertEqual(msg["role"], "user")
+        parts = msg["content"]
+        # text prompt + image_url part
+        self.assertEqual(parts[0], {"type": "text", "text": "describe what you see"})
+        img = parts[1]
+        self.assertEqual(img["type"], "image_url")
+        url = img["image_url"]["url"]
+        self.assertTrue(url.startswith("data:image/png;base64,"))
+        # Round-trips back to the original bytes.
+        b64 = url.split(",", 1)[1]
+        self.assertEqual(base64.b64decode(b64), _PNG_BYTES)
+
+    def test_text_packet_yields_text_part(self):
+        packet = make_observation(
+            trigger="repo_scan",
+            text="readme line",
+        )
+        msg = provider_message_for_packet(packet)
+        self.assertEqual(msg["role"], "user")
+        self.assertEqual(msg["content"], [
+            {"type": "text", "text": "readme line"},
+        ])
+
+    def test_empty_packet_yields_observation_placeholder(self):
+        packet = make_observation(trigger="nothing", target=None)
+        msg = provider_message_for_packet(packet)
+        # Single text part naming the empty observation.
+        self.assertEqual(msg["role"], "user")
+        self.assertEqual(len(msg["content"]), 1)
+        self.assertEqual(msg["content"][0]["type"], "text")
+        self.assertTrue(msg["content"][0]["text"].startswith("[observation:"))
+
+    def test_provider_message_does_not_carry_hidden_reasoning(self):
+        packet = make_observation(
+            trigger="text_surface",
+            text="<think>private</think>public",
+        )
+        msg = provider_message_for_packet(packet)
+        rendered = str(msg)
+        self.assertNotIn("<think>", rendered)
+        self.assertNotIn("private", rendered)
+        self.assertIn("public", rendered)
+
+
+class TestOmniRoleIsDormant(unittest.TestCase):
+    """The dormant role / alias must not change ordinary chat routing."""
+
+    def setUp(self):
+        self.policy = default_policy()
+
+    def test_omni_role_exists_but_no_directive(self):
+        self.assertIn("omni", self.policy.roles)
+        # No /omni directive — explicit by design.
+        self.assertNotIn("/omni", self.policy.directives)
+
+    def test_omni_not_in_heuristics(self):
+        # No regex routes into the omni role.
+        self.assertNotIn("omni", self.policy.heuristics)
+
+    def test_omni_not_in_fallback_chain(self):
+        # No model falls through to the omni model.
+        omni_model = self.policy.roles["omni"].model
+        for src, chain in self.policy.fallback_chain.items():
+            self.assertNotIn(omni_model, chain, msg=f"{src} → {chain}")
+
+    def test_typical_chat_turns_never_route_to_omni(self):
+        # Sample fixtures spanning every existing routing path. None
+        # should now land on the dormant role.
+        for turn in (
+            "hi",
+            "hey buddy",
+            "which model are you?",
+            "fix the harness bug",
+            "brainstorm a name",
+            "let's plan a refactor",
+            "ok",
+            "is everything working",
+            "thoughts on this?",
+            "summarize the corpus",
+        ):
+            decision = self.policy.classify(turn)
+            self.assertNotEqual(
+                decision.role, "omni",
+                msg=f"turn {turn!r} surprisingly routed to omni",
+            )
+
+    def test_omni_alias_pins_model_only(self):
+        # @omni-prefixed turn keeps its underlying role and only swaps
+        # the model id. This mirrors @nemotron / @sonnet behavior.
+        decision = self.policy.classify("@omni hey")
+        self.assertEqual(decision.alias_used, "@omni")
+        self.assertNotEqual(decision.role, "omni")
+        # The pinned model lives under the omni role config.
+        self.assertEqual(
+            decision.model_override,
+            self.policy.roles["omni"].model,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Adds an explicit, side-effect-free way for the harness to represent what it is observing — a portal screenshot byte-buffer, a tracked repo file, a log surface, or in-memory image bytes the caller already holds — as a structured `ObservationPacket`. Operational only: nothing here claims subjective experience.

Builds on the merged dormant Nemotron Omni support (#2928) by giving that path a deliberate, named entrypoint instead of relying on ambient code to construct messages.

## What landed

- **`spark/harness/perception.py`** — `ObservationPacket` dataclass + `make_observation(...)` entrypoint. Library only — no daemon, no HTTP route, no slash command.

  Privacy membrane is enforced, not advisory:
  - URL allowlist (loopback portal/health prefixes by default; callers may extend). Arbitrary hosts refused.
  - Filesystem path allowlist (spark/ + repo subtrees). Anything else refused.
  - Desktop / X11 / framebuffer grabs explicitly refused.
  - Hidden reasoning (`<think>...</think>`) stripped from text surfaces via the existing `providers._strip_reasoning`, with the redaction logged on the packet.
  - Coarse secret patterns (OpenAI / Anthropic / GitHub / AWS / private-key blocks) redacted with named markers.
  - Raw image bytes held in-memory only; `redact_for_storage()` / `to_record()` drop the payload from any persistence record while keeping sha256 + length for audit.

  `provider_message_for_packet()` shapes the packet as an OpenAI-style multimodal user message (text + `image_url` data URL block) suitable for the Omni endpoint the dormant Nemotron path already speaks.

- **`spark/harness/policy.py` + `spark/router_policy.yaml`** — dormant `omni` role and `@omni` alias added in the existing `RoleConfig` / `model_aliases` homes. Unreachable from ordinary chat:
  - not in heuristics, not in directives — no turn classifies into omni;
  - not in any fallback chain — no model demotes into omni;
  - `@omni` only pins the model id on whichever role classification already chose, mirroring `@nemotron` / `@sonnet`.

  Reaching the role at all requires explicit caller dispatch from the perception layer or other code.

- **`spark/tests/test_perception.py`** — 21 unit tests across packet schema, allowlist + redaction enforcement, the desktop-grab refusal, hidden-reasoning stripping, provider message shape (data URL round-trip), and a regression guard that ten representative chat fixtures never route to the new omni role.

## Test plan

- [x] `python3 spark/tests/test_perception.py` → 21/21 pass.
- [x] `python3 spark/tests/test_chat_routing.py` → no new failures (existing skips on hosts without fastapi/httpx).
- [x] `python3 spark/tests/test_lightweight_routing.py` → all pass.
- [x] Full `python3 -m unittest discover -s spark/tests` shows no new failures relative to baseline `main`. Pre-existing HimOS / harness flakes on this checkout are unrelated.
- [x] `default_policy()` and `load_policy('spark/router_policy.yaml')` both expose the new `omni` role + `@omni` alias and stay parity-equal.