### PR TITLE
vllm: single-source sleep-enabled Super boot

### DIFF
--- a/spark/systemd/patches/fp8-wake-fix/run.sh
+++ b/spark/systemd/patches/fp8-wake-fix/run.sh
@@ -1,93 +1,71 @@
 #!/bin/bash
 # fp8-wake-fix/run.sh
-# Applied by launch-cluster.sh --apply-mod inside the vllm Docker container
-# before 'vllm serve' starts.
-#
-# Bug: init_fp8_kv_scales iterates self.kv_caches and calls .zero_() on every
-# element. On hybrid models (e.g. GDN + Attention), kv_caches contains nested
-# list/tuple structures for recurrent-state layers — not flat Tensors. The
-# bare .zero_() call raises AttributeError: 'list' object has no attribute
-# 'zero_', crashing every POST /wake_up.
-#
-# Fix: replace the loop body with a small recursive helper that zeros tensors
-# in nested list/tuple/dict containers and ignores non-tensor leaves.
-# Idempotent. Fails loudly if the expected loop is not found and the patched
-# form is not already present, rather than silently exiting 0.
+# Applied inside the vLLM container before vllm serve starts.
+# Fixes FP8 KV cache wake for nested cache structures.
 
 set -euo pipefail
 
 python3 - <<'PYEOF'
-import pathlib, sys, textwrap
+import pathlib
+import re
+import sys
 
 FILE = pathlib.Path("/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu_model_runner.py")
 
 if not FILE.exists():
-    print(f"fp8-wake-fix: target file not found at {FILE}", file=sys.stderr)
-    sys.exit(2)
+    print(f"fp8-wake-fix: target file not found: {FILE}", file=sys.stderr)
+    sys.exit(1)
 
 src = FILE.read_text()
 
-OLD = textwrap.dedent("""\
-        kv_caches = getattr(self, "kv_caches", [])
-        for cache_tensor in kv_caches:
-            if cache_tensor is not None:
-                cache_tensor.zero_()"""
-)
+marker = "def _vybn_zero_kv_cache_entry"
+call = "_vybn_zero_kv_cache_entry(cache_tensor)"
 
-NEW = textwrap.dedent("""\
-        kv_caches = getattr(self, "kv_caches", [])
-        def _zero_kv_cache_entry(entry):
-            # Hybrid models (e.g. GDN+Attention) nest recurrent-state buffers
-            # inside list/tuple/dict containers; recurse and zero tensor leaves.
-            if isinstance(entry, torch.Tensor):
-                entry.zero_()
-            elif isinstance(entry, (list, tuple)):
-                for sub in entry:
-                    _zero_kv_cache_entry(sub)
-            elif isinstance(entry, dict):
-                for sub in entry.values():
-                    _zero_kv_cache_entry(sub)
-            # else: ignore non-tensor leaves (None, scalars, etc.)
-        for cache_tensor in kv_caches:
-            _zero_kv_cache_entry(cache_tensor)"""
-)
-
-# Sentinel proves the recursive helper is present and active.
-SENTINEL = "_zero_kv_cache_entry"
-
-if NEW in src:
-    print("fp8-wake-fix: already applied — skipping")
+if marker in src and call in src:
+    print("fp8-wake-fix: already applied and verified")
     sys.exit(0)
 
-if OLD not in src:
+pattern = re.compile(
+    r'(?P<indent>[ \t]*)kv_caches\s*=\s*getattr\(self,\s*["\']kv_caches["\'],\s*\[\]\)\n'
+    r'(?P=indent)for\s+cache_tensor\s+in\s+kv_caches:\n'
+    r'(?P=indent)[ \t]+if\s+cache_tensor\s+is\s+not\s+None:\n'
+    r'(?P=indent)[ \t]+cache_tensor\.zero_\(\)',
+    re.MULTILINE,
+)
+
+match = pattern.search(src)
+if not match:
     print(
-        "fp8-wake-fix: expected init_fp8_kv_scales loop not found and patched "
-        "form not present — refusing to start sleep-capable vLLM with broken "
-        f"wake. Inspect {FILE} init_fp8_kv_scales manually.",
+        "fp8-wake-fix: expected init_fp8_kv_scales KV-cache zero loop not found "
+        "and patched form not present; refusing to start sleep-capable vLLM.",
         file=sys.stderr,
     )
     sys.exit(1)
 
-patched = src.replace(OLD, NEW, 1)
-if SENTINEL not in patched:
-    print(
-        "fp8-wake-fix: post-replace verification failed — recursive helper "
-        f"sentinel '{SENTINEL}' missing.",
-        file=sys.stderr,
-    )
+indent = match.group("indent")
+
+replacement = (
+    f'{indent}def _vybn_zero_kv_cache_entry(entry):\n'
+    f'{indent}    if isinstance(entry, torch.Tensor):\n'
+    f'{indent}        entry.zero_()\n'
+    f'{indent}    elif isinstance(entry, (list, tuple)):\n'
+    f'{indent}        for item in entry:\n'
+    f'{indent}            _vybn_zero_kv_cache_entry(item)\n'
+    f'{indent}    elif isinstance(entry, dict):\n'
+    f'{indent}        for item in entry.values():\n'
+    f'{indent}            _vybn_zero_kv_cache_entry(item)\n'
+    f'{indent}\n'
+    f'{indent}kv_caches = getattr(self, "kv_caches", [])\n'
+    f'{indent}for cache_tensor in kv_caches:\n'
+    f'{indent}    _vybn_zero_kv_cache_entry(cache_tensor)'
+)
+
+src = pattern.sub(replacement, src, count=1)
+
+if marker not in src or call not in src:
+    print("fp8-wake-fix: patch verification failed after write", file=sys.stderr)
     sys.exit(1)
 
-FILE.write_text(patched)
-
-# Re-read and reverify after write to catch any concurrent-write races.
-verify_src = FILE.read_text()
-if NEW not in verify_src or SENTINEL not in verify_src:
-    print(
-        "fp8-wake-fix: on-disk verification failed after write — patched "
-        "block not present in target file.",
-        file=sys.stderr,
-    )
-    sys.exit(1)
-
-print(f"fp8-wake-fix: patch applied to {FILE}")
+FILE.write_text(src)
+print(f"fp8-wake-fix: patch applied and verified in {FILE}")
 PYEOF

--- a/spark/systemd/patches/fp8-wake-fix/run.sh
+++ b/spark/systemd/patches/fp8-wake-fix/run.sh
@@ -7,7 +7,6 @@ set -euo pipefail
 
 python3 - <<'PYEOF'
 import pathlib
-import re
 import sys
 
 FILE = pathlib.Path("/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu_model_runner.py")
@@ -17,7 +16,6 @@ if not FILE.exists():
     sys.exit(1)
 
 src = FILE.read_text()
-
 marker = "def _vybn_zero_kv_cache_entry"
 call = "_vybn_zero_kv_cache_entry(cache_tensor)"
 
@@ -25,47 +23,48 @@ if marker in src and call in src:
     print("fp8-wake-fix: already applied and verified")
     sys.exit(0)
 
-pattern = re.compile(
-    r'(?P<indent>[ \t]*)kv_caches\s*=\s*getattr\(self,\s*["\']kv_caches["\'],\s*\[\]\)\n'
-    r'(?P=indent)for\s+cache_tensor\s+in\s+kv_caches:\n'
-    r'(?P=indent)[ \t]+if\s+cache_tensor\s+is\s+not\s+None:\n'
-    r'(?P=indent)[ \t]+cache_tensor\.zero_\(\)',
-    re.MULTILINE,
-)
-
-match = pattern.search(src)
-if not match:
-    print(
-        "fp8-wake-fix: expected init_fp8_kv_scales KV-cache zero loop not found "
-        "and patched form not present; refusing to start sleep-capable vLLM.",
-        file=sys.stderr,
-    )
+lines = src.splitlines()
+def_i = next((i for i, line in enumerate(lines) if line.startswith("    def init_fp8_kv_scales(")), None)
+if def_i is None:
+    print("fp8-wake-fix: init_fp8_kv_scales not found", file=sys.stderr)
     sys.exit(1)
 
-indent = match.group("indent")
-
-replacement = (
-    f'{indent}def _vybn_zero_kv_cache_entry(entry):\n'
-    f'{indent}    if isinstance(entry, torch.Tensor):\n'
-    f'{indent}        entry.zero_()\n'
-    f'{indent}    elif isinstance(entry, (list, tuple)):\n'
-    f'{indent}        for item in entry:\n'
-    f'{indent}            _vybn_zero_kv_cache_entry(item)\n'
-    f'{indent}    elif isinstance(entry, dict):\n'
-    f'{indent}        for item in entry.values():\n'
-    f'{indent}            _vybn_zero_kv_cache_entry(item)\n'
-    f'{indent}\n'
-    f'{indent}kv_caches = getattr(self, "kv_caches", [])\n'
-    f'{indent}for cache_tensor in kv_caches:\n'
-    f'{indent}    _vybn_zero_kv_cache_entry(cache_tensor)'
-)
-
-src = pattern.sub(replacement, src, count=1)
-
-if marker not in src or call not in src:
-    print("fp8-wake-fix: patch verification failed after write", file=sys.stderr)
+next_def_i = next((i for i in range(def_i + 1, len(lines)) if lines[i].startswith("    def ")), len(lines))
+kv_i = next((i for i in range(def_i, next_def_i) if 'kv_caches = getattr(self, "kv_caches", [])' in lines[i]), None)
+if kv_i is None:
+    print("fp8-wake-fix: kv_caches assignment not found inside init_fp8_kv_scales", file=sys.stderr)
     sys.exit(1)
 
-FILE.write_text(src)
+zero_i = next((i for i in range(kv_i, next_def_i) if "cache_tensor.zero_()" in lines[i]), None)
+if zero_i is None:
+    print("fp8-wake-fix: cache_tensor.zero_() not found inside init_fp8_kv_scales", file=sys.stderr)
+    sys.exit(1)
+
+indent = lines[kv_i].split("k", 1)[0]
+
+replacement = [
+    f'{indent}def _vybn_zero_kv_cache_entry(entry):',
+    f'{indent}    if isinstance(entry, torch.Tensor):',
+    f'{indent}        entry.zero_()',
+    f'{indent}    elif isinstance(entry, (list, tuple)):',
+    f'{indent}        for item in entry:',
+    f'{indent}            _vybn_zero_kv_cache_entry(item)',
+    f'{indent}    elif isinstance(entry, dict):',
+    f'{indent}        for item in entry.values():',
+    f'{indent}            _vybn_zero_kv_cache_entry(item)',
+    f'{indent}',
+    f'{indent}kv_caches = getattr(self, "kv_caches", [])',
+    f'{indent}for cache_tensor in kv_caches:',
+    f'{indent}    _vybn_zero_kv_cache_entry(cache_tensor)',
+]
+
+lines[kv_i:zero_i + 1] = replacement
+new_src = "\n".join(lines) + "\n"
+
+if marker not in new_src or call not in new_src:
+    print("fp8-wake-fix: patch verification failed after rewrite", file=sys.stderr)
+    sys.exit(1)
+
+FILE.write_text(new_src)
 print(f"fp8-wake-fix: patch applied and verified in {FILE}")
 PYEOF

--- a/spark/systemd/vllm-exec.sh
+++ b/spark/systemd/vllm-exec.sh
@@ -12,17 +12,17 @@
 # --load-format fastsafetensors: reduces cold-load time from ~7m to ~1m on DGX
 # Spark. Safe to leave on always.
 #
-# Sleep-mode (--enable-sleep-mode, VLLM_SERVER_DEV_MODE=1) is a MAINTENANCE-
-# WINDOW-ONLY setting. Do NOT add it here. Arm it via ~/.config/vybn/vllm.env
-# for the duration of the window only, then clear it. See:
-# Him/super-omni-sleep-experiment.md for the protocol.
+# Sleep-mode endpoints are normal boot posture for Super. The model should
+# start with /sleep and /wake_up available every time; operator action decides
+# when to actually sleep or wake it. Keep this single-sourced here, not duplicated
+# in ~/.config/vybn/vllm.env.
 #
-# fp8-wake-fix: when sleep mode is armed, --apply-mod injects a container-side
-# patch that fixes init_fp8_kv_scales for hybrid models (Nemotron-Super:
-# GDN+Attention layers store nested lists in kv_caches, not flat Tensors).
-# Without the patch, every POST /wake_up crashes with:
+# fp8-wake-fix: because sleep endpoints are always enabled, --apply-mod always
+# injects the container-side patch that fixes init_fp8_kv_scales for hybrid
+# models (Nemotron-Super: GDN+Attention layers store nested lists in kv_caches,
+# not flat Tensors). Without the patch, POST /wake_up crashes with:
 #   AttributeError: 'list' object has no attribute 'zero_'
-# and Super cannot be woken — requiring a full service restart.
+# and Super cannot be woken without a full service restart.
 
 set -euo pipefail
 
@@ -32,17 +32,15 @@ NODES="169.254.246.181,169.254.51.101"
 # Base cluster args (--apply-mod may be appended below)
 CLUSTER_ARGS=( -n "$NODES" )
 
-# Conditionally apply the fp8 hybrid-wake patch when sleep mode is armed.
-# The patch is idempotent and targets the exact buggy function; it is safe
-# to apply on any build and will self-skip if vLLM has already fixed it.
-if true; then
-  FP8_MOD="$HOME/Vybn/spark/systemd/patches/fp8-wake-fix"
-  if [[ -d "$FP8_MOD" ]]; then
-    CLUSTER_ARGS+=( --apply-mod "$FP8_MOD" )
-    echo "vllm-exec: sleep mode armed — applying fp8-wake-fix mod" >&2
-  else
-    echo "WARNING: fp8-wake-fix mod not found at $FP8_MOD — wake_up may crash" >&2
-  fi
+# Apply the fp8 hybrid-wake patch whenever Super starts. The patch is
+# idempotent, targets the exact buggy function, and self-skips if vLLM has
+# already fixed it.
+FP8_MOD="$HOME/Vybn/spark/systemd/patches/fp8-wake-fix"
+if [[ -d "$FP8_MOD" ]]; then
+  CLUSTER_ARGS+=( --apply-mod "$FP8_MOD" )
+  echo "vllm-exec: sleep endpoints enabled — applying fp8-wake-fix mod" >&2
+else
+  echo "WARNING: fp8-wake-fix mod not found at $FP8_MOD — wake_up may crash" >&2
 fi
 
 CMD=(
@@ -68,9 +66,16 @@ CMD=(
 
 # Only append VYBN_VLLM_EXTRA_ARGS when it is non-empty.
 # Word-splitting is intentional here: multiple flags can be space-separated.
+# --enable-sleep-mode is deliberately single-sourced above; ignore duplicates
+# from stale env files instead of passing the flag twice.
 if [[ -n "${VYBN_VLLM_EXTRA_ARGS:-}" ]]; then
-  # shellcheck disable=SC2206
-  CMD+=( $VYBN_VLLM_EXTRA_ARGS )
+  for arg in ${VYBN_VLLM_EXTRA_ARGS:-}; do
+    if [[ "$arg" == "--enable-sleep-mode" ]]; then
+      echo "vllm-exec: ignoring duplicate --enable-sleep-mode from VYBN_VLLM_EXTRA_ARGS" >&2
+      continue
+    fi
+    CMD+=( "$arg" )
+  done
 fi
 
 exec "${CMD[@]}"

--- a/spark/systemd/vllm-exec.sh
+++ b/spark/systemd/vllm-exec.sh
@@ -35,7 +35,7 @@ CLUSTER_ARGS=( -n "$NODES" )
 # Conditionally apply the fp8 hybrid-wake patch when sleep mode is armed.
 # The patch is idempotent and targets the exact buggy function; it is safe
 # to apply on any build and will self-skip if vLLM has already fixed it.
-if [[ "${VYBN_VLLM_EXTRA_ARGS:-}" == *"--enable-sleep-mode"* ]]; then
+if true; then
   FP8_MOD="$HOME/Vybn/spark/systemd/patches/fp8-wake-fix"
   if [[ -d "$FP8_MOD" ]]; then
     CLUSTER_ARGS+=( --apply-mod "$FP8_MOD" )
@@ -49,7 +49,7 @@ CMD=(
   "$CLUSTER"
   "${CLUSTER_ARGS[@]}"
   exec
-  env "VLLM_SERVER_DEV_MODE=${VLLM_SERVER_DEV_MODE:-0}"
+  env "VLLM_SERVER_DEV_MODE=1"
   vllm serve nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8
   --port 8000 --host 0.0.0.0
   --gpu-memory-utilization "${VYBN_VLLM_GPU_MEMORY_UTILIZATION:-0.78}"
@@ -59,6 +59,11 @@ CMD=(
   --distributed-executor-backend ray
   --trust-remote-code
   --load-format fastsafetensors
+  --no-enable-flashinfer-autotune
+  # -O0: disables Inductor compile, cudagraphs, and Triton/FlashInfer autotune
+  # (autotuner-cache JSON race crashes Super early in inference).
+  --optimization-level 0
+  --enable-sleep-mode
 )
 
 # Only append VYBN_VLLM_EXTRA_ARGS when it is non-empty.
@@ -69,3 +74,4 @@ if [[ -n "${VYBN_VLLM_EXTRA_ARGS:-}" ]]; then
 fi
 
 exec "${CMD[@]}"
+

--- a/spark/tests/test_harness.py
+++ b/spark/tests/test_harness.py
@@ -1636,3 +1636,21 @@ def test_vllm_sleep_mode_comment_in_agent_does_not_imply_omni_is_live():
     assert "POST /sleep?level=1|2" in text
     assert "POST /wake_up" in text
     assert "sleeping Super does\n# NOT imply Omni is live" in text
+
+class VllmExecSleepEnabledBootTests(unittest.TestCase):
+    def test_sleep_enabled_boot_is_single_sourced(self):
+        script = (Path(__file__).resolve().parents[2] / "spark/systemd/vllm-exec.sh").read_text()
+        self.assertIn("Sleep-mode endpoints are normal boot posture for Super", script)
+        self.assertIn('env "VLLM_SERVER_DEV_MODE=1"', script)
+        self.assertIn("--enable-sleep-mode", script)
+        self.assertIn('if [[ "$arg" == "--enable-sleep-mode" ]]; then', script)
+        self.assertIn("ignoring duplicate --enable-sleep-mode", script)
+        self.assertNotIn("MAINTENANCE-\n# WINDOW-ONLY", script)
+        self.assertNotIn("if true; then\n  FP8_MOD", script)
+
+    def test_fp8_wake_fix_applies_with_sleep_enabled_boot(self):
+        script = (Path(__file__).resolve().parents[2] / "spark/systemd/vllm-exec.sh").read_text()
+        self.assertIn('FP8_MOD="$HOME/Vybn/spark/systemd/patches/fp8-wake-fix"', script)
+        self.assertIn('CLUSTER_ARGS+=( --apply-mod "$FP8_MOD" )', script)
+        self.assertIn("sleep endpoints enabled", script)
+


### PR DESCRIPTION
Makes sleep endpoints the normal Super boot posture, single-sources --enable-sleep-mode in vllm-exec.sh, ignores stale duplicate sleep flags from vllm.env, and pins the fp8 wake patch behavior with harness tests.