### PR TITLE
harness: explicit maintenance/deferral gate for local model availability

### DIFF
--- a/spark/tests/test_lightweight_routing.py
+++ b/spark/tests/test_lightweight_routing.py
@@ -1071,3 +1071,352 @@ def test_omni_perception_skipped_when_url_unset():
         except OSError:
             pass
 
+
+# Super maintenance / deferral gate. Operator-armed VYBN_SUPER_MAINTENANCE
+# short-circuits any local-Super-bound turn with an honest "paused, retry
+# shortly" notice instead of either hanging on the SDK timeout or surfacing
+# a raw "(provider error: Connection refused)" string. The same notice
+# appears when an in-flight call refuses (Super was bounced by something
+# else, or vLLM died). Cloud Anthropic / OpenAI traffic is unaffected.
+def _load_agent_module():
+    import importlib.util as _ilu
+    path = SPARK_DIR / "vybn_spark_agent.py"
+    spec = _ilu.spec_from_file_location("vybn_spark_agent_maint_test", path)
+    mod = _ilu.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_is_local_super_base_classifies_loopback_and_lan():
+    mod = _load_agent_module()
+    assert mod._is_local_super_base("http://127.0.0.1:8000/v1") is True
+    assert mod._is_local_super_base("http://localhost:8000/v1") is True
+    assert mod._is_local_super_base("http://10.0.0.5:8001/v1") is True
+    assert mod._is_local_super_base("http://192.168.1.42:8000/v1") is True
+    assert mod._is_local_super_base("http://172.16.5.5:8000/v1") is True
+    # Public hosts must not trigger the gate.
+    assert mod._is_local_super_base("https://api.openai.com/v1") is False
+    assert mod._is_local_super_base("https://api.anthropic.com") is False
+    assert mod._is_local_super_base(None) is False
+    assert mod._is_local_super_base("") is False
+    # 172.32.x is outside the 172.16-31 private block.
+    assert mod._is_local_super_base("http://172.32.0.1/v1") is False
+
+
+def test_super_maintenance_state_reads_env_flag_and_file():
+    import os as _os
+    import tempfile as _tmp
+    mod = _load_agent_module()
+    prev_flag = _os.environ.get("VYBN_SUPER_MAINTENANCE")
+    prev_file = _os.environ.get("VYBN_SUPER_MAINTENANCE_FILE")
+    try:
+        # Unset -> inactive.
+        _os.environ.pop("VYBN_SUPER_MAINTENANCE", None)
+        _os.environ.pop("VYBN_SUPER_MAINTENANCE_FILE", None)
+        active, _ = mod._super_maintenance_state()
+        assert active is False
+        # Truthy bare flag -> active with default reason.
+        _os.environ["VYBN_SUPER_MAINTENANCE"] = "1"
+        active, reason = mod._super_maintenance_state()
+        assert active is True
+        assert reason
+        # Falsy literal -> inactive.
+        _os.environ["VYBN_SUPER_MAINTENANCE"] = "0"
+        active, _ = mod._super_maintenance_state()
+        assert active is False
+        # Custom string reason -> active with that string.
+        _os.environ["VYBN_SUPER_MAINTENANCE"] = "GPU rebalance for omni window"
+        active, reason = mod._super_maintenance_state()
+        assert active is True
+        assert "GPU rebalance" in reason
+        # File overrides bare flag's default reason.
+        _os.environ["VYBN_SUPER_MAINTENANCE"] = "1"
+        f = _tmp.NamedTemporaryFile("w", suffix=".txt", delete=False)
+        try:
+            f.write("operator note: bouncing super at 09:00")
+            f.flush()
+            f.close()
+            _os.environ["VYBN_SUPER_MAINTENANCE_FILE"] = f.name
+            active, reason = mod._super_maintenance_state()
+            assert active is True
+            assert "09:00" in reason
+        finally:
+            try:
+                _os.unlink(f.name)
+            except OSError:
+                pass
+            _os.environ.pop("VYBN_SUPER_MAINTENANCE_FILE", None)
+    finally:
+        if prev_flag is None:
+            _os.environ.pop("VYBN_SUPER_MAINTENANCE", None)
+        else:
+            _os.environ["VYBN_SUPER_MAINTENANCE"] = prev_flag
+        if prev_file is None:
+            _os.environ.pop("VYBN_SUPER_MAINTENANCE_FILE", None)
+        else:
+            _os.environ["VYBN_SUPER_MAINTENANCE_FILE"] = prev_file
+
+
+def test_super_maintenance_gate_short_circuits_local_turn():
+    """When VYBN_SUPER_MAINTENANCE is armed and the resolved role's base_url
+    is local Super, run_agent_loop returns a maintenance notice without ever
+    constructing a provider — no ~10-min restart needed, no raw
+    'Connection refused' surfaces to the chat."""
+    import os as _os
+    from harness.policy import Router as _Router
+    from harness.policy import default_policy as _dp
+
+    mod = _load_agent_module()
+    # Lightweight stand-ins so the test exercises only the gate.
+    saved_rag = mod.rag_snippets
+    saved_rag_tier = mod.rag_snippets_with_tier
+    saved_disc = mod.render_him_vy_discovery_packet
+    saved_turn = mod.render_him_vy_turn_packet
+    saved_probes = mod.run_probes
+    mod.rag_snippets = lambda *a, **kw: ""
+    mod.rag_snippets_with_tier = lambda *a, **kw: ("", "lightweight")
+    mod.render_him_vy_discovery_packet = lambda *a, **kw: ""
+    mod.render_him_vy_turn_packet = lambda *a, **kw: ""
+    mod.run_probes = lambda *a, **kw: []
+
+    class _FakeRegistry:
+        def get(_s, cfg):
+            raise AssertionError(
+                "maintenance flag must short-circuit BEFORE any provider "
+                "is constructed — Super must not be touched"
+            )
+
+    class _FakeLogger:
+        path = "/dev/null"
+        def __init__(_s):
+            _s.events = []
+        def emit(_s, name, **kw):
+            _s.events.append((name, kw))
+
+    prev_flag = _os.environ.get("VYBN_SUPER_MAINTENANCE")
+    deferrals_before = len(mod._MAINTENANCE_DEFERRALS)
+    try:
+        _os.environ["VYBN_SUPER_MAINTENANCE"] = "operator paused for omni window"
+        logger = _FakeLogger()
+        # /local directive routes to the local_private role whose base_url
+        # is http://127.0.0.1:8000/v1 — the canonical Super endpoint.
+        reply = mod.run_agent_loop(
+            user_input="/local scan him for funders",
+            messages=[],
+            bash=None,
+            system_prompt=None,
+            router=_Router(_dp()),
+            registry=_FakeRegistry(),
+            logger=logger,
+            turn_number=1,
+        )
+        assert "maintenance" in reply.lower() or "paused" in reply.lower()
+        assert "retry" in reply.lower()
+        assert "omni window" in reply
+        # Bounded deferral was recorded.
+        assert len(mod._MAINTENANCE_DEFERRALS) == deferrals_before + 1
+        # The maintenance notice event was emitted.
+        names = [n for n, _ in logger.events]
+        assert "super_maintenance_notice" in names
+    finally:
+        if prev_flag is None:
+            _os.environ.pop("VYBN_SUPER_MAINTENANCE", None)
+        else:
+            _os.environ["VYBN_SUPER_MAINTENANCE"] = prev_flag
+        # Trim the deferral list back so we don't leak across tests.
+        del mod._MAINTENANCE_DEFERRALS[deferrals_before:]
+        mod.rag_snippets = saved_rag
+        mod.rag_snippets_with_tier = saved_rag_tier
+        mod.render_him_vy_discovery_packet = saved_disc
+        mod.render_him_vy_turn_packet = saved_turn
+        mod.run_probes = saved_probes
+
+
+def test_super_maintenance_gate_does_not_fire_on_cloud_turn():
+    """A cloud Anthropic/OpenAI turn must never be short-circuited by the
+    Super maintenance flag — Super pause only applies to the local
+    endpoint. We assert this by arming the flag, sending a turn that
+    routes to a cloud model, and confirming the registry IS consulted
+    (the gate did not short-circuit)."""
+    import os as _os
+    from harness.policy import Router as _Router
+    from harness.policy import default_policy as _dp
+
+    mod = _load_agent_module()
+    saved_rag = mod.rag_snippets
+    saved_rag_tier = mod.rag_snippets_with_tier
+    saved_disc = mod.render_him_vy_discovery_packet
+    saved_turn = mod.render_him_vy_turn_packet
+    saved_probes = mod.run_probes
+    mod.rag_snippets = lambda *a, **kw: ""
+    mod.rag_snippets_with_tier = lambda *a, **kw: ("", "lightweight")
+    mod.render_him_vy_discovery_packet = lambda *a, **kw: ""
+    mod.render_him_vy_turn_packet = lambda *a, **kw: ""
+    mod.run_probes = lambda *a, **kw: []
+
+    consulted = {"count": 0}
+
+    class _FakeHandle:
+        def __iter__(_s):
+            return iter([])
+        def final(_s):
+            class _R:
+                text = "ok"
+                tool_calls = []
+                stop_reason = "end_turn"
+                in_tokens = 0
+                out_tokens = 0
+                raw_assistant_content = {"role": "assistant", "content": "ok"}
+            return _R()
+
+    class _FakeProvider:
+        def stream(_s, *, system, messages, tools, role):
+            return _FakeHandle()
+
+    class _FakeRegistry:
+        def get(_s, cfg):
+            consulted["count"] += 1
+            return _FakeProvider()
+
+    class _FakeLogger:
+        path = "/dev/null"
+        def __init__(_s):
+            _s.events = []
+        def emit(_s, name, **kw):
+            _s.events.append((name, kw))
+
+    prev_flag = _os.environ.get("VYBN_SUPER_MAINTENANCE")
+    try:
+        _os.environ["VYBN_SUPER_MAINTENANCE"] = "1"
+        # @sonnet pins a cloud Anthropic model — base_url is None.
+        logger = _FakeLogger()
+        mod.run_agent_loop(
+            user_input="@sonnet hi",
+            messages=[],
+            bash=None,
+            system_prompt=None,
+            router=_Router(_dp()),
+            registry=_FakeRegistry(),
+            logger=logger,
+            turn_number=1,
+        )
+        assert consulted["count"] >= 1, (
+            "cloud turn must reach the provider; super-maintenance must not "
+            "block non-local routes"
+        )
+        names = [n for n, _ in logger.events]
+        assert "super_maintenance_notice" not in names
+    finally:
+        if prev_flag is None:
+            _os.environ.pop("VYBN_SUPER_MAINTENANCE", None)
+        else:
+            _os.environ["VYBN_SUPER_MAINTENANCE"] = prev_flag
+        mod.rag_snippets = saved_rag
+        mod.rag_snippets_with_tier = saved_rag_tier
+        mod.render_him_vy_discovery_packet = saved_disc
+        mod.render_him_vy_turn_packet = saved_turn
+        mod.run_probes = saved_probes
+
+
+def test_super_refusal_converts_to_maintenance_notice():
+    """Without the maintenance flag set, a transport refusal from local
+    Super (e.g. vLLM crashed or rebooting) gets converted to the same
+    visible "paused, retry shortly" notice instead of surfacing as
+    '(provider error: ConnectionError: Connection refused)'. The
+    classification mirrors OpenAIProvider._call's transport_signals."""
+    import os as _os
+    from harness.policy import Router as _Router
+    from harness.policy import default_policy as _dp
+
+    mod = _load_agent_module()
+    saved_rag = mod.rag_snippets
+    saved_rag_tier = mod.rag_snippets_with_tier
+    saved_disc = mod.render_him_vy_discovery_packet
+    saved_turn = mod.render_him_vy_turn_packet
+    saved_probes = mod.run_probes
+    mod.rag_snippets = lambda *a, **kw: ""
+    mod.rag_snippets_with_tier = lambda *a, **kw: ("", "lightweight")
+    mod.render_him_vy_discovery_packet = lambda *a, **kw: ""
+    mod.render_him_vy_turn_packet = lambda *a, **kw: ""
+    mod.run_probes = lambda *a, **kw: []
+
+    class _RefusingProvider:
+        def stream(_s, *, system, messages, tools, role):
+            raise ConnectionError(
+                "HTTPConnectionPool(host='127.0.0.1', port=8000): "
+                "Max retries exceeded — connection refused"
+            )
+
+    class _FakeRegistry:
+        def get(_s, cfg):
+            return _RefusingProvider()
+
+    class _FakeLogger:
+        path = "/dev/null"
+        def __init__(_s):
+            _s.events = []
+        def emit(_s, name, **kw):
+            _s.events.append((name, kw))
+
+    prev_flag = _os.environ.get("VYBN_SUPER_MAINTENANCE")
+    deferrals_before = len(mod._MAINTENANCE_DEFERRALS)
+    try:
+        _os.environ.pop("VYBN_SUPER_MAINTENANCE", None)
+        logger = _FakeLogger()
+        reply = mod.run_agent_loop(
+            user_input="/local scan him for funders",
+            messages=[],
+            bash=None,
+            system_prompt=None,
+            router=_Router(_dp()),
+            registry=_FakeRegistry(),
+            logger=logger,
+            turn_number=1,
+        )
+        assert "Super" in reply or "maintenance" in reply.lower() or "paused" in reply.lower()
+        assert "retry" in reply.lower()
+        # Raw "(provider error: …)" must NOT leak through anymore for this
+        # transport class against local Super.
+        assert "(provider error" not in reply.lower()
+        # Deferral and event wiring fired.
+        assert len(mod._MAINTENANCE_DEFERRALS) == deferrals_before + 1
+        names = [n for n, _ in logger.events]
+        assert "super_maintenance_notice" in names
+        # The provider_error event still fires (with the conversion flag),
+        # so observability into refusals is preserved.
+        assert "provider_error" in names
+    finally:
+        if prev_flag is not None:
+            _os.environ["VYBN_SUPER_MAINTENANCE"] = prev_flag
+        del mod._MAINTENANCE_DEFERRALS[deferrals_before:]
+        mod.rag_snippets = saved_rag
+        mod.rag_snippets_with_tier = saved_rag_tier
+        mod.render_him_vy_discovery_packet = saved_disc
+        mod.render_him_vy_turn_packet = saved_turn
+        mod.run_probes = saved_probes
+
+
+def test_maintenance_deferrals_are_bounded():
+    """The in-memory deferral list never grows past the cap. This is a
+    deferral notice, not a durable queue — bounded length is part of the
+    honesty contract."""
+    mod = _load_agent_module()
+    saved = list(mod._MAINTENANCE_DEFERRALS)
+    try:
+        mod._MAINTENANCE_DEFERRALS.clear()
+        cap = mod._MAINTENANCE_DEFERRALS_CAP
+        for i in range(cap + 25):
+            mod._format_super_maintenance_notice(
+                reason=f"reason-{i}",
+                cause="flag",
+                role_model="nemotron",
+                role_base="http://127.0.0.1:8000/v1",
+                logger=None,
+                turn_number=i,
+            )
+        assert len(mod._MAINTENANCE_DEFERRALS) == cap
+    finally:
+        mod._MAINTENANCE_DEFERRALS.clear()
+        mod._MAINTENANCE_DEFERRALS.extend(saved)
+
+

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import os
 import sys
+import time
 
 # Ensure the spark/ directory is importable when this file is run directly.
 _SPARK_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -662,6 +663,143 @@ _TRANSIENT_PATTERNS = (
 )
 
 
+# Local-Super maintenance / deferral gate.
+#
+# Super (the always-on local OpenAI-compatible endpoint, typically vLLM at
+# 127.0.0.1:8000/v1) takes ~10 minutes to restart, so the operator strongly
+# prefers NOT to bounce it. When Super is intentionally paused (operator is
+# running an explicit Omni perception window, doing GPU maintenance, etc.)
+# or when its endpoint refuses connections in-flight, the chat surface used
+# to either hang on the SDK timeout or surface a raw "(provider error: …
+# Connection refused)" string. Both are bad for an interlocutor: the chat
+# does not learn that something is intentionally paused and that it can
+# retry shortly.
+#
+# This block adds a small, honest gate:
+#   * VYBN_SUPER_MAINTENANCE (and optional VYBN_SUPER_MAINTENANCE_FILE)
+#     mark Super as paused before any provider call is made.
+#   * _is_local_super_base() classifies a base_url as Super-local so the
+#     gate only triggers for the local endpoint, never for cloud Anthropic
+#     or OpenAI calls.
+#   * _format_super_maintenance_notice() returns the user-visible text and
+#     records a bounded deferral entry in _MAINTENANCE_DEFERRALS so the
+#     operator can see how many turns landed during the window. The list
+#     is intentionally bounded and in-memory: this is a deferral notice,
+#     not a durable queue, and we do not promise background delivery
+#     because there is no executor for it.
+#
+# vLLM does ship sleep mode (/sleep, /wake_up, /is_sleeping) when launched
+# with VLLM_SERVER_DEV_MODE=1 + --enable-sleep-mode, but this Super does
+# not expose those endpoints today. The gate therefore degrades to
+# explicit operator-controlled maintenance state rather than probing.
+
+_MAINTENANCE_DEFERRALS_CAP = 32
+_MAINTENANCE_DEFERRALS: list[dict[str, Any]] = []
+
+
+def _is_local_super_base(base_url: str | None) -> bool:
+    """True when base_url points at a loopback/private-LAN OpenAI-compatible
+    endpoint (i.e. Super or peer-Spark Omni), false for cloud providers.
+
+    Cloud Anthropic / OpenAI traffic is unaffected by Super maintenance —
+    the gate must never fire on those paths.
+    """
+    if not base_url:
+        return False
+    b = base_url.lower()
+    if "://" not in b:
+        return False
+    host = b.split("://", 1)[1].split("/", 1)[0].split(":", 1)[0]
+    if host in ("localhost", "127.0.0.1", "0.0.0.0", "::1"):
+        return True
+    if host.startswith("10.") or host.startswith("192.168."):
+        return True
+    if host.startswith("172."):
+        try:
+            second = int(host.split(".", 2)[1])
+            if 16 <= second <= 31:
+                return True
+        except (ValueError, IndexError):
+            return False
+    return False
+
+
+def _super_maintenance_state() -> tuple[bool, str]:
+    """Return (active, message). Active when VYBN_SUPER_MAINTENANCE is set
+    to a truthy value, or when VYBN_SUPER_MAINTENANCE_FILE points at a
+    readable file. The file's contents (bounded to 400 chars) become the
+    operator-visible reason; otherwise VYBN_SUPER_MAINTENANCE's value is
+    used verbatim. Empty/whitespace values from the env or file are
+    treated as a generic reason rather than ignored, so the operator
+    cannot accidentally arm the flag without arming the message."""
+    raw = (os.environ.get("VYBN_SUPER_MAINTENANCE") or "").strip()
+    path = (os.environ.get("VYBN_SUPER_MAINTENANCE_FILE") or "").strip()
+    file_msg = ""
+    if path:
+        try:
+            with open(os.path.expanduser(path), "r", encoding="utf-8", errors="replace") as fh:
+                file_msg = fh.read(400).strip()
+        except OSError:
+            file_msg = ""
+    truthy_env = raw and raw.lower() not in ("0", "false", "no", "off")
+    if not truthy_env and not file_msg:
+        return False, ""
+    if file_msg:
+        return True, file_msg
+    if raw and raw not in ("1", "true", "yes", "on"):
+        return True, raw
+    return True, "operator paused Super for maintenance"
+
+
+def _format_super_maintenance_notice(
+    *,
+    reason: str,
+    cause: str,
+    role_model: str | None,
+    role_base: str | None,
+    logger: "EventLogger | None",
+    turn_number: int | None,
+) -> str:
+    """Build the user-visible maintenance reply and record a bounded
+    deferral entry. cause is "flag" (operator armed the env flag) or
+    "refused" (endpoint refused/timed out in-flight)."""
+    entry = {
+        "ts": time.time(),
+        "cause": cause,
+        "reason": reason[:200],
+        "model": role_model,
+    }
+    _MAINTENANCE_DEFERRALS.append(entry)
+    if len(_MAINTENANCE_DEFERRALS) > _MAINTENANCE_DEFERRALS_CAP:
+        del _MAINTENANCE_DEFERRALS[: len(_MAINTENANCE_DEFERRALS) - _MAINTENANCE_DEFERRALS_CAP]
+    deferred = len(_MAINTENANCE_DEFERRALS)
+    if logger is not None:
+        try:
+            logger.emit(
+                "super_maintenance_notice",
+                turn=turn_number,
+                cause=cause,
+                model=role_model,
+                deferred=deferred,
+            )
+        except Exception:
+            pass
+    if cause == "refused":
+        head = (
+            "[Super is briefly unreachable — endpoint refused this turn. "
+            "Resuming shortly; please retry."
+        )
+    else:
+        head = (
+            "[Super is in maintenance — paused by the operator. "
+            "Resuming shortly; please retry."
+        )
+    if reason:
+        head += f" reason: {reason}"
+    head += f" deferred-this-session: {deferred}]"
+    return head
+
+
 def _sanitize_provider_error(exc: BaseException, limit: int = 160) -> str:
     """Return a short, safe excerpt of a provider error.
 
@@ -1143,6 +1281,32 @@ def run_agent_loop(
         )
         return reply
 
+    # Pre-flight Super maintenance gate. Operator-armed VYBN_SUPER_MAINTENANCE
+    # short-circuits any turn whose resolved provider base_url points at a
+    # loopback / private-LAN OpenAI-compatible endpoint (Super on :8000 or
+    # peer-Spark Omni). This avoids the ~10-min restart cost: instead of
+    # stopping the vLLM server, the operator flips a flag, every chat
+    # surface gets an honest "paused, retry shortly" notice, and Super
+    # stays warm. Cloud Anthropic / OpenAI traffic is untouched because
+    # _is_local_super_base only matches loopback / RFC1918 hosts. The
+    # gate runs before registry.get so no provider is constructed and
+    # the local endpoint is not even probed.
+    if _is_local_super_base(role_cfg.base_url):
+        _maint_active, _maint_reason = _super_maintenance_state()
+        if _maint_active:
+            notice = _format_super_maintenance_notice(
+                reason=_maint_reason,
+                cause="flag",
+                role_model=role_cfg.model,
+                role_base=role_cfg.base_url,
+                logger=logger,
+                turn_number=turn_number,
+            )
+            _warn(notice)
+            messages.append({"role": "user", "content": decision.cleaned_input})
+            messages.append({"role": "assistant", "content": notice})
+            return notice
+
     provider = registry.get(role_cfg)
 
     # Executable Him discovery packet. This is generated before provider
@@ -1354,11 +1518,45 @@ def run_agent_loop(
                 bag["stop_reason"] = "interrupted"
                 return "(interrupted during API call)"
             except Exception as e:
+                # In-flight refusal against local Super (or peer-Spark Omni)
+                # is converted to a visible maintenance/resume-shortly
+                # notice instead of a raw "(provider error: …)" string.
+                # The classification below mirrors the transport_signals
+                # used in OpenAIProvider._call so the user-visible behavior
+                # is consistent whether the failure surfaces from the SDK
+                # path or the raw-HTTP fallback. Cloud provider errors and
+                # non-transport local errors continue to surface raw —
+                # those are real bugs and should not be hidden.
+                _err_msg = _sanitize_provider_error(e)
+                _err_lower = str(e).lower()
+                _refusal_signals = (
+                    "connection", "refused", "timed out",
+                    "connect", "name or service", "temporar",
+                    "max retries exceeded",
+                )
+                _is_refusal = any(sig in _err_lower for sig in _refusal_signals)
+                if _is_refusal and _is_local_super_base(role_cfg.base_url):
+                    bag["stop_reason"] = "super_maintenance"
+                    logger.emit(
+                        "provider_error",
+                        turn=turn_number,
+                        error=str(e),
+                        super_maintenance_converted=True,
+                    )
+                    notice = _format_super_maintenance_notice(
+                        reason=_err_msg,
+                        cause="refused",
+                        role_model=role_cfg.model,
+                        role_base=role_cfg.base_url,
+                        logger=logger,
+                        turn_number=turn_number,
+                    )
+                    _warn(notice)
+                    return notice
                 bag["stop_reason"] = "error"
                 logger.emit("provider_error", turn=turn_number, error=str(e))
-                _msg = _sanitize_provider_error(e)
-                _warn(f"provider error ({e.__class__.__name__}): {_msg}")
-                return f"(provider error: {e.__class__.__name__}: {_msg})"
+                _warn(f"provider error ({e.__class__.__name__}): {_err_msg}")
+                return f"(provider error: {e.__class__.__name__}: {_err_msg})"
 
             bag["in_tokens"] += response.in_tokens
             bag["out_tokens"] += response.out_tokens


### PR DESCRIPTION
## Summary

Adds a small operator-controlled maintenance gate inside the existing
agent loop so that any local-endpoint outage (operator-armed pause **or**
in-flight refusal) surfaces to chat as a visible *\"paused, retry shortly\"*
notice instead of either hanging on the SDK timeout or returning a raw
`(provider error: Connection refused)` string. The interlocutor learns
that something is intentionally paused and can retry, rather than seeing
a silent failure.

The gate avoids restart churn on the local always-on server: the operator
pauses traffic via an environment flag without bouncing the server.

Two entry points, both confined to `spark/vybn_spark_agent.py`:

- **Pre-flight flag:** `VYBN_SUPER_MAINTENANCE` (with optional
  `VYBN_SUPER_MAINTENANCE_FILE` for a free-form reason) short-circuits
  any turn whose resolved provider base URL points at a loopback /
  RFC1918 host. No provider is constructed; the local endpoint is not
  touched.
- **In-flight refusal conversion:** ConnectionError / refused / timeout
  raised against the same local host class is rewritten through the
  same notice path. Cloud Anthropic / OpenAI traffic is untouched —
  the host classifier only matches loopback / RFC1918 — and
  `provider_error` events still emit so observability is preserved.

The deferral list is bounded (32 entries, in-memory) and explicitly
labelled as a deferral notice, not a durable queue, because there is
no executor to honor delivery promises.

No new files, modules, routes, daemons, or services. The change lives
in the existing agent-loop home next to the `@omni` alias gate.

## Test plan

- [x] `python -m pytest spark/tests/test_lightweight_routing.py` — 55 passed, 6 skipped (pre-existing skips for missing torch/HF), including 6 new tests covering:
  - host classification (loopback / 10.x / 192.168.x / 172.16-31 vs cloud)
  - env-flag and file parsing (truthy / falsy / file-overrides)
  - pre-flight short-circuit on a `/local` Super-bound turn (provider never constructed)
  - non-firing on a cloud Anthropic turn while the flag is armed
  - in-flight refusal conversion against `127.0.0.1:8000`
  - bounded deferral list

---
🤖 *Generated by Computer*