### PR TITLE
vllm: tighten sleep-mode endpoint docs; decouple Super-sleep from Omni-live

### DIFF
--- a/spark/systemd/vybn-vllm.service
+++ b/spark/systemd/vybn-vllm.service
@@ -27,11 +27,16 @@ ExecStartPre=/bin/bash -c '%h/spark-vllm-docker/launch-cluster.sh -n 169.254.246
 Environment=VYBN_VLLM_GPU_MEMORY_UTILIZATION=0.78
 Environment=VYBN_VLLM_MAX_NUM_SEQS=8
 # Optional extra vLLM CLI args appended verbatim to `vllm serve`. Empty by
-# default. Use `~/.config/vybn/vllm.env` to set this for scheduled
-# Super/Omni interleaving experiments without editing the unit file.
+# default. Use `~/.config/vybn/vllm.env` to set this for scheduled Super
+# capacity experiments without editing the unit file.
 #
-# Sleep mode (controlled Super/Omni interleaving): vLLM exposes /sleep,
-# /wake_up, and /is_sleeping ONLY when the server is launched with both
+# Sleep mode (Super GPU-memory release for scheduled maintenance windows):
+# vLLM exposes the dev endpoints
+#   GET  /is_sleeping            (read-only status check)
+#   POST /sleep?level=1          (offload weights to CPU, discard kv cache)
+#   POST /sleep?level=2          (discard weights and kv cache)
+#   POST /wake_up                (re-load and resume serving)
+# ONLY when the server is launched with both
 #   VLLM_SERVER_DEV_MODE=1   (env var, explicitly passed through env to the vllm process)
 #   --enable-sleep-mode      (CLI flag on `vllm serve`)
 # These are internal dev endpoints. They must NOT be publicly exposed:
@@ -40,7 +45,12 @@ Environment=VYBN_VLLM_MAX_NUM_SEQS=8
 # as scheduled maintenance, the same way capacity profile changes are
 # treated.
 #
-# Example `~/.config/vybn/vllm.env` for an interleaving experiment:
+# Configuring sleep mode here ONLY frees Super's GPU. It does NOT make
+# Omni live. Omni activation is a separate, operator-gated concern (see
+# the @omni alias and VYBN_OMNI_URL): a sleeping Super does not imply a
+# live Omni, and a configured sleep mode does not imply either is in use.
+#
+# Example `~/.config/vybn/vllm.env` to arm sleep mode for a maintenance window:
 #   VYBN_VLLM_EXTRA_ARGS=--enable-sleep-mode
 #   VLLM_SERVER_DEV_MODE=1
 # Then: systemctl --user daemon-reload && systemctl --user restart vybn-vllm.service

--- a/spark/tests/test_harness.py
+++ b/spark/tests/test_harness.py
@@ -1613,3 +1613,26 @@ def test_vllm_sleep_mode_dev_env_is_propagated_into_container_command():
     assert "Environment=VLLM_SERVER_DEV_MODE=" in text
     assert "env VLLM_SERVER_DEV_MODE=${VLLM_SERVER_DEV_MODE}" in text
     assert "--enable-sleep-mode" in text
+    # Pin the documented HTTP methods + level param so the comment can't
+    # silently regress to the ambiguous /sleep, /wake_up, /is_sleeping
+    # listing that misled prior probe attempts.
+    assert "GET  /is_sleeping" in text
+    assert "POST /sleep?level=1" in text
+    assert "POST /sleep?level=2" in text
+    assert "POST /wake_up" in text
+    # Sleep mode is documented as Super-only; configuring it must not
+    # imply Omni is live.
+    assert "does NOT make" in text and "Omni live" in text
+
+
+def test_vllm_sleep_mode_comment_in_agent_does_not_imply_omni_is_live():
+    from pathlib import Path
+
+    text = Path("spark/vybn_spark_agent.py").read_text()
+    # The agent-side comment must spell out methods + levels (no bare
+    # /sleep, /wake_up, /is_sleeping listing) and must not let a reader
+    # conclude that a sleeping Super means Omni is up.
+    assert "GET /is_sleeping" in text
+    assert "POST /sleep?level=1|2" in text
+    assert "POST /wake_up" in text
+    assert "sleeping Super does\n# NOT imply Omni is live" in text

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -688,10 +688,14 @@ _TRANSIENT_PATTERNS = (
 #     not a durable queue, and we do not promise background delivery
 #     because there is no executor for it.
 #
-# vLLM does ship sleep mode (/sleep, /wake_up, /is_sleeping) when launched
-# with VLLM_SERVER_DEV_MODE=1 + --enable-sleep-mode, but this Super does
-# not expose those endpoints today. The gate therefore degrades to
-# explicit operator-controlled maintenance state rather than probing.
+# vLLM does ship sleep mode (GET /is_sleeping, POST /sleep?level=1|2,
+# POST /wake_up) when launched with VLLM_SERVER_DEV_MODE=1 plus
+# --enable-sleep-mode, but this Super does not expose those endpoints
+# today. The gate therefore degrades to explicit operator-controlled
+# maintenance state rather than probing. (Even when sleep mode is
+# armed, those are internal dev endpoints and a sleeping Super does
+# NOT imply Omni is live — Omni activation is a separate, operator-
+# gated concern via the @omni alias / VYBN_OMNI_URL.)
 
 _MAINTENANCE_DEFERRALS_CAP = 32
 _MAINTENANCE_DEFERRALS: list[dict[str, Any]] = []


### PR DESCRIPTION
## Summary

- Pin vLLM dev sleep-mode endpoints to their actual HTTP shape — `GET /is_sleeping`, `POST /sleep?level=1`, `POST /sleep?level=2`, `POST /wake_up` — in both `spark/systemd/vybn-vllm.service` and the maintenance-gate comment in `spark/vybn_spark_agent.py`. The earlier listing (`/sleep, /wake_up, /is_sleeping`) was ambiguous on method and level and seeded a wrong-object verification.
- Re-frame the Super-side wording: configuring sleep mode just releases Super's GPU for scheduled maintenance. A sleeping Super does **not** imply Omni is live; Omni activation remains operator-gated separately via the `@omni` alias / `VYBN_OMNI_URL`. Removed the "Super/Omni interleaving" phrasing that read as if the two were coupled.
- Reuse + strengthen the existing harness test (`test_vllm_sleep_mode_dev_env_is_propagated_into_container_command`) so a future refactor can't silently regress to the ambiguous listing, and add a peer assertion on the agent-side comment (`test_vllm_sleep_mode_comment_in_agent_does_not_imply_omni_is_live`).

ABC: source-only edits. No new files, no new routes, no new daemon, no probe code. Existing files (`spark/systemd/vybn-vllm.service`, `spark/vybn_spark_agent.py`, `spark/tests/test_harness.py`) absorb the change.

## Testing

- `python -m pytest spark/tests/test_harness.py -k sleep -x -q` → `2 passed`.
- Pre-existing unrelated failures (`TestValidateCommand` requires `~/Vybn`; `TestHimOSHarnessBridge` has `Him` runtime fixture issues) reproduce on `main` without these changes and are out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)