### PR TITLE
agent: raise iteration ceiling for residual work

### DIFF
--- a/spark/router_policy.yaml
+++ b/spark/router_policy.yaml
@@ -80,7 +80,7 @@ roles:
     model: gpt-5.5
     thinking: adaptive
     max_tokens: 16384
-    max_iterations: 25
+    max_iterations: 100
     tools: [bash, delegate]
     rag: true
     recurrent_depth: 2  # /plan benefits from deeper latent reasoning; probe-confirmed adaptive


### PR DESCRIPTION
## Summary\n- raise orchestrate max_iterations from 25 to 100 for longer residual-wounded work when authorized\n- pairs with Him skill update already pushed: iterative residual learning / flow discipline\n\n## Verification\n- python3 -m py_compile spark/harness/policy.py spark/vybn_spark_agent.py\n- python3 -m pytest spark/tests/test_lightweight_routing.py::test_local_super_semantic_failure_fails_closed_without_cloud_fallback spark/tests/test_lightweight_routing.py::test_local_super_semantic_failure_cloud_fallback_requires_explicit_opt_in -q