### PR TITLE
omni: operator-supplied perception packet on explicit @omni turn

### DIFF
--- a/spark/harness/policy.py
+++ b/spark/harness/policy.py
@@ -917,7 +917,11 @@ _DEFAULT_MODEL_ALIASES: dict[str, str] = {
     # and ordinary chat routing so Super topology (always-on, both Sparks)
     # is never silently interrupted. Without VYBN_OMNI_URL the alias surfaces
     # an explicit error rather than falling back to Super's :8000. Optional
-    # VYBN_OMNI_MODEL overrides the default model id below.
+    # VYBN_OMNI_MODEL overrides the default model id below. Optional
+    # VYBN_OMNI_PERCEPTION=<path> rides a bounded operator-supplied
+    # perception packet (text file) on the explicit @omni turn only — used
+    # for perception/dream/evolve narratives produced elsewhere in the
+    # repo; never auto-fires, never persists, never touches Super.
     "@omni": "nvidia/NVIDIA-Nemotron-Nano-Omni",
     "@gpt": "gpt-5.5",
     "@gpt5": "gpt-5.5",

--- a/spark/router_policy.yaml
+++ b/spark/router_policy.yaml
@@ -350,7 +350,12 @@ model_aliases:
   # activates when the user types @omni AND the operator has started an
   # Omni endpoint and exported VYBN_OMNI_URL. NOT in fallback_chain, NOT a
   # heuristic target, NOT a directive. Super topology stays untouched.
-  # Optional VYBN_OMNI_MODEL overrides the default model id.
+  # Optional VYBN_OMNI_MODEL overrides the default model id. Optional
+  # VYBN_OMNI_PERCEPTION=<path> rides a bounded operator-supplied
+  # perception packet (text file; e.g. a tail of
+  # continuous_local_compute.jsonl, a Him-vy discovery dump) on the
+  # explicit @omni turn only — never auto-fires, never persists, never
+  # touches Super.
   "@omni": nvidia/NVIDIA-Nemotron-Nano-Omni
   "@gpt": gpt-5.5
   "@gpt5": gpt-5.5

--- a/spark/tests/test_lightweight_routing.py
+++ b/spark/tests/test_lightweight_routing.py
@@ -845,3 +845,229 @@ def test_omni_alias_classifies_with_override():
     assert decision.alias_used == "@omni"
     assert decision.model_override == default_policy().model_aliases["@omni"]
 
+
+# Operator-supplied perception preamble. VYBN_OMNI_PERCEPTION is the env
+# var that lets a perception/dream/evolve text packet ride the explicit
+# @omni turn (and only that turn). It must be documented alongside the
+# @omni alias in both the YAML and the default-policy module so the
+# operator surface stays discoverable, and it must be wired in the agent
+# loop inside the same alias-override branch that already gates on
+# VYBN_OMNI_URL — never as a separate path that could fire without the
+# URL gate (which would risk leaking onto Super).
+def test_omni_perception_env_documented():
+    active = (
+        Path("spark/harness/policy.py").read_text()
+        + "\n"
+        + Path("spark/router_policy.yaml").read_text()
+    )
+    assert "VYBN_OMNI_PERCEPTION" in active
+
+
+def test_omni_perception_wired_in_agent_alias_branch():
+    text = Path("spark/vybn_spark_agent.py").read_text()
+    assert "VYBN_OMNI_PERCEPTION" in text
+    # The perception read must live inside the same @omni alias branch
+    # that gates on VYBN_OMNI_URL — i.e. between the alias_used == "@omni"
+    # check and the elif for claude- aliases. This guarantees perception
+    # is unreachable unless VYBN_OMNI_URL is set, so an unset operator
+    # cannot silently route a perception packet to Super on :8000.
+    omni_branch_idx = text.find('alias_used", None) == "@omni"')
+    elif_claude_idx = text.find('elif override_model.startswith("claude-")')
+    assert omni_branch_idx > 0
+    assert elif_claude_idx > omni_branch_idx
+    branch = text[omni_branch_idx:elif_claude_idx]
+    assert "VYBN_OMNI_URL" in branch
+    assert "VYBN_OMNI_PERCEPTION" in branch
+    assert "alias_omni_perception" in branch
+    # Bounded read — protects the turn against giant files. The agent
+    # reads at most this many bytes from the perception path.
+    assert "16_000" in branch or "16000" in branch
+
+
+def test_omni_perception_preamble_runs_on_explicit_omni_turn(tmp_path=None):
+    """End-to-end: with VYBN_OMNI_URL and VYBN_OMNI_PERCEPTION both set,
+    the explicit @omni turn prepends a bounded perception preamble to the
+    user message before the provider sees it. No persistence, no Super
+    fallback, no auto-fire — only on the alias turn."""
+    import importlib.util as _ilu
+    import os as _os
+    import tempfile as _tmp
+    from harness.policy import Router as _Router
+    from harness.policy import default_policy as _dp
+    from harness.substrate import LayeredPrompt as _LP
+
+    path = SPARK_DIR / "vybn_spark_agent.py"
+    spec = _ilu.spec_from_file_location("vybn_spark_agent_omni_test", path)
+    mod = _ilu.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    # Lightweight stand-ins for deep-memory + Him surfaces so the test
+    # exercises the @omni branch only and does not accidentally depend
+    # on RAG/torch model loading, which is expensive and pre-existing-
+    # skipped in this env.
+    saved_rag = mod.rag_snippets
+    saved_rag_tier = mod.rag_snippets_with_tier
+    saved_disc = mod.render_him_vy_discovery_packet
+    saved_turn = mod.render_him_vy_turn_packet
+    saved_probes = mod.run_probes
+    mod.rag_snippets = lambda *a, **kw: ""
+    mod.rag_snippets_with_tier = lambda *a, **kw: ("", "lightweight")
+    mod.render_him_vy_discovery_packet = lambda *a, **kw: ""
+    mod.render_him_vy_turn_packet = lambda *a, **kw: ""
+    mod.run_probes = lambda *a, **kw: []
+
+    captured_messages: list = []
+
+    class _FakeHandle:
+        def __iter__(_s):
+            return iter([])
+        def final(_s):
+            class _R:
+                text = "ok"
+                tool_calls = []
+                stop_reason = "end_turn"
+                in_tokens = 0
+                out_tokens = 0
+                raw_assistant_content = {"role": "assistant", "content": "ok"}
+            return _R()
+
+    class _FakeProvider:
+        def stream(_s, *, system, messages, tools, role):
+            captured_messages.extend(messages)
+            return _FakeHandle()
+
+    class _FakeRegistry:
+        def get(_s, cfg):
+            return _FakeProvider()
+
+    class _FakeLogger:
+        path = "/dev/null"
+        events: list = []
+        def emit(_s, name, **kw):
+            _s.events.append((name, kw))
+
+    pf = _tmp.NamedTemporaryFile("w", suffix=".txt", delete=False)
+    try:
+        pf.write("[him-vy continuous-compute tail]\nresidual=alive\n")
+        pf.flush()
+        pf.close()
+        prev_url = _os.environ.get("VYBN_OMNI_URL")
+        prev_perc = _os.environ.get("VYBN_OMNI_PERCEPTION")
+        _os.environ["VYBN_OMNI_URL"] = "http://127.0.0.1:65535/v1"
+        _os.environ["VYBN_OMNI_PERCEPTION"] = pf.name
+        try:
+            messages: list = []
+            logger = _FakeLogger()
+            mod.run_agent_loop(
+                user_input="@omni what do you see?",
+                messages=messages,
+                bash=None,
+                system_prompt=_LP(identity="I"),
+                system_prompt_no_tools=_LP(identity="I"),
+                router=_Router(_dp()),
+                registry=_FakeRegistry(),
+                logger=logger,
+                turn_number=1,
+            )
+            user_msgs = [
+                m for m in captured_messages if m.get("role") == "user"
+            ]
+            assert user_msgs, "provider never received a user message"
+            content = user_msgs[-1].get("content", "")
+            assert "perception packet" in content
+            assert "residual=alive" in content
+            assert "what do you see?" in content
+            event_names = [n for n, _ in logger.events]
+            assert "alias_omni_perception" in event_names
+        finally:
+            if prev_url is None:
+                _os.environ.pop("VYBN_OMNI_URL", None)
+            else:
+                _os.environ["VYBN_OMNI_URL"] = prev_url
+            if prev_perc is None:
+                _os.environ.pop("VYBN_OMNI_PERCEPTION", None)
+            else:
+                _os.environ["VYBN_OMNI_PERCEPTION"] = prev_perc
+    finally:
+        try:
+            _os.unlink(pf.name)
+        except OSError:
+            pass
+        mod.rag_snippets = saved_rag
+        mod.rag_snippets_with_tier = saved_rag_tier
+        mod.render_him_vy_discovery_packet = saved_disc
+        mod.render_him_vy_turn_packet = saved_turn
+        mod.run_probes = saved_probes
+
+
+def test_omni_perception_skipped_when_url_unset():
+    """If VYBN_OMNI_URL is unset, the @omni turn refuses with the
+    explicit error envelope and the perception path is never opened —
+    even if VYBN_OMNI_PERCEPTION points at a real file. Super topology
+    is preserved (no provider call)."""
+    import importlib.util as _ilu
+    import os as _os
+    import tempfile as _tmp
+    from harness.policy import Router as _Router
+    from harness.policy import default_policy as _dp
+
+    path = SPARK_DIR / "vybn_spark_agent.py"
+    spec = _ilu.spec_from_file_location(
+        "vybn_spark_agent_omni_unset_test", path,
+    )
+    mod = _ilu.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    class _FakeRegistry:
+        def get(_s, cfg):
+            raise AssertionError(
+                "@omni turn with VYBN_OMNI_URL unset must refuse before "
+                "any provider call — Super fallback is forbidden"
+            )
+
+    class _FakeLogger:
+        path = "/dev/null"
+        events: list = []
+        def emit(_s, name, **kw):
+            _s.events.append((name, kw))
+
+    pf = _tmp.NamedTemporaryFile("w", suffix=".txt", delete=False)
+    try:
+        pf.write("perception payload\n")
+        pf.flush()
+        pf.close()
+        prev_url = _os.environ.get("VYBN_OMNI_URL")
+        prev_perc = _os.environ.get("VYBN_OMNI_PERCEPTION")
+        _os.environ.pop("VYBN_OMNI_URL", None)
+        _os.environ["VYBN_OMNI_PERCEPTION"] = pf.name
+        try:
+            messages: list = []
+            logger = _FakeLogger()
+            reply = mod.run_agent_loop(
+                user_input="@omni hi",
+                messages=messages,
+                bash=None,
+                system_prompt=None,
+                router=_Router(_dp()),
+                registry=_FakeRegistry(),
+                logger=logger,
+                turn_number=1,
+            )
+            assert "VYBN_OMNI_URL" in reply
+            event_names = [n for n, _ in logger.events]
+            assert "alias_omni_unconfigured" in event_names
+            # Perception event must NOT have fired — the URL gate blocks it.
+            assert "alias_omni_perception" not in event_names
+        finally:
+            if prev_url is not None:
+                _os.environ["VYBN_OMNI_URL"] = prev_url
+            if prev_perc is None:
+                _os.environ.pop("VYBN_OMNI_PERCEPTION", None)
+            else:
+                _os.environ["VYBN_OMNI_PERCEPTION"] = prev_perc
+    finally:
+        try:
+            _os.unlink(pf.name)
+        except OSError:
+            pass
+

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -989,6 +989,50 @@ def run_agent_loop(
             )
             override_provider = "openai"
             override_base_url = _omni_url
+            # Operator-supplied perception preamble. When VYBN_OMNI_PERCEPTION
+            # points at a readable file, prepend a bounded prefix of its
+            # contents to this turn's user input so Omni receives the
+            # operator's perception/dream/evolve packet (e.g. a tail of
+            # continuous_local_compute.jsonl, a Him-vy discovery dump, an
+            # ObservationPacket text). This rides only the explicit @omni
+            # turn — never auto-fires, never touches Super, never persists
+            # to disk, and is bounded so a giant file cannot blow up the
+            # turn. Unreadable path is logged and the turn proceeds without
+            # the preamble; we do NOT silently route to Super.
+            _perception_path = (
+                os.environ.get("VYBN_OMNI_PERCEPTION") or ""
+            ).strip()
+            if _perception_path:
+                try:
+                    _ppath = os.path.expanduser(_perception_path)
+                    with open(_ppath, "r", encoding="utf-8", errors="replace") as _pf:
+                        _ptext = _pf.read(16_000)
+                    _ptext = _ptext.strip()
+                    if _ptext:
+                        decision.cleaned_input = (
+                            "[@omni perception packet — operator-supplied "
+                            f"from {_ppath}]\n{_ptext}\n[end perception "
+                            "packet]\n\n" + decision.cleaned_input
+                        )
+                        logger.emit(
+                            "alias_omni_perception",
+                            turn=turn_number,
+                            path=_ppath,
+                            chars=len(_ptext),
+                        )
+                    else:
+                        logger.emit(
+                            "alias_omni_perception_empty",
+                            turn=turn_number,
+                            path=_ppath,
+                        )
+                except Exception as _perr:
+                    logger.emit(
+                        "alias_omni_perception_error",
+                        turn=turn_number,
+                        path=_perception_path,
+                        err=repr(_perr)[:200],
+                    )
         elif override_model.startswith("claude-"):
             override_provider = "anthropic"
             override_base_url = None
@@ -2204,6 +2248,8 @@ def main() -> None:
     print("  or with @opus4.6/@opus4.6/@sonnet/@nemotron/@gpt to pin a model for one turn.")
     print("  @omni pins peer-Spark Nano-Omni — requires VYBN_OMNI_URL set; "
           "refuses (no Super fallback) when unset.")
+    print("    optional VYBN_OMNI_PERCEPTION=<path> rides a perception "
+          "packet on the @omni turn only.")
     print("  REPL commands: exit | clear | reload | history | policy | /resume | /sessions | /newsession")
     print()
 


### PR DESCRIPTION
## Summary

Makes the existing `@omni` alias (PR #2932) actually useful for perception/dream/evolve narratives by letting the operator ride a bounded text packet on the explicit `@omni` turn only. Lives entirely inside the existing alias-override branch in `spark/vybn_spark_agent.py` — no new files, modules, daemons, public routes, or heuristics.

After PRs #2928, #2931, and #2932 the surface had: (a) the dormant `reasoning_content` fallback in `providers.py`, (b) a single explicit `@omni` activation gated on `VYBN_OMNI_URL`, and (c) no way for the operator to put any perception/dream/evolve text in front of Omni at activation time. This restores the missing third leg without resurrecting the perception module that #2931 rectified.

## What changed (M-only)

- `spark/vybn_spark_agent.py`: inside the existing `if decision.alias_used == "@omni"` branch (after `VYBN_OMNI_URL` is confirmed set), optionally read `VYBN_OMNI_PERCEPTION` (path to a text file). If readable, prepend a bounded prefix (<=16k chars) of its contents to `decision.cleaned_input` as a `[@omni perception packet …]` envelope. Emits `alias_omni_perception` / `alias_omni_perception_empty` / `alias_omni_perception_error` events. The startup banner now lists `VYBN_OMNI_PERCEPTION` underneath the `@omni` line.
- `spark/router_policy.yaml` + `spark/harness/policy.py`: comment block on the `@omni` alias extended to document `VYBN_OMNI_PERCEPTION`.
- `spark/tests/test_lightweight_routing.py`: four new tests (added to the existing file, no new test files).

## ABC compliance

- `git diff --name-status main...HEAD` is **M-only** — no `A` entries.
- Activation surface unchanged: `@omni` is still alias-only, still absent from `roles`, `heuristics`, `directives`, and `fallback_chain`.
- The perception read is structurally inside the same alias-omni branch that gates on `VYBN_OMNI_URL`. With `VYBN_OMNI_URL` unset the turn refuses with the existing envelope and the perception path is never opened — verified by a tripwire test that fails the assertion if any provider call is made.
- No daemon, cron, public route, or new test file is created. No persistence — the preamble rides one turn and is gone.
- Super topology preserved: `@omni` still cannot disturb the always-on Super on `:8000`.
- PR #2928 reasoning_content fallback untouched.

## Tests

```
$ python3 -m pytest spark/tests/test_lightweight_routing.py
49 passed, 6 skipped (skips pre-existing)

$ python3 -m pytest spark/tests/test_chat_routing.py tests/test_origins_portal_contract.py
8 passed, 25 skipped (skips pre-existing)
```

New cases:

- `test_omni_perception_env_documented` — `VYBN_OMNI_PERCEPTION` documented in YAML + policy.py.
- `test_omni_perception_wired_in_agent_alias_branch` — textual contract that the perception read is inside the same alias-omni branch that gates on `VYBN_OMNI_URL` and the read is bounded.
- `test_omni_perception_preamble_runs_on_explicit_omni_turn` — end-to-end via `run_agent_loop` with a `FakeProvider`. Verifies the user message the provider sees contains both the perception body and the original user text, and that `alias_omni_perception` is emitted.
- `test_omni_perception_skipped_when_url_unset` — with `VYBN_OMNI_URL` unset and `VYBN_OMNI_PERCEPTION` set to a real file, the turn refuses with the existing envelope, no provider call is made, and `alias_omni_perception` never fires.

## Operator usage

```
# 1. Start the Omni endpoint on the peer Spark and:
export VYBN_OMNI_URL=http://<host>:<port>/v1
# 2. (Optional) point at any text artifact you want Omni to perceive:
export VYBN_OMNI_PERCEPTION="$HOME/.local/state/vybn/continuous_local_compute.jsonl"
# 3. Activate explicitly:
@omni what do you make of the residue?
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)