### PR TITLE
fix(fp8-wake-fix): recursive zeroing + fatal on patch miss

### DIFF
--- a/spark/systemd/patches/fp8-wake-fix/run.sh
+++ b/spark/systemd/patches/fp8-wake-fix/run.sh
@@ -4,16 +4,15 @@
 # before 'vllm serve' starts.
 #
 # Bug: init_fp8_kv_scales iterates self.kv_caches and calls .zero_() on every
-# element. On hybrid models (Nemotron-Super: GDN + Attention), kv_caches
-# contains nested lists for GDN state layers — not flat Tensors. The .zero_()
-# call raises AttributeError: 'list' object has no attribute 'zero_',
-# crashing every POST /wake_up and leaving Super permanently sleeping.
+# element. On hybrid models (e.g. GDN + Attention), kv_caches contains nested
+# list/tuple structures for recurrent-state layers — not flat Tensors. The
+# bare .zero_() call raises AttributeError: 'list' object has no attribute
+# 'zero_', crashing every POST /wake_up.
 #
-# Fix: replace the bare None-check with isinstance(cache_tensor, torch.Tensor)
-# and add a list-flattening branch. Idempotent; safe on updated vllm builds.
-#
-# Upstream issue: github.com/vllm-project/vllm (FP8 KV cache + hybrid model
-# sleep/wake, April 2026). Diagnosed and patched from Vybn repo.
+# Fix: replace the loop body with a small recursive helper that zeros tensors
+# in nested list/tuple/dict containers and ignores non-tensor leaves.
+# Idempotent. Fails loudly if the expected loop is not found and the patched
+# form is not already present, rather than silently exiting 0.
 
 set -euo pipefail
 
@@ -23,8 +22,8 @@ import pathlib, sys, textwrap
 FILE = pathlib.Path("/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu_model_runner.py")
 
 if not FILE.exists():
-    print("fp8-wake-fix: target file not found — skipping", file=sys.stderr)
-    sys.exit(0)
+    print(f"fp8-wake-fix: target file not found at {FILE}", file=sys.stderr)
+    sys.exit(2)
 
 src = FILE.read_text()
 
@@ -37,16 +36,24 @@ OLD = textwrap.dedent("""\
 
 NEW = textwrap.dedent("""\
         kv_caches = getattr(self, "kv_caches", [])
+        def _zero_kv_cache_entry(entry):
+            # Hybrid models (e.g. GDN+Attention) nest recurrent-state buffers
+            # inside list/tuple/dict containers; recurse and zero tensor leaves.
+            if isinstance(entry, torch.Tensor):
+                entry.zero_()
+            elif isinstance(entry, (list, tuple)):
+                for sub in entry:
+                    _zero_kv_cache_entry(sub)
+            elif isinstance(entry, dict):
+                for sub in entry.values():
+                    _zero_kv_cache_entry(sub)
+            # else: ignore non-tensor leaves (None, scalars, etc.)
         for cache_tensor in kv_caches:
-            # Hybrid models (e.g. GDN+Attention) store nested lists in
-            # kv_caches for recurrent-state layers; guard with isinstance.
-            if isinstance(cache_tensor, torch.Tensor):
-                cache_tensor.zero_()
-            elif isinstance(cache_tensor, list):
-                for sub in cache_tensor:
-                    if isinstance(sub, torch.Tensor):
-                        sub.zero_()"""
+            _zero_kv_cache_entry(cache_tensor)"""
 )
+
+# Sentinel proves the recursive helper is present and active.
+SENTINEL = "_zero_kv_cache_entry"
 
 if NEW in src:
     print("fp8-wake-fix: already applied — skipping")
@@ -54,12 +61,33 @@ if NEW in src:
 
 if OLD not in src:
     print(
-        "fp8-wake-fix: pattern not found — vLLM may have been updated; "
-        "review init_fp8_kv_scales manually",
+        "fp8-wake-fix: expected init_fp8_kv_scales loop not found and patched "
+        "form not present — refusing to start sleep-capable vLLM with broken "
+        f"wake. Inspect {FILE} init_fp8_kv_scales manually.",
         file=sys.stderr,
     )
-    sys.exit(0)  # non-fatal: upstream may have fixed it
+    sys.exit(1)
 
-FILE.write_text(src.replace(OLD, NEW, 1))
+patched = src.replace(OLD, NEW, 1)
+if SENTINEL not in patched:
+    print(
+        "fp8-wake-fix: post-replace verification failed — recursive helper "
+        f"sentinel '{SENTINEL}' missing.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+FILE.write_text(patched)
+
+# Re-read and reverify after write to catch any concurrent-write races.
+verify_src = FILE.read_text()
+if NEW not in verify_src or SENTINEL not in verify_src:
+    print(
+        "fp8-wake-fix: on-disk verification failed after write — patched "
+        "block not present in target file.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
 print(f"fp8-wake-fix: patch applied to {FILE}")
 PYEOF

--- a/spark/tests/test_fp8_wake_fix_patch.py
+++ b/spark/tests/test_fp8_wake_fix_patch.py
@@ -1,0 +1,92 @@
+"""Static checks on spark/systemd/patches/fp8-wake-fix/run.sh.
+
+These guard two regressions of the fp8-wake-fix patcher:
+
+1. The patch must not silently exit 0 with a "pattern not found" message —
+   that previously let sleep-capable vLLM start with a broken wake path.
+2. The injected replacement must contain a recursive helper that handles
+   list/tuple containers (hybrid models nest tensors inside lists).
+
+Run: python3 spark/tests/test_fp8_wake_fix_patch.py
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+RUN_SH = ROOT / "spark" / "systemd" / "patches" / "fp8-wake-fix" / "run.sh"
+
+
+def _src() -> str:
+    return RUN_SH.read_text(encoding="utf-8")
+
+
+def test_run_sh_exists():
+    assert RUN_SH.exists(), f"missing {RUN_SH}"
+
+
+def test_no_silent_pattern_not_found_exit_zero():
+    src = _src()
+    # Find every "pattern not found" occurrence; none of them may be paired
+    # with an exit 0 in the same neighborhood.
+    for match in re.finditer(r"pattern not found|loop not found|not found", src, re.I):
+        window = src[match.start(): match.start() + 400]
+        assert "sys.exit(0)" not in window, (
+            "fp8-wake-fix run.sh appears to silently exit 0 after a "
+            "'pattern/loop not found' message; this lets sleep-capable "
+            "vLLM start with broken wake. Failing exit required."
+        )
+
+
+def test_failure_branch_uses_nonzero_exit():
+    src = _src()
+    # The script must contain at least one nonzero sys.exit() to signal
+    # failure when the expected loop is missing.
+    assert re.search(r"sys\.exit\(\s*[1-9]\d*\s*\)", src), (
+        "expected at least one nonzero sys.exit() for the failure branch"
+    )
+
+
+def test_recursive_helper_handles_list_and_tuple():
+    src = _src()
+    assert "_zero_kv_cache_entry" in src, "recursive helper name missing"
+    # Must dispatch on Tensor and recurse on list/tuple containers.
+    assert "isinstance(entry, torch.Tensor)" in src, (
+        "recursive helper must check torch.Tensor leaves"
+    )
+    assert re.search(r"isinstance\(\s*entry\s*,\s*\(\s*list\s*,\s*tuple\s*\)\s*\)", src), (
+        "recursive helper must recurse on list/tuple containers"
+    )
+
+
+def test_idempotent_already_applied_path():
+    src = _src()
+    # Idempotence: when the patched form is already present, exit 0 cleanly.
+    assert "already applied" in src, "expected 'already applied' idempotence path"
+    # That idempotence path must be exit 0 (success), distinct from the
+    # failure branch above.
+    assert re.search(r"already applied[^\n]*\n[^\n]*\n[^\n]*sys\.exit\(\s*0\s*\)|already applied[^\n]*\n[^\n]*sys\.exit\(\s*0\s*\)", src) or \
+        ("already applied" in src and "sys.exit(0)" in src), (
+        "'already applied' branch must exit 0"
+    )
+
+
+if __name__ == "__main__":
+    import traceback
+    fns = [
+        (n, f) for n, f in list(globals().items())
+        if n.startswith("test_") and callable(f)
+    ]
+    passed = 0
+    for name, fn in fns:
+        try:
+            fn()
+            print(f"OK  {name}")
+            passed += 1
+        except AssertionError as e:
+            print(f"FAIL {name}: {e}")
+            traceback.print_exc()
+    print(f"\n{passed}/{len(fns)} passed")
+    sys.exit(0 if passed == len(fns) else 1)


### PR DESCRIPTION
## Summary

Update the existing fp8-wake-fix patcher (`spark/systemd/patches/fp8-wake-fix/run.sh`) so it:

- Replaces the bare `cache_tensor.zero_()` loop with a small recursive `_zero_kv_cache_entry` helper that handles `Tensor` leaves and recurses through `list` / `tuple` / `dict` containers, ignoring non-tensor leaves. This is what hybrid models (e.g. GDN + Attention) need — they nest recurrent-state buffers inside lists, which is why `init_fp8_kv_scales` was raising `AttributeError: 'list' object has no attribute 'zero_'` on every wake.
- Fails loudly (nonzero exit) if neither the patched form nor the expected upstream loop is found, instead of silently exiting 0 with "pattern not found". This stops sleep-capable startup from proceeding with a broken wake.
- Re-reads and reverifies the file after writing.
- Preserves idempotence: already-applied form exits 0 cleanly.

Adds a focused static test (`spark/tests/test_fp8_wake_fix_patch.py`) that asserts no silent "pattern not found" exit 0, presence of recursive list/tuple handling, and the idempotent already-applied path.

No changes outside `spark/systemd/patches/fp8-wake-fix/run.sh` and the new test file.

## Testing

- `bash -n spark/systemd/patches/fp8-wake-fix/run.sh` → OK
- `python3 spark/tests/test_fp8_wake_fix_patch.py` → 5/5 passed