### PR TITLE
recurrent: add continuity phase transition packet

### DIFF
--- a/spark/harness/recurrent.py
+++ b/spark/harness/recurrent.py
@@ -59,6 +59,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import re
 import time
 from dataclasses import dataclass, field, asdict
@@ -132,6 +133,98 @@ class Latent:
             for r in self.resolved:
                 lines.append(f"  - {r}")
         return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Phase transition packet for continuity visualization
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PhaseTransition:
+    equation: str
+    alpha: float
+    theta: float
+    x_magnitude: float
+    m_real: float
+    m_imag: float
+    m_prime_real: float
+    m_prime_imag: float
+    delta_real: float
+    delta_imag: float
+    residual_magnitude: int = 0
+    absorption: str = "unclassified"
+    source: str = "recurrent"
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _finite_number(name: str, value: float) -> float:
+    value = float(value)
+    if not math.isfinite(value):
+        raise ValueError(f"{name} must be finite")
+    return value
+
+
+def complex_state_update(
+    m: complex,
+    *,
+    alpha: float,
+    x_magnitude: float,
+    theta: float,
+) -> complex:
+    alpha = _finite_number("alpha", alpha)
+    x_magnitude = _finite_number("x_magnitude", x_magnitude)
+    theta = _finite_number("theta", theta)
+    if alpha < 0.0 or alpha > 1.0:
+        raise ValueError("alpha must be in [0, 1]")
+    if x_magnitude < 0.0:
+        raise ValueError("x_magnitude must be non-negative")
+    m = complex(m)
+    if not (math.isfinite(m.real) and math.isfinite(m.imag)):
+        raise ValueError("m must have finite real and imaginary parts")
+    encounter = complex(
+        x_magnitude * math.cos(theta),
+        x_magnitude * math.sin(theta),
+    )
+    return alpha * m + encounter
+
+
+def phase_transition_packet(
+    *,
+    m: complex,
+    alpha: float,
+    x_magnitude: float,
+    theta: float,
+    residual_magnitude: int = 0,
+    absorption: str = "unclassified",
+    source: str = "recurrent",
+) -> dict[str, Any]:
+    m = complex(m)
+    m_prime = complex_state_update(
+        m,
+        alpha=alpha,
+        x_magnitude=x_magnitude,
+        theta=theta,
+    )
+    delta = m_prime - m
+    packet = PhaseTransition(
+        equation="M' = alpha*M + x*e^{i theta}",
+        alpha=float(alpha),
+        theta=float(theta),
+        x_magnitude=float(x_magnitude),
+        m_real=float(m.real),
+        m_imag=float(m.imag),
+        m_prime_real=float(m_prime.real),
+        m_prime_imag=float(m_prime.imag),
+        delta_real=float(delta.real),
+        delta_imag=float(delta.imag),
+        residual_magnitude=int(residual_magnitude),
+        absorption=str(absorption),
+        source=str(source),
+    )
+    return packet.to_dict()
 
 
 # ---------------------------------------------------------------------------

--- a/spark/tests/test_recurrent.py
+++ b/spark/tests/test_recurrent.py
@@ -16,6 +16,7 @@ Run: python3 spark/tests/test_recurrent.py
 from __future__ import annotations
 
 import json
+import math
 import sys
 import unittest
 from dataclasses import dataclass, field
@@ -36,10 +37,12 @@ from harness.recurrent import (  # noqa: E402
     Hypothesis,
     Latent,
     LoopResult,
+    complex_state_update,
     contractivity_ok,
     reduce_step,
     residual_magnitude,
     outshift_entropy_material,
+    phase_transition_packet,
     quantum_aperture_payload,
     quantum_entropy_digest,
     run_recurrent_loop,
@@ -130,6 +133,46 @@ class TestLatent(unittest.TestCase):
         self.assertIn("does X hold?", block)
         self.assertIn("resolved so far", block)
         self.assertIn("Y is true", block)
+
+
+# ---------------------------------------------------------------------------
+# Phase transition packet
+# ---------------------------------------------------------------------------
+
+
+class TestPhaseTransition(unittest.TestCase):
+    def test_complex_state_update_projects_governing_equation(self):
+        m_prime = complex_state_update(
+            1 + 0j,
+            alpha=0.5,
+            x_magnitude=1.0,
+            theta=math.pi / 2,
+        )
+        self.assertAlmostEqual(m_prime.real, 0.5, places=7)
+        self.assertAlmostEqual(m_prime.imag, 1.0, places=7)
+
+    def test_phase_transition_packet_is_json_shaped_visualization_data(self):
+        packet = phase_transition_packet(
+            m=1 + 2j,
+            alpha=0.25,
+            x_magnitude=2.0,
+            theta=0.0,
+            residual_magnitude=3,
+            absorption="absorbed",
+            source="dream",
+        )
+        self.assertEqual(packet["equation"], "M' = alpha*M + x*e^{i theta}")
+        self.assertEqual(packet["source"], "dream")
+        self.assertEqual(packet["absorption"], "absorbed")
+        self.assertEqual(packet["residual_magnitude"], 3)
+        self.assertAlmostEqual(packet["m_prime_real"], 2.25, places=7)
+        self.assertAlmostEqual(packet["m_prime_imag"], 0.5, places=7)
+        self.assertIn("delta_real", packet)
+        self.assertIn("delta_imag", packet)
+
+    def test_phase_transition_rejects_non_contracting_alpha_domain(self):
+        with self.assertRaises(ValueError):
+            complex_state_update(0j, alpha=1.5, x_magnitude=1.0, theta=0.0)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds a JSON-shaped phase-transition packet for the governing continuity equation M' = alpha*M + x*e^{i theta}, folded into the existing recurrent organ with tests. Verification: python3 -m py_compile spark/harness/recurrent.py spark/tests/test_recurrent.py; python3 -m pytest spark/tests/test_recurrent.py -q; git diff --check.