### PR TITLE
vllm: operator-controlled extra-args hook for sleep-mode interleaving

### DIFF
--- a/spark/systemd/vybn-vllm.service
+++ b/spark/systemd/vybn-vllm.service
@@ -26,6 +26,25 @@ ExecStartPre=/bin/bash -c '%h/spark-vllm-docker/launch-cluster.sh -n 169.254.246
 # utilization and max-num-seqs rather than CPU swap reservation.
 Environment=VYBN_VLLM_GPU_MEMORY_UTILIZATION=0.78
 Environment=VYBN_VLLM_MAX_NUM_SEQS=8
+# Optional extra vLLM CLI args appended verbatim to `vllm serve`. Empty by
+# default. Use `~/.config/vybn/vllm.env` to set this for scheduled
+# Super/Omni interleaving experiments without editing the unit file.
+#
+# Sleep mode (controlled Super/Omni interleaving): vLLM exposes /sleep,
+# /wake_up, and /is_sleeping ONLY when the server is launched with both
+#   VLLM_SERVER_DEV_MODE=1   (env var, propagated to the vllm process)
+#   --enable-sleep-mode      (CLI flag on `vllm serve`)
+# These are internal dev endpoints. They must NOT be publicly exposed:
+# the portal / public tier MUST NOT route to them, and the cluster front
+# door already binds vLLM to the internal LAN. Treat enabling sleep mode
+# as scheduled maintenance, the same way capacity profile changes are
+# treated.
+#
+# Example `~/.config/vybn/vllm.env` for an interleaving experiment:
+#   VYBN_VLLM_EXTRA_ARGS=--enable-sleep-mode
+#   VLLM_SERVER_DEV_MODE=1
+# Then: systemctl --user daemon-reload && systemctl --user restart vybn-vllm.service
+Environment=VYBN_VLLM_EXTRA_ARGS=
 EnvironmentFile=-%h/.config/vybn/vllm.env
 # Foreground (no -d) so systemd supervises.
 ExecStart=/home/vybnz69/spark-vllm-docker/launch-cluster.sh \
@@ -37,7 +56,8 @@ ExecStart=/home/vybnz69/spark-vllm-docker/launch-cluster.sh \
   --max-num-seqs ${VYBN_VLLM_MAX_NUM_SEQS} \
   --tensor-parallel-size 1 --pipeline-parallel-size 2 \
   --distributed-executor-backend ray \
-  --trust-remote-code
+  --trust-remote-code \
+  ${VYBN_VLLM_EXTRA_ARGS}
 ExecStop=/bin/bash -c '%h/spark-vllm-docker/launch-cluster.sh -n 169.254.246.181,169.254.51.101 stop || true'
 Restart=always
 RestartSec=30


### PR DESCRIPTION
## Summary

- Adds a single `VYBN_VLLM_EXTRA_ARGS=` env hook (default empty) to `spark/systemd/vybn-vllm.service`, expanded at the end of the existing `ExecStart` for `vllm serve`.
- Embeds an inline operator warning that vLLM `/sleep`, `/wake_up`, `/is_sleeping` are **internal dev endpoints**, only present when the server runs with `VLLM_SERVER_DEV_MODE=1` and `--enable-sleep-mode`, and must not be publicly exposed.
- No new files. No daemon, no router, no new module. Existing `EnvironmentFile=-%h/.config/vybn/vllm.env` already gives operators the override channel; this PR just makes it possible to add CLI flags through it.

## Motivation

Controlled Super/Omni interleaving experiments need vLLM sleep mode without a unit-file edit (and without restart churn) every time. Today, enabling sleep mode requires editing the unit. After this change, an operator drops one line into `~/.config/vybn/vllm.env`, runs `daemon-reload && restart`, and the existing PR #2935 maintenance/deferral gate covers the warm-up window.

## Shape

```
Environment=VYBN_VLLM_EXTRA_ARGS=
ExecStart=... \
  --trust-remote-code \
  ${VYBN_VLLM_EXTRA_ARGS}
```

Operator opts in via:

```
# ~/.config/vybn/vllm.env
VYBN_VLLM_EXTRA_ARGS=--enable-sleep-mode
VLLM_SERVER_DEV_MODE=1
```

`VLLM_SERVER_DEV_MODE` is the upstream-recognized name and is read directly from the EnvironmentFile, so there is no second knob to keep in sync.

## Testing

- `systemd-analyze verify spark/systemd/vybn-vllm.service` returns the same single pre-existing diagnostic (`launch-cluster.sh` not present in this sandbox) before and after the change — i.e. no new syntax issues introduced.
- `pytest spark/tests/test_continuous_local_compute.py` — passes (sibling systemd unit tests still green).
- No existing test asserts content of `vybn-vllm.service`, so per ABC no new test file was added just to satisfy a quota.

🤖 Generated with [Claude Code](https://claude.com/claude-code)