### PR TITLE
omni: explicit operator-gated @omni alias activation

### DIFF
--- a/spark/harness/policy.py
+++ b/spark/harness/policy.py
@@ -910,6 +910,15 @@ _DEFAULT_MODEL_ALIASES: dict[str, str] = {
     "@sonnet46": "claude-sonnet-4-6",
     "@nemotron": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
     "@local": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
+    # Omni — peer-Spark Nano-Omni endpoint. Operator-gated: only fires when
+    # the user explicitly prefixes a turn with @omni AND the operator has
+    # exported VYBN_OMNI_URL pointing at a started Omni endpoint. The alias
+    # is intentionally absent from heuristics, directives, fallback_chain,
+    # and ordinary chat routing so Super topology (always-on, both Sparks)
+    # is never silently interrupted. Without VYBN_OMNI_URL the alias surfaces
+    # an explicit error rather than falling back to Super's :8000. Optional
+    # VYBN_OMNI_MODEL overrides the default model id below.
+    "@omni": "nvidia/NVIDIA-Nemotron-Nano-Omni",
     "@gpt": "gpt-5.5",
     "@gpt5": "gpt-5.5",
     "@gpro": "gpt-5.5-pro",

--- a/spark/router_policy.yaml
+++ b/spark/router_policy.yaml
@@ -346,6 +346,12 @@ model_aliases:
   "@sonnet46": claude-sonnet-4-6
   "@nemotron": nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8
   "@local": nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8
+  # @omni — peer-Spark Nano-Omni, operator-gated by VYBN_OMNI_URL. Only
+  # activates when the user types @omni AND the operator has started an
+  # Omni endpoint and exported VYBN_OMNI_URL. NOT in fallback_chain, NOT a
+  # heuristic target, NOT a directive. Super topology stays untouched.
+  # Optional VYBN_OMNI_MODEL overrides the default model id.
+  "@omni": nvidia/NVIDIA-Nemotron-Nano-Omni
   "@gpt": gpt-5.5
   "@gpt5": gpt-5.5
   "@gpro": gpt-5.5-pro

--- a/spark/tests/test_lightweight_routing.py
+++ b/spark/tests/test_lightweight_routing.py
@@ -785,3 +785,63 @@ def test_opus47_has_fallback_chain():
     policy = default_policy()
     assert policy.fallback_chain["claude-opus-4-7"] == ["claude-opus-4-6", "claude-sonnet-4-6"]
 
+
+# Omni explicit-activation alias. The peer-Spark Nano-Omni is the ONLY
+# automatic-routing-free path: it never appears in fallback_chain or in
+# any heuristic/directive, only as the @omni model alias which the
+# operator activates by exporting VYBN_OMNI_URL.
+def test_omni_alias_present_in_default_policy():
+    from spark.harness.policy import default_policy
+    policy = default_policy()
+    assert policy.model_aliases.get("@omni") is not None
+    # Default model id is the Nano-Omni; operator can override via
+    # VYBN_OMNI_MODEL at runtime without editing policy.
+    assert "Omni" in policy.model_aliases["@omni"]
+
+
+def test_omni_alias_present_in_router_policy_yaml():
+    active = (
+        Path("spark/harness/policy.py").read_text()
+        + "\n"
+        + Path("spark/router_policy.yaml").read_text()
+    )
+    assert "@omni" in active
+    assert "VYBN_OMNI_URL" in active
+
+
+def test_omni_not_in_fallback_chain():
+    from spark.harness.policy import default_policy
+    policy = default_policy()
+    omni_model = policy.model_aliases["@omni"]
+    # Omni model id must not be a fallback target for any other model
+    # (Super topology stays untouched; Omni only fires on explicit @omni).
+    for src, chain in policy.fallback_chain.items():
+        assert omni_model not in chain, (
+            f"@omni model leaked into fallback_chain[{src!r}]"
+        )
+    # Nor should there be a fallback chain rooted at the Omni model.
+    assert omni_model not in policy.fallback_chain
+
+
+def test_omni_not_in_any_heuristic_or_directive():
+    from spark.harness.policy import default_policy
+    policy = default_policy()
+    # No role named omni — alias-only mechanism.
+    assert "omni" not in policy.roles
+    # No directive (slash-prefix) routes to omni.
+    for directive, role in policy.directives.items():
+        assert role != "omni"
+    # No heuristic regex mentions omni — the alias is the only entry.
+    for role, patterns in policy.heuristics.items():
+        for pat in patterns:
+            assert "omni" not in pat.pattern.lower(), (
+                f"heuristic for {role} mentions omni: {pat.pattern!r}"
+            )
+
+
+def test_omni_alias_classifies_with_override():
+    from spark.harness.policy import default_policy
+    decision = default_policy().classify("@omni summarise this paragraph")
+    assert decision.alias_used == "@omni"
+    assert decision.model_override == default_policy().model_aliases["@omni"]
+

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -955,7 +955,41 @@ def run_agent_loop(
     if getattr(decision, "model_override", None):
         import dataclasses as _dc
         override_model = decision.model_override
-        if override_model.startswith("claude-"):
+        # @omni is the explicit, operator-gated activation path for the
+        # peer-Spark Nano-Omni endpoint. It is the ONLY way Omni ever
+        # routes — never via heuristic, directive, fallback_chain, or
+        # ordinary chat. The operator must (1) start the Omni endpoint
+        # on the peer Spark and (2) export VYBN_OMNI_URL pointing at it
+        # (e.g. http://10.0.0.X:8001/v1). Optional VYBN_OMNI_MODEL
+        # overrides the policy default model id. Without VYBN_OMNI_URL
+        # this turn refuses with an explicit error rather than silently
+        # falling back to Super on :8000 — Super spans both Sparks and
+        # is always-on; we do not want @omni to disturb that topology
+        # or to start/stop any service. No daemon, cron, or public
+        # route is installed by this code path.
+        if getattr(decision, "alias_used", None) == "@omni":
+            _omni_url = (os.environ.get("VYBN_OMNI_URL") or "").strip()
+            if not _omni_url:
+                logger.emit(
+                    "alias_omni_unconfigured",
+                    turn=turn_number,
+                    alias="@omni",
+                    role=decision.role,
+                )
+                return (
+                    "[@omni unavailable: VYBN_OMNI_URL is not set. "
+                    "Start the Omni endpoint on the peer Spark and "
+                    "export VYBN_OMNI_URL=http://<host>:<port>/v1 "
+                    "before retrying. This turn will not silently "
+                    "fall back to Super (:8000) — Super topology is "
+                    "preserved.]"
+                )
+            override_model = (
+                os.environ.get("VYBN_OMNI_MODEL") or override_model
+            )
+            override_provider = "openai"
+            override_base_url = _omni_url
+        elif override_model.startswith("claude-"):
             override_provider = "anthropic"
             override_base_url = None
         elif override_model.startswith("gpt-"):
@@ -2168,6 +2202,8 @@ def main() -> None:
     print("  Type naturally. Prefix with /chat, /create, /plan, /task, /local "
           "to force a role,")
     print("  or with @opus4.6/@opus4.6/@sonnet/@nemotron/@gpt to pin a model for one turn.")
+    print("  @omni pins peer-Spark Nano-Omni — requires VYBN_OMNI_URL set; "
+          "refuses (no Super fallback) when unset.")
     print("  REPL commands: exit | clear | reload | history | policy | /resume | /sessions | /newsession")
     print()
 


### PR DESCRIPTION
## Summary

Gives Omni one honest, explicit, operator-gated activation path that lives entirely inside existing files — no new modules, tests, daemons, services, public routes, or cron entries. The user's note was that current integration is unacceptable because **Omni never activates except manually**. After PR #2928 (dormant reasoning_content fallback) and PR #2931 (rectified perception sprawl that left @omni unreachable), Omni had no honest entry point. This restores one.

- `spark/harness/policy.py` + `spark/router_policy.yaml`: add a single `@omni` -> `nvidia/NVIDIA-Nemotron-Nano-Omni` entry to the existing `model_aliases` map. **Alias-only** — not in `roles`, not in `heuristics`, not in `directives`, not in `fallback_chain`.
- `spark/vybn_spark_agent.py`: extend the existing alias-override block (already shaped for `claude-`/`gpt-`/`nemotron-` prefixes) with one operator-gated branch: when `decision.alias_used == "@omni"`, read `VYBN_OMNI_URL` from env. If unset → refuse the turn with a clear error message and an `alias_omni_unconfigured` event. **No silent fallback to Super on :8000** so `@omni` cannot disturb the always-on Super topology. Optional `VYBN_OMNI_MODEL` overrides the default model id without editing YAML.
- Startup banner now mentions `@omni` and its env gate.

## ABC compliance

- `git diff --name-status main...HEAD` is **M-only**, no `A` entries.
- Omni is reachable **only** by an explicit user turn starting with `@omni`. Never via heuristic, directive, or fallback_chain.
- Activation requires the operator to (1) start the Omni endpoint on the peer Spark and (2) export `VYBN_OMNI_URL=http://<host>:<port>/v1`. This code reads the env var; it does not start, stop, or supervise any service.
- Super topology preserved: when `VYBN_OMNI_URL` is unset, `@omni` refuses rather than redirecting to `:8000`. No phantom Super traffic.
- PR #2928 behavior untouched (`providers.py` and `origins_portal_api_v4.py` not edited; the Omni reply shape continues through the existing `reasoning_content` fallback).

## Test plan

- [x] `python3 -m pytest spark/tests/test_lightweight_routing.py` — 45 passed, 6 skipped (pre-existing). 5 new Omni cases included: alias present in default policy; alias present in YAML; Omni not leaking into `fallback_chain`; no role/directive/heuristic mentions omni; `@omni` classifies and sets `model_override`.
- [x] `python3 -m pytest spark/tests/test_chat_routing.py` — 6 passed (PR #2928 reasoning_content fallback), 25 skipped (pre-existing).
- [x] `python3 -m pytest tests/test_origins_portal_contract.py` — 2 passed.
- [x] `python3 -m py_compile spark/vybn_spark_agent.py` — OK.
- [ ] Operator smoke: with peer-Spark Omni endpoint up, `export VYBN_OMNI_URL=http://<peer>:<port>/v1` and send `@omni hello` — expect routing through the existing OpenAIProvider + reasoning_content fallback.
- [ ] Operator negative smoke: with `VYBN_OMNI_URL` unset, `@omni hello` returns the explicit refusal envelope and emits `alias_omni_unconfigured`; no Super call is made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)