### PR TITLE
vllm: propagate sleep-mode dev env into container command

### DIFF
--- a/spark/systemd/vybn-vllm.service
+++ b/spark/systemd/vybn-vllm.service
@@ -32,7 +32,7 @@ Environment=VYBN_VLLM_MAX_NUM_SEQS=8
 #
 # Sleep mode (controlled Super/Omni interleaving): vLLM exposes /sleep,
 # /wake_up, and /is_sleeping ONLY when the server is launched with both
-#   VLLM_SERVER_DEV_MODE=1   (env var, propagated to the vllm process)
+#   VLLM_SERVER_DEV_MODE=1   (env var, explicitly passed through env to the vllm process)
 #   --enable-sleep-mode      (CLI flag on `vllm serve`)
 # These are internal dev endpoints. They must NOT be publicly exposed:
 # the portal / public tier MUST NOT route to them, and the cluster front
@@ -45,11 +45,13 @@ Environment=VYBN_VLLM_MAX_NUM_SEQS=8
 #   VLLM_SERVER_DEV_MODE=1
 # Then: systemctl --user daemon-reload && systemctl --user restart vybn-vllm.service
 Environment=VYBN_VLLM_EXTRA_ARGS=
+Environment=VLLM_SERVER_DEV_MODE=
 EnvironmentFile=-%h/.config/vybn/vllm.env
 # Foreground (no -d) so systemd supervises.
 ExecStart=/home/vybnz69/spark-vllm-docker/launch-cluster.sh \
   -n 169.254.246.181,169.254.51.101 \
   exec \
+  env VLLM_SERVER_DEV_MODE=${VLLM_SERVER_DEV_MODE} \
   vllm serve nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8 \
   --port 8000 --host 0.0.0.0 \
   --gpu-memory-utilization ${VYBN_VLLM_GPU_MEMORY_UTILIZATION} --max-model-len 8192 \

--- a/spark/tests/test_harness.py
+++ b/spark/tests/test_harness.py
@@ -1603,3 +1603,13 @@ def test_inline_reasoning_filter_accepts_retired_v2_buffer_limit_alias():
     assert "if buffer_limit is not None:" in source
     assert "min_buffer = buffer_limit" in source
     assert "from reasoning_filter_v2" not in source
+
+
+def test_vllm_sleep_mode_dev_env_is_propagated_into_container_command():
+    from pathlib import Path
+
+    text = Path("spark/systemd/vybn-vllm.service").read_text()
+    assert "EnvironmentFile=-%h/.config/vybn/vllm.env" in text
+    assert "Environment=VLLM_SERVER_DEV_MODE=" in text
+    assert "env VLLM_SERVER_DEV_MODE=${VLLM_SERVER_DEV_MODE}" in text
+    assert "--enable-sleep-mode" in text


### PR DESCRIPTION
Propagates the operator-controlled VLLM_SERVER_DEV_MODE value into the vLLM container command so sleep-mode maintenance experiments can expose the intended internal endpoints when enabled. Adds a harness regression pin for the unit command shape.