### PR TITLE
portal: gate all public vLLM generation surfaces

### DIFF
--- a/origins_portal_api_v4.py
+++ b/origins_portal_api_v4.py
@@ -1576,6 +1576,13 @@ async def perspective_endpoint(req: PerspectiveRequest, request: Request):
 
         try:
             async with httpx.AsyncClient(timeout=httpx.Timeout(120.0)) as client:
+                semantic = await _vllm_semantic_health()
+                if not semantic.get("ok"):
+                    log.error(f"perspective: vLLM semantic gate failed closed: {semantic}")
+                    async for frame in _semantic_maintenance_sse(semantic):
+                        yield frame
+                    return
+
                 payload = {
                     "model": MODEL_NAME,
                     "messages": messages,
@@ -2037,6 +2044,13 @@ async def voice_endpoint(req: VoiceRequest, request: Request):
 
         try:
             async with httpx.AsyncClient(timeout=httpx.Timeout(180.0)) as client:
+                semantic = await _vllm_semantic_health()
+                if not semantic.get("ok"):
+                    log.error(f"voice: vLLM semantic gate failed closed: {semantic}")
+                    async for frame in _semantic_maintenance_sse(semantic):
+                        yield frame
+                    return
+
                 payload = {
                     "model": MODEL_NAME,
                     "messages": messages,


### PR DESCRIPTION
## Summary
- extend the Super semantic integrity gate beyond /api/chat
- make /api/perspective and /api/voice fail closed before streaming from local vLLM
- keep one shared gate and maintenance SSE path for all active public generation surfaces

## Verification
- python3 -m py_compile origins_portal_api_v4.py
- source assertions: all three direct /v1/chat/completions surfaces gated
- git diff --check