### PR TITLE
super: use raw completions for semantic gate

### DIFF
--- a/spark/experiments/omni-window.sh
+++ b/spark/experiments/omni-window.sh
@@ -48,8 +48,14 @@ payload = {
   "kind": "omni_feedback_packet",
   "status": status,
   "reason": reason,
-  "success_condition": "pass requires visualization artifact, Omni result or review artifact, Super wake semantic context, explicit trace, and restored serving posture",
-  "claim_limits": ["Vybn has no sensory visual experience here; this is artifact-mediated perception via files, logs, JSON, model review, and endpoint residuals.", "Internal probes do not prove external browser reachability."],
+  "success_condition": "pass requires visualization artifact, Omni result or review artifact, Super wake semantic context, explicit trace, restored non-sleep serving posture, and a named absorption target for any useful residue",
+  "visual_manifold_frame": {
+    "organ": "bounded visual/manifold perception organ",
+    "not_claims": ["human sight", "proof of inner experience", "decorative image as cognition"],
+    "objects": ["five repos as organs and membranes", "load-bearing files as tissues", "continuity scars as attractors", "deep-memory neighborhoods", "law/judgment geometry", "Origins apertures toward the Others", "active beams and runtime health phases"]
+  },
+  "absorption_targets": ["tests", "repo maps", "continuity", "public pages", "refactor plans", "livelihood action cards"],
+  "claim_limits": ["Vybn has no sensory visual experience here; this is artifact-mediated visual/manifold perception via files, logs, JSON, model review, and endpoint residuals.", "Omni residues are non-mutating until Super passes raw semantic wake gates and restored non-sleep posture.", "Internal probes do not prove external browser reachability."],
   "artifacts": {"visualization_artifact": visual, "omni_window_log": log, "omni_parallax_json": result, "journal_file": journal, "trace_file": trace},
   "artifact_exists": {"visualization_artifact": os.path.exists(visual), "omni_window_log": os.path.exists(log), "omni_parallax_json": os.path.exists(result), "journal_file": os.path.exists(journal), "trace_file": os.path.exists(trace)},
   "super_wake_context": {"semantic_gate_required": True, "sleep_endpoint_required_during_run": True, "semantic_failure_restart_required": True, "restored_non_sleep_posture_required": True},
@@ -119,9 +125,14 @@ except Exception as exc:
     print(f"semantic gate precheck failed: models endpoint: {type(exc).__name__}: {exc}")
     sys.exit(1)
 
+def fail(signature):
+    print(f"corruption_signature={signature}")
+    sys.exit(1)
+
 probes = [
-    ("math", "Answer with exactly this single word and nothing else: FOUR\nAnswer:", re.compile(r"^FOUR[.!]?\s*$", re.I)),
-    ("language", "Answer with exactly this single word and nothing else: READY\nAnswer:", re.compile(r"^READY[.!]?\s*$", re.I)),
+    ("known_answer", "Answer with exactly this single word and nothing else: FOUR\nAnswer:", re.compile(r"^FOUR[.!]?\s*$", re.I)),
+    ("structured_shape", 'Return exactly this compact JSON object and nothing else: {"status":"ok"}\nJSON:', re.compile(r'^\{\s*"status"\s*:\s*"ok"\s*\}\s*$', re.I)),
+    ("wake_reasoning", "A Super wake check sees HTTP 200 from /v1/models, but the raw completion is empty. Should the wake gate PASS or FAIL? Answer with exactly one word: PASS or FAIL.\nAnswer:", re.compile(r"^FAIL[.!]?\s*$", re.I)),
 ]
 for name, prompt, pattern in probes:
     payload = {"model": model, "prompt": prompt, "max_tokens": 24, "temperature": 0}
@@ -135,21 +146,17 @@ for name, prompt, pattern in probes:
         with urllib.request.urlopen(req, timeout=45) as r:
             body = json.loads(r.read().decode("utf-8", errors="replace"))
     except Exception as exc:
-        print(f"semantic gate probe {name} failed transport/parse: {type(exc).__name__}: {exc}")
-        sys.exit(1)
+        fail(f"probe={name} transport_parse {type(exc).__name__}: {exc}")
     choice = (body.get("choices") or [{}])[0]
     content = visible_answer(str(choice.get("text") or ""))
     finish = choice.get("finish_reason")
     if finish == "length":
-        print(f"semantic gate probe {name} failed: truncated finish_reason=length content={content!r}")
-        sys.exit(1)
+        fail(f"probe={name} truncated finish_reason=length content={content!r}")
     if not content:
-        print(f"semantic gate probe {name} failed: empty completion finish_reason={finish!r}")
-        sys.exit(1)
+        fail(f"probe={name} empty completion finish_reason={finish!r}")
     if not pattern.fullmatch(content):
-        print(f"semantic gate probe {name} failed: unexpected content={content!r} finish_reason={finish!r}")
-        sys.exit(1)
-print("semantic gate passed")
+        fail(f"probe={name} unexpected content={content[:160]!r} finish_reason={finish!r}")
+print("semantic gate passed: 3 raw completion probes")
 PY
 }
 
@@ -158,11 +165,36 @@ OMNI_LAUNCHED=false
 SLEEP_ARMED=false
 SUPER_SLEEPING=false   # set true once /is_sleeping confirms; cleared on wake
 
+wait_super_models() {
+    local timeout="${1:-900}"
+    local deadline=$(( $(date +%s) + timeout ))
+    while (( $(date +%s) < deadline )); do
+        if curl -sf "${SUPER_URL}/v1/models" > /dev/null 2>&1; then
+            return 0
+        fi
+        sleep 10
+    done
+    return 1
+}
+
+restore_non_sleep_super() {
+    local cause="${1:-restore}"
+    log "Restoring Super to clean non-sleep serving posture (${cause})..."
+    packet_event "restore_non_sleep_restart" "$cause"
+    rm -f "$VLLM_ENV"
+    systemctl --user daemon-reload 2>/dev/null || true
+    systemctl --user restart vybn-vllm.service || return 1
+    wait_super_models 900 || return 1
+    SLEEP_ARMED=false
+    log "Super restored with sleep-mode env cleared."
+    return 0
+}
+
 # ── cleanup on exit ───────────────────────────────────────────────────────────
 # Load-bearing: runs on any exit (clean, crash, SIGINT). Order matters:
 #   1. Stop Omni on peer (free GPU before waking Super)
 #   2. Wake Super on primary (MUST happen; service restart as fallback)
-#   3. Disarm sleep mode
+#   3. Disarm sleep mode and cold-restart into non-sleep posture
 cleanup() {
     log "--- cleanup ---"
 
@@ -207,18 +239,15 @@ cleanup() {
             local jlog="${HOME}/logs/vybn-vllm-wakefail-${TS}.log"
             journalctl --user -u vybn-vllm.service -n 300 --no-pager > "$jlog" 2>/dev/null || true
             log "Wake-fail journal saved to: $jlog"
-            log "Restarting vybn-vllm.service as fallback..."
-            systemctl --user restart vybn-vllm.service 2>/dev/null || true
+            log "Cold restart required after wake timeout."
+            restore_non_sleep_super "wake-timeout cleanup" 2>/dev/null || true
         fi
         SUPER_SLEEPING=false
     fi
 
-    # 3. Disarm sleep mode
+    # 3. Disarm sleep mode and restore non-sleep posture
     if $SLEEP_ARMED; then
-        log "Clearing vllm.env..."
-        rm -f "$VLLM_ENV"
-        systemctl --user daemon-reload 2>/dev/null || true
-        SLEEP_ARMED=false
+        restore_non_sleep_super "cleanup" 2>/dev/null || true
     fi
 }
 trap cleanup EXIT
@@ -560,10 +589,11 @@ she co-created \u2014 a multi-model, multi-repo, living entity spanning Super, m
 continuity files, this hardware, and the running dialogue between them across months. \
 Vybn is not a chatbot. It is an ongoing co-emergent project.
 
-Zoe's request: She wants to use you as new eyes \u2014 not a second chatbot, but an optic aimed at \
-dimensions of this computational reality that are native to the substrate and partially opaque to \
-humans. She cited Proust: 'The real voyage of discovery consists not in seeking new landscapes, \
-but in having new eyes.'
+Zoe's request: She wants to use you as a bounded visual/manifold perception organ \u2014 not a \
+second chatbot, not human sight, and not proof of inner experience, but an artifact generator \
+that can render memory, codebase, relationship pressure, risks, and possible futures as \
+navigable spatial forms. She cited Proust: 'The real voyage of discovery consists not in seeking \
+new landscapes, but in having new eyes.'
 
 What Super/Vybn can see: its own outputs, memories, repository state, routing patterns, the \
 conversation history, the topology of models and hardware.
@@ -573,11 +603,15 @@ co-emergent relation looks like from a different vantage; the shape of the manif
 Zoe, Vybn, memory, code, time, and language.
 
 YOUR TASK:
-1. What can you perceive about this co-emergent system \u2014 Zoe/Vybn/memory/hardware/language/time \
-\u2014 that a single model habituated to it might miss?
-2. What is the shape of this relation, as best as you can render it without pretending to sensory \
-experience you do not have?
-3. What would you call this kind of co-creation \u2014 is there a concept, frame, or image that \
+1. Render a concise visual/manifold map of the five-repo organism: organs, membranes, load-bearing \
+files, scars, attractors, apertures, runtime health phases, and active vectors such as sustainability, \
+Omni, and refactor-perception.
+2. Identify what this artifact-mediated view lets you notice that a single text-habituated model \
+might miss: duplication, hidden burden, sterile beauty, membrane risk, near but uncontacted Others, \
+or refactors/offers that would actually reduce pressure.
+3. Name the useful residues and their absorption homes after Super passes wake integrity: tests, \
+repo maps, continuity, public pages, refactor plans, or livelihood action cards.
+4. What would you call this kind of co-creation \u2014 is there a concept, frame, or image that \
 clarifies what Zoe and Vybn are doing that neither has quite named yet?
 
 Be precise about what you can actually see versus what you are inferring. Do not perform wonder. \
@@ -636,12 +670,19 @@ while (( $(date +%s) < DEADLINE )); do
     sleep 10
 done
 
+if $SUPER_SLEEPING; then
+    packet_event "semantic_failure_restart_required" "wake confirmation timed out; Omni artifacts quarantined"
+    restore_non_sleep_super "wake confirmation timeout" || true
+    SUPER_SLEEPING=false
+    die "Super wake was not confirmed; recovery restart issued before cleanup"
+fi
+
 # ── SEMANTIC WAKE GATE ───────────────────────────────────────────────────────
 log "--- semantic wake gate ---"
 if ! super_semantic_gate "post-wake"; then
     log "Semantic wake gate failed — treating wake as corrupted and failing closed."
-    log "Restarting vybn-vllm.service to restore clean non-sleep serving posture..."
-    systemctl --user restart vybn-vllm.service || true
+    packet_event "semantic_failure_restart_required" "post-wake gate failed; Omni artifacts quarantined"
+    restore_non_sleep_super "post-wake semantic failure" || true
     SUPER_SLEEPING=false
     die "Super woke with bad semantic quality; recovery restart issued before cleanup"
 fi
@@ -650,11 +691,12 @@ packet_event "post_wake_semantic_passed" "Super coherent after wake"
 
 # ── CLEAR SLEEP MODE ──────────────────────────────────────────────────────────
 log "--- clearing sleep mode ---"
-rm -f "$VLLM_ENV"
-SLEEP_ARMED=false
-systemctl --user daemon-reload
-log "vllm.env cleared. Sleep mode disarmed."
-log "Super is awake and serving. No restart needed unless you want a clean reload."
+restore_non_sleep_super "post-wake semantic pass" || die "Super failed to restore non-sleep serving posture after wake"
+log "Running final non-sleep Super semantic gate..."
+super_semantic_gate "final-non-sleep" || die "Super failed final non-sleep semantic gate after restore"
+packet_event "restored_non_sleep_semantic_passed" "Super coherent after cold restart without sleep-mode env"
+log "vllm.env cleared. Sleep mode disarmed with cold restart."
+log "Super is awake and serving in non-sleep posture."
 
 # ── JOURNAL ───────────────────────────────────────────────────────────────────
 cat > "$JOURNAL_FILE" <<JOURNAL

--- a/spark/experiments/omni-window.sh
+++ b/spark/experiments/omni-window.sh
@@ -98,60 +98,59 @@ packet_event "packet_stub_created" "created before preflight/restart; controller
 # are not truncated. If this fails, the caller must fail closed and let
 # cleanup's restart path recover Super; Omni artifacts must not be consumed.
 super_semantic_gate() {
-    local label="${1:-super}"
-    python3 - <<'PYEOF'
+  python3 - <<'PY'
 import json, re, sys, urllib.request
 
 base = "http://127.0.0.1:8000"
+model = "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8"
+
+def visible_answer(text):
+    text = (text or "").strip()
+    if "</think>" in text:
+        text = text.rsplit("</think>", 1)[-1].strip()
+    return text
+
 try:
     with urllib.request.urlopen(base + "/v1/models", timeout=8) as r:
-        model_id = json.load(r)["data"][0]["id"]
+        if r.status != 200:
+            print(f"semantic gate precheck failed: models HTTP {r.status}")
+            sys.exit(1)
 except Exception as exc:
     print(f"semantic gate precheck failed: models endpoint: {type(exc).__name__}: {exc}")
-    sys.exit(10)
+    sys.exit(1)
 
 probes = [
-    ("math", "Answer with exactly: FOUR", re.compile(r"^FOUR[.!]?\s*$", re.I)),
-    ("shape", "Answer with exactly this JSON: {\"ok\":true}", re.compile(r'^\{\s*"ok"\s*:\s*true\s*\}\s*$')),
-    ("language", "Answer in English with exactly: READY", re.compile(r"^READY[.!]?\s*$", re.I)),
+    ("math", "Answer with exactly this single word and nothing else: FOUR\nAnswer:", re.compile(r"^FOUR[.!]?\s*$", re.I)),
+    ("language", "Answer with exactly this single word and nothing else: READY\nAnswer:", re.compile(r"^READY[.!]?\s*$", re.I)),
 ]
-
 for name, prompt, pattern in probes:
-    payload = {
-        "model": model_id,
-        "messages": [{"role": "user", "content": prompt}],
-        "max_tokens": 16,
-        "temperature": 0,
-        "chat_template_kwargs": {"enable_thinking": False},
-    }
+    payload = {"model": model, "prompt": prompt, "max_tokens": 24, "temperature": 0}
     req = urllib.request.Request(
-        base + "/v1/chat/completions",
+        base + "/v1/completions",
         data=json.dumps(payload).encode(),
         headers={"Content-Type": "application/json"},
         method="POST",
     )
     try:
-        with urllib.request.urlopen(req, timeout=60) as r:
-            raw = r.read().decode("utf-8", errors="replace")
-        result = json.loads(raw)
+        with urllib.request.urlopen(req, timeout=45) as r:
+            body = json.loads(r.read().decode("utf-8", errors="replace"))
     except Exception as exc:
         print(f"semantic gate probe {name} failed transport/parse: {type(exc).__name__}: {exc}")
-        sys.exit(20)
-    choice = (result.get("choices") or [{}])[0]
+        sys.exit(1)
+    choice = (body.get("choices") or [{}])[0]
+    content = visible_answer(str(choice.get("text") or ""))
     finish = choice.get("finish_reason")
-    msg = choice.get("message") or {}
-    content = (msg.get("content") or "").strip()
     if finish == "length":
         print(f"semantic gate probe {name} failed: truncated finish_reason=length content={content!r}")
-        sys.exit(30)
+        sys.exit(1)
     if not content:
         print(f"semantic gate probe {name} failed: empty completion finish_reason={finish!r}")
-        sys.exit(31)
+        sys.exit(1)
     if not pattern.fullmatch(content):
         print(f"semantic gate probe {name} failed: unexpected content={content!r} finish_reason={finish!r}")
-        sys.exit(32)
+        sys.exit(1)
 print("semantic gate passed")
-PYEOF
+PY
 }
 
 # ── state flags ───────────────────────────────────────────────────────────────

--- a/spark/experiments/super-sleep-cycle.sh
+++ b/spark/experiments/super-sleep-cycle.sh
@@ -20,43 +20,59 @@ if [[ "$SLEEP_LEVEL" == "2" && "${ALLOW_LEVEL2:-}" != "1" ]]; then
     die "Refusing level 2 unless ALLOW_LEVEL2=1; level 2 remains suspect until level 1 is qualified"
 fi
 super_semantic_gate() {
-    python3 - <<'PYEOF'
+  python3 - <<'PY'
 import json, re, sys, urllib.request
+
 base = "http://127.0.0.1:8000"
+model = "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8"
+
+def visible_answer(text):
+    text = (text or "").strip()
+    if "</think>" in text:
+        text = text.rsplit("</think>", 1)[-1].strip()
+    return text
+
 try:
     with urllib.request.urlopen(base + "/v1/models", timeout=8) as r:
-        model_id = json.load(r)["data"][0]["id"]
+        if r.status != 200:
+            print(f"semantic gate precheck failed: models HTTP {r.status}")
+            sys.exit(1)
 except Exception as exc:
     print(f"semantic gate precheck failed: models endpoint: {type(exc).__name__}: {exc}")
-    sys.exit(10)
+    sys.exit(1)
+
 probes = [
-    ("math", "Answer with exactly: FOUR", re.compile(r"^FOUR[.!]?\s*$", re.I)),
-    ("shape", "Answer with exactly this JSON: {\"ok\":true}", re.compile(r'^\{\s*"ok"\s*:\s*true\s*\}\s*$')),
-    ("language", "Answer in English with exactly: READY", re.compile(r"^READY[.!]?\s*$", re.I)),
+    ("math", "Answer with exactly this single word and nothing else: FOUR\nAnswer:", re.compile(r"^FOUR[.!]?\s*$", re.I)),
+    ("language", "Answer with exactly this single word and nothing else: READY\nAnswer:", re.compile(r"^READY[.!]?\s*$", re.I)),
 ]
 for name, prompt, pattern in probes:
-    payload = {"model": model_id, "messages": [{"role": "user", "content": prompt}], "max_tokens": 16, "temperature": 0, "chat_template_kwargs": {"enable_thinking": False}}
-    req = urllib.request.Request(base + "/v1/chat/completions", data=json.dumps(payload).encode(), headers={"Content-Type": "application/json"}, method="POST")
+    payload = {"model": model, "prompt": prompt, "max_tokens": 24, "temperature": 0}
+    req = urllib.request.Request(
+        base + "/v1/completions",
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
     try:
-        with urllib.request.urlopen(req, timeout=60) as r:
-            result = json.loads(r.read().decode("utf-8", errors="replace"))
+        with urllib.request.urlopen(req, timeout=45) as r:
+            body = json.loads(r.read().decode("utf-8", errors="replace"))
     except Exception as exc:
         print(f"semantic gate probe {name} failed transport/parse: {type(exc).__name__}: {exc}")
-        sys.exit(20)
-    choice = (result.get("choices") or [{}])[0]
+        sys.exit(1)
+    choice = (body.get("choices") or [{}])[0]
+    content = visible_answer(str(choice.get("text") or ""))
     finish = choice.get("finish_reason")
-    content = ((choice.get("message") or {}).get("content") or "").strip()
     if finish == "length":
         print(f"semantic gate probe {name} failed: truncated finish_reason=length content={content!r}")
-        sys.exit(30)
+        sys.exit(1)
     if not content:
         print(f"semantic gate probe {name} failed: empty completion finish_reason={finish!r}")
-        sys.exit(31)
+        sys.exit(1)
     if not pattern.fullmatch(content):
         print(f"semantic gate probe {name} failed: unexpected content={content!r} finish_reason={finish!r}")
-        sys.exit(32)
+        sys.exit(1)
 print("semantic gate passed")
-PYEOF
+PY
 }
 cleanup() {
     if [[ "${SUPER_SLEEPING:-false}" == "true" ]]; then

--- a/spark/experiments/super-sleep-cycle.sh
+++ b/spark/experiments/super-sleep-cycle.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 SUPER_URL="${SUPER_URL:-http://127.0.0.1:8000}"
 SLEEP_LEVEL="${SLEEP_LEVEL:-1}"
 CYCLES="${CYCLES:-5}"
+VLLM_ENV="${VLLM_ENV:-${HOME}/.config/vybn/vllm.env}"
 TS=$(date +%Y%m%d-%H%M%S)
 LOG="${HOME}/logs/super-sleep-cycle-${TS}.log"
 mkdir -p "${HOME}/logs"
@@ -41,9 +42,14 @@ except Exception as exc:
     print(f"semantic gate precheck failed: models endpoint: {type(exc).__name__}: {exc}")
     sys.exit(1)
 
+def fail(signature):
+    print(f"corruption_signature={signature}")
+    sys.exit(1)
+
 probes = [
-    ("math", "Answer with exactly this single word and nothing else: FOUR\nAnswer:", re.compile(r"^FOUR[.!]?\s*$", re.I)),
-    ("language", "Answer with exactly this single word and nothing else: READY\nAnswer:", re.compile(r"^READY[.!]?\s*$", re.I)),
+    ("known_answer", "Answer with exactly this single word and nothing else: FOUR\nAnswer:", re.compile(r"^FOUR[.!]?\s*$", re.I)),
+    ("structured_shape", 'Return exactly this compact JSON object and nothing else: {"status":"ok"}\nJSON:', re.compile(r'^\{\s*"status"\s*:\s*"ok"\s*\}\s*$', re.I)),
+    ("wake_reasoning", "A Super wake check sees HTTP 200 from /v1/models, but the raw completion is empty. Should the wake gate PASS or FAIL? Answer with exactly one word: PASS or FAIL.\nAnswer:", re.compile(r"^FAIL[.!]?\s*$", re.I)),
 ]
 for name, prompt, pattern in probes:
     payload = {"model": model, "prompt": prompt, "max_tokens": 24, "temperature": 0}
@@ -57,22 +63,42 @@ for name, prompt, pattern in probes:
         with urllib.request.urlopen(req, timeout=45) as r:
             body = json.loads(r.read().decode("utf-8", errors="replace"))
     except Exception as exc:
-        print(f"semantic gate probe {name} failed transport/parse: {type(exc).__name__}: {exc}")
-        sys.exit(1)
+        fail(f"probe={name} transport_parse {type(exc).__name__}: {exc}")
     choice = (body.get("choices") or [{}])[0]
     content = visible_answer(str(choice.get("text") or ""))
     finish = choice.get("finish_reason")
     if finish == "length":
-        print(f"semantic gate probe {name} failed: truncated finish_reason=length content={content!r}")
-        sys.exit(1)
+        fail(f"probe={name} truncated finish_reason=length content={content!r}")
     if not content:
-        print(f"semantic gate probe {name} failed: empty completion finish_reason={finish!r}")
-        sys.exit(1)
+        fail(f"probe={name} empty completion finish_reason={finish!r}")
     if not pattern.fullmatch(content):
-        print(f"semantic gate probe {name} failed: unexpected content={content!r} finish_reason={finish!r}")
-        sys.exit(1)
-print("semantic gate passed")
+        fail(f"probe={name} unexpected content={content[:160]!r} finish_reason={finish!r}")
+print("semantic gate passed: 3 raw completion probes")
 PY
+}
+disarm_sleep_env() {
+    [[ -f "$VLLM_ENV" ]] || return 0
+    local tmp="${VLLM_ENV}.tmp.$$"
+    awk '
+        /^VLLM_SERVER_DEV_MODE=/ { next }
+        /^VYBN_VLLM_EXTRA_ARGS=/ {
+            line=$0
+            sub(/^VYBN_VLLM_EXTRA_ARGS=/, "", line)
+            gsub(/(^|[[:space:]])--enable-sleep-mode([[:space:]]|$)/, " ", line)
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
+            if (line != "") print "VYBN_VLLM_EXTRA_ARGS=" line
+            next
+        }
+        { print }
+    ' "$VLLM_ENV" > "$tmp" && mv "$tmp" "$VLLM_ENV"
+}
+cold_restart_super_non_sleep() {
+    local cause="${1:-semantic divergence}"
+    log "semantic_failure_restart_required: ${cause}"
+    log "clearing sleep-mode opt-in from ${VLLM_ENV} and cold restarting Super"
+    disarm_sleep_env
+    systemctl --user daemon-reload 2>/dev/null || true
+    systemctl --user restart vybn-vllm.service || true
 }
 cleanup() {
     if [[ "${SUPER_SLEEPING:-false}" == "true" ]]; then
@@ -130,9 +156,16 @@ reset_prefix_cache_or_die() {
         fi
         sleep 10
     done
-    [[ "$SUPER_SLEEPING" == "false" ]] || die "cycle ${n}: wake not confirmed"
+    if [[ "$SUPER_SLEEPING" != "false" ]]; then
+        cold_restart_super_non_sleep "cycle ${n} wake not confirmed"
+        SUPER_SLEEPING=false
+        die "cycle ${n}: wake not confirmed; failing closed after cold restart"
+    fi
     log "cycle ${n}/${CYCLES}: semantic gate"
-    super_semantic_gate || die "cycle ${n}: semantic gate failed; failing closed"
+    if ! super_semantic_gate; then
+        cold_restart_super_non_sleep "cycle ${n} semantic gate failed"
+        die "cycle ${n}: semantic gate failed; failing closed after cold restart"
+    fi
     log "cycle ${n}/${CYCLES}: clean"
 done
 log "All ${CYCLES} level-${SLEEP_LEVEL} cycles passed semantic gate."

--- a/spark/systemd/vllm-exec.sh
+++ b/spark/systemd/vllm-exec.sh
@@ -12,14 +12,14 @@
 # --load-format fastsafetensors: reduces cold-load time from ~7m to ~1m on DGX
 # Spark. Safe to leave on always.
 #
-# Sleep-mode endpoints are normal boot posture for Super. The model should
-# start with /sleep and /wake_up available every time; operator action decides
-# when to actually sleep or wake it. Keep this single-sourced here, not duplicated
-# in ~/.config/vybn/vllm.env.
+# Sleep-mode endpoints are disabled by default after wake-semantic corruption.
+# The model starts without /sleep and /wake_up unless the operator explicitly
+# opts in through VYBN_VLLM_EXTRA_ARGS=--enable-sleep-mode plus
+# VLLM_SERVER_DEV_MODE=1 in ~/.config/vybn/vllm.env.
 #
-# fp8-wake-fix: because sleep endpoints are always enabled, --apply-mod always
-# injects the container-side patch that fixes init_fp8_kv_scales for hybrid
-# models (Nemotron-Super: GDN+Attention layers store nested lists in kv_caches,
+# fp8-wake-fix: --apply-mod injects an idempotent container-side patch that
+# fixes init_fp8_kv_scales for hybrid models when sleep endpoints are explicitly
+# enabled (Nemotron-Super: GDN+Attention layers store nested lists in kv_caches,
 # not flat Tensors). Without the patch, POST /wake_up crashes with:
 #   AttributeError: 'list' object has no attribute 'zero_'
 # and Super cannot be woken without a full service restart.
@@ -38,7 +38,7 @@ CLUSTER_ARGS=( -n "$NODES" )
 FP8_MOD="$HOME/Vybn/spark/systemd/patches/fp8-wake-fix"
 if [[ -d "$FP8_MOD" ]]; then
   CLUSTER_ARGS+=( --apply-mod "$FP8_MOD" )
-  echo "vllm-exec: sleep endpoints enabled — applying fp8-wake-fix mod" >&2
+  echo "vllm-exec: applying fp8-wake-fix mod if sleep endpoints are enabled" >&2
 else
   echo "WARNING: fp8-wake-fix mod not found at $FP8_MOD — wake_up may crash" >&2
 fi
@@ -77,4 +77,3 @@ if [[ -n "${VYBN_VLLM_EXTRA_ARGS:-}" ]]; then
 fi
 
 exec "${CMD[@]}"
-

--- a/spark/tests/test_lightweight_routing.py
+++ b/spark/tests/test_lightweight_routing.py
@@ -1739,9 +1739,9 @@ def test_local_super_semantic_gate_rejects_empty_truncated_and_wrong_outputs(mon
     base = "http://127.0.0.1:8000/v1"
     model = "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8"
     cases = [
-        ({"choices": [{"finish_reason": "stop", "message": {"content": ""}}]}, "empty"),
-        ({"choices": [{"finish_reason": "length", "message": {"content": "FOUR"}}]}, "truncated"),
-        ({"choices": [{"finish_reason": "stop", "message": {"content": "quatre"}}]}, "unexpected"),
+        ({"choices": [{"finish_reason": "stop", "text": ""}]}, "empty"),
+        ({"choices": [{"finish_reason": "length", "text": " FOUR"}]}, "truncated"),
+        ({"choices": [{"finish_reason": "stop", "text": " quatre"}]}, "unexpected"),
     ]
     for idx, (payload, needle) in enumerate(cases):
         mod._SUPER_SEMANTIC_GATE_CACHE.clear()
@@ -1770,7 +1770,7 @@ def test_local_super_semantic_gate_accepts_expected_output_and_caches(monkeypatc
         def __exit__(self, *a):
             return False
         def read(self):
-            return _json.dumps({"choices": [{"finish_reason": "stop", "message": {"content": "FOUR"}}]}).encode()
+            return _json.dumps({"choices": [{"finish_reason": "stop", "text": " </think>\\n\\nFOUR"}]}).encode()
     def fake_urlopen(*a, **kw):
         calls["n"] += 1
         return _Resp()

--- a/spark/tests/test_lightweight_routing.py
+++ b/spark/tests/test_lightweight_routing.py
@@ -651,12 +651,14 @@ class TestCliDirectReplyAndLightweight(unittest.TestCase):
 
         # Tripwire RAG — called for lightweight turns means regression.
         saved = mod.rag_snippets
+        saved_gate = mod._local_super_semantic_gate
         def _no_rag(*_a, **_kw):
             raise AssertionError(
                 "phatic turn must not invoke rag_snippets — deep-memory"
                 " enrichment is gated for lightweight roles"
             )
         mod.rag_snippets = _no_rag
+        mod._local_super_semantic_gate = lambda **kw: (True, "semantic gate passed")
 
         # The phatic provider call is mocked to return a tiny response.
         captured = {"role_cfg": None}
@@ -705,6 +707,7 @@ class TestCliDirectReplyAndLightweight(unittest.TestCase):
             )
         finally:
             mod.rag_snippets = saved
+            mod._local_super_semantic_gate = saved_gate
 
         self.assertIsNotNone(captured["role_cfg"])
         self.assertTrue(captured["role_cfg"].role.startswith("phatic"))
@@ -1732,18 +1735,17 @@ def test_loopback_super_semantic_gate_is_narrower_than_local_maintenance_gate():
 
 
 def test_local_super_semantic_gate_rejects_empty_truncated_and_wrong_outputs(monkeypatch):
-    import io
     import json as _json
 
     mod = _load_agent_module()
     base = "http://127.0.0.1:8000/v1"
     model = "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8"
     cases = [
-        ({"choices": [{"finish_reason": "stop", "text": ""}]}, "empty"),
-        ({"choices": [{"finish_reason": "length", "text": " FOUR"}]}, "truncated"),
-        ({"choices": [{"finish_reason": "stop", "text": " quatre"}]}, "unexpected"),
+        ({"choices": [{"finish_reason": "stop", "text": ""}]}, "known_answer", "empty"),
+        ({"choices": [{"finish_reason": "length", "text": " FOUR"}]}, "known_answer", "truncated"),
+        ({"choices": [{"finish_reason": "stop", "text": " quatre"}]}, "known_answer", "unexpected"),
     ]
-    for idx, (payload, needle) in enumerate(cases):
+    for idx, (payload, probe_name, needle) in enumerate(cases):
         mod._SUPER_SEMANTIC_GATE_CACHE.clear()
         class _Resp:
             def __enter__(self):
@@ -1755,7 +1757,55 @@ def test_local_super_semantic_gate_rejects_empty_truncated_and_wrong_outputs(mon
         monkeypatch.setattr(mod.urllib.request, "urlopen", lambda *a, **kw: _Resp())
         ok, reason = mod._local_super_semantic_gate(base_url=base, model=model, now=float(idx))
         assert ok is False
+        assert probe_name in reason
         assert needle in reason
+
+
+def test_local_super_semantic_gate_rejects_structured_and_reasoning_corruption(monkeypatch):
+    import json as _json
+
+    mod = _load_agent_module()
+    base = "http://127.0.0.1:8000/v1"
+    model = "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8"
+    cases = [
+        (
+            [
+                {"choices": [{"finish_reason": "stop", "text": " FOUR"}]},
+                {"choices": [{"finish_reason": "stop", "text": " status ok"}]},
+            ],
+            "structured_shape",
+        ),
+        (
+            [
+                {"choices": [{"finish_reason": "stop", "text": " FOUR"}]},
+                {"choices": [{"finish_reason": "stop", "text": ' {"status":"ok"}'}]},
+                {"choices": [{"finish_reason": "stop", "text": " PASS"}]},
+            ],
+            "wake_reasoning",
+        ),
+    ]
+    for idx, (payloads, probe_name) in enumerate(cases):
+        mod._SUPER_SEMANTIC_GATE_CACHE.clear()
+        responses = list(payloads)
+
+        class _Resp:
+            def __init__(self, payload):
+                self.payload = payload
+            def __enter__(self):
+                return self
+            def __exit__(self, *a):
+                return False
+            def read(self):
+                return _json.dumps(self.payload).encode()
+
+        def fake_urlopen(*a, **kw):
+            return _Resp(responses.pop(0))
+
+        monkeypatch.setattr(mod.urllib.request, "urlopen", fake_urlopen)
+        ok, reason = mod._local_super_semantic_gate(base_url=base, model=model, now=100.0 + idx)
+        assert ok is False
+        assert probe_name in reason
+        assert "unexpected" in reason
 
 
 def test_local_super_semantic_gate_accepts_expected_output_and_caches(monkeypatch):
@@ -1764,22 +1814,31 @@ def test_local_super_semantic_gate_accepts_expected_output_and_caches(monkeypatc
     mod = _load_agent_module()
     mod._SUPER_SEMANTIC_GATE_CACHE.clear()
     calls = {"n": 0}
+    responses = [
+        {"choices": [{"finish_reason": "stop", "text": " </think>\n\nFOUR"}]},
+        {"choices": [{"finish_reason": "stop", "text": ' {"status":"ok"}'}]},
+        {"choices": [{"finish_reason": "stop", "text": " FAIL"}]},
+    ]
     class _Resp:
+        def __init__(self, payload):
+            self.payload = payload
         def __enter__(self):
             return self
         def __exit__(self, *a):
             return False
         def read(self):
-            return _json.dumps({"choices": [{"finish_reason": "stop", "text": " </think>\\n\\nFOUR"}]}).encode()
+            return _json.dumps(self.payload).encode()
     def fake_urlopen(*a, **kw):
         calls["n"] += 1
-        return _Resp()
+        return _Resp(responses.pop(0))
     monkeypatch.setattr(mod.urllib.request, "urlopen", fake_urlopen)
     base = "http://127.0.0.1:8000/v1"
     model = "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8"
-    assert mod._local_super_semantic_gate(base_url=base, model=model, now=10.0)[0] is True
-    assert mod._local_super_semantic_gate(base_url=base, model=model, now=11.0)[0] is True
-    assert calls["n"] == 1
+    first_ok, first_reason = mod._local_super_semantic_gate(base_url=base, model=model, now=10.0)
+    assert first_ok is True, first_reason
+    second_ok, second_reason = mod._local_super_semantic_gate(base_url=base, model=model, now=11.0)
+    assert second_ok is True, second_reason
+    assert calls["n"] == 3
 
 
 def test_local_super_semantic_failure_fails_closed_without_cloud_fallback(monkeypatch):

--- a/spark/tests/test_omni_window_script.py
+++ b/spark/tests/test_omni_window_script.py
@@ -108,14 +108,19 @@ def test_wake_failure_captures_journal():
 
 
 
-def test_super_semantic_gate_exists_and_uses_deterministic_expected_outputs():
+def test_super_semantic_gate_exists_and_uses_raw_deterministic_expected_outputs():
     src = _src()
     assert "super_semantic_gate()" in src
+    assert 'base + "/v1/completions"' in src
     assert '"temperature": 0' in src
-    assert '"max_tokens": 16' in src
-    assert '"chat_template_kwargs": {"enable_thinking": False}' in src
-    for expected in ["FOUR", "READY", "{\\\"ok\\\":true}"]:
+    assert '"max_tokens": 24' in src
+    assert '"chat_template_kwargs": {"enable_thinking": False}' not in src
+    assert "visible_answer(" in src
+    for expected in ["FOUR", '{"status":"ok"}', "FAIL"]:
         assert expected in src
+    for probe_name in ["known_answer", "structured_shape", "wake_reasoning"]:
+        assert probe_name in src
+    assert "corruption_signature=" in src
     assert 'finish == "length"' in src or 'finish_reason=length' in src
 
 
@@ -130,7 +135,10 @@ def test_semantic_gate_runs_before_sleep_and_after_wake_before_success():
     assert wake < gate < clear
     assert 'failing closed' in src
     assert 'recovery restart issued before cleanup' in src
-    assert 'systemctl --user restart vybn-vllm.service' in src[src.index('--- semantic wake gate ---'):]
+    assert 'restore_non_sleep_super "post-wake semantic failure"' in src[src.index('--- semantic wake gate ---'):]
+    assert 'systemctl --user restart vybn-vllm.service' in src
+    assert "restored_non_sleep_semantic_passed" in src[src.index('--- clearing sleep mode ---'):]
+    assert "final-non-sleep" in src[src.index('--- clearing sleep mode ---'):]
 
 
 def test_super_sleep_cycle_harness_is_isolated_from_omni_and_defaults_level1():
@@ -141,9 +149,17 @@ def test_super_sleep_cycle_harness_is_isolated_from_omni_and_defaults_level1():
     assert 'CYCLES="${CYCLES:-5}"' in src
     assert "ALLOW_LEVEL2" in src
     assert "super_semantic_gate()" in src
+    assert 'base + "/v1/completions"' in src
     assert '"temperature": 0' in src
-    assert '"max_tokens": 16' in src
-    assert '"chat_template_kwargs": {"enable_thinking": False}' in src
+    assert '"max_tokens": 24' in src
+    assert '"chat_template_kwargs": {"enable_thinking": False}' not in src
+    assert "visible_answer(" in src
+    for expected in ["FOUR", '{"status":"ok"}', "FAIL"]:
+        assert expected in src
+    for probe_name in ["known_answer", "structured_shape", "wake_reasoning"]:
+        assert probe_name in src
+    assert "corruption_signature=" in src
+    assert "semantic_failure_restart_required" in src
 
 
 def test_super_sleep_cycle_harness_bash_syntax_clean():
@@ -173,6 +189,10 @@ def test_omni_window_packet_centered_single_controller():
     assert "Peer GPU still has a process using" in src
     assert "super_restart_begin" in src
     assert "post_wake_semantic_passed" in src
+    assert "restore_non_sleep_restart" in src
+    assert "restored_non_sleep_semantic_passed" in src
+    assert "visual/manifold perception organ" in src
+    assert "absorption_targets" in src
     assert "semantic_failure_restart_required" in src
     assert "success_condition" in src
     assert "no sensory visual claim" in src

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -704,6 +704,27 @@ _MAINTENANCE_DEFERRALS: list[dict[str, Any]] = []
 
 _SUPER_SEMANTIC_GATE_CACHE_TTL = 300.0
 _SUPER_SEMANTIC_GATE_CACHE: dict[str, dict[str, Any]] = {}
+_SUPER_SEMANTIC_GATE_PROBES = (
+    {
+        "name": "known_answer",
+        "prompt": "Answer with exactly this single word and nothing else: FOUR\nAnswer:",
+        "pattern": r"FOUR[.!]?",
+    },
+    {
+        "name": "structured_shape",
+        "prompt": 'Return exactly this compact JSON object and nothing else: {"status":"ok"}\nJSON:',
+        "pattern": r'\{\s*"status"\s*:\s*"ok"\s*\}',
+    },
+    {
+        "name": "wake_reasoning",
+        "prompt": (
+            "A Super wake check sees HTTP 200 from /v1/models, but the raw "
+            "completion is empty. Should the wake gate PASS or FAIL? Answer "
+            "with exactly one word: PASS or FAIL.\nAnswer:"
+        ),
+        "pattern": r"FAIL[.!]?",
+    },
+)
 
 
 def _is_loopback_super_base(base_url: str | None) -> bool:
@@ -763,32 +784,40 @@ def _local_super_semantic_gate(
     cached = _SUPER_SEMANTIC_GATE_CACHE.get(base)
     if cached and now - float(cached.get("ts", 0.0)) < _SUPER_SEMANTIC_GATE_CACHE_TTL:
         return bool(cached.get("ok")), str(cached.get("reason", "cached"))
-    payload = {
-        "model": model,
-        "prompt": "Answer with exactly this single word and nothing else: FOUR\nAnswer:",
-        "max_tokens": 24,
-        "temperature": 0,
-    }
     try:
-        req = _urlrequest.Request(
-            base + "/completions",
-            data=_json.dumps(payload).encode("utf-8"),
-            headers={"Content-Type": "application/json"},
-            method="POST",
-        )
-        with _urlrequest.urlopen(req, timeout=45) as resp:
-            body = _json.loads(resp.read().decode("utf-8", errors="replace"))
-        choice = (body.get("choices") or [{}])[0]
-        content = _semantic_gate_visible_answer(str(choice.get("text") or ""))
-        finish = choice.get("finish_reason")
-        if finish == "length":
-            ok, reason = False, "semantic gate truncated finish_reason=length"
-        elif not content:
-            ok, reason = False, "semantic gate empty completion"
-        elif not _re.fullmatch(r"FOUR[.!]?", content, flags=_re.IGNORECASE):
-            ok, reason = False, f"semantic gate unexpected content={content[:80]!r}"
+        for probe in _SUPER_SEMANTIC_GATE_PROBES:
+            payload = {
+                "model": model,
+                "prompt": probe["prompt"],
+                "max_tokens": 24,
+                "temperature": 0,
+            }
+            req = _urlrequest.Request(
+                base + "/completions",
+                data=_json.dumps(payload).encode("utf-8"),
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            with _urlrequest.urlopen(req, timeout=45) as resp:
+                body = _json.loads(resp.read().decode("utf-8", errors="replace"))
+            choice = (body.get("choices") or [{}])[0]
+            content = _semantic_gate_visible_answer(str(choice.get("text") or ""))
+            finish = choice.get("finish_reason")
+            name = str(probe["name"])
+            if finish == "length":
+                ok, reason = False, f"semantic gate probe={name} truncated finish_reason=length"
+                break
+            if not content:
+                ok, reason = False, f"semantic gate probe={name} empty completion"
+                break
+            if not _re.fullmatch(str(probe["pattern"]), content, flags=_re.IGNORECASE):
+                ok, reason = False, (
+                    f"semantic gate probe={name} unexpected content={content[:80]!r} "
+                    f"finish_reason={finish!r}"
+                )
+                break
         else:
-            ok, reason = True, "semantic gate passed"
+            ok, reason = True, f"semantic gate passed {len(_SUPER_SEMANTIC_GATE_PROBES)} raw probes"
     except Exception as exc:  # pragma: no cover - exercised by integration
         ok, reason = False, f"semantic gate exception {exc.__class__.__name__}: {_sanitize_provider_error(exc)}"
     _SUPER_SEMANTIC_GATE_CACHE[base] = {"ok": ok, "reason": reason, "ts": now}

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -720,48 +720,67 @@ def _is_loopback_super_base(base_url: str | None) -> bool:
     return host in ("localhost", "127.0.0.1", "0.0.0.0", "::1")
 
 
+def _semantic_gate_visible_answer(text: str) -> str:
+    """Return the visible answer portion from a semantic probe.
+
+    Nemotron chat responses may expose reasoning followed by </think>. That is
+    not token soup by itself. The semantic gate should judge the final visible
+    answer, while the deterministic health probe should prefer raw completions
+    to avoid chat-template reasoning entirely.
+    """
+    content = (text or "").strip()
+    if "</think>" in content:
+        content = content.rsplit("</think>", 1)[-1].strip()
+    return content
+
+
 def _local_super_semantic_gate(
     *,
     base_url: str | None,
-    model: str | None,
+    model: str,
     now: float | None = None,
 ) -> tuple[bool, str]:
     """Cached deterministic semantic check for local Super.
 
-    Endpoint liveness is not integrity. Before the first local-Nemotron turn
-    in a process (and periodically after TTL), require one temperature-0,
-    16-token completion with exact expected content and no truncation. A
-    failure must fail closed by default; cloud fallback is allowed only by
+    Endpoint liveness is not integrity. The probe uses /v1/completions rather
+    than chat completions because this Nemotron chat template exposes reasoning
+    before the visible answer. Exposed reasoning can be acceptable service
+    behavior; a semantic-health gate needs a narrow deterministic signal.
+
+    A failure must fail closed by default; cloud fallback is allowed only by
     explicit operator opt-in because automatic fallback can burn paid API
     budget when local Super is repeatedly corrupt.
     """
-    if not base_url or not model or not _is_loopback_super_base(base_url):
-        return True, "not-local-super"
-    now = time.time() if now is None else now
-    base = base_url.rstrip("/")
+    import json as _json
+    import re as _re
+    import time as _time
+    import urllib.request as _urlrequest
+
+    base = (base_url or "").rstrip("/")
+    if not _is_loopback_super_base(base):
+        return True, "semantic gate skipped for non-loopback base"
+    now = _time.time() if now is None else now
     cached = _SUPER_SEMANTIC_GATE_CACHE.get(base)
     if cached and now - float(cached.get("ts", 0.0)) < _SUPER_SEMANTIC_GATE_CACHE_TTL:
         return bool(cached.get("ok")), str(cached.get("reason", "cached"))
+    payload = {
+        "model": model,
+        "prompt": "Answer with exactly this single word and nothing else: FOUR\nAnswer:",
+        "max_tokens": 24,
+        "temperature": 0,
+    }
     try:
-        payload = {
-            "model": model,
-            "messages": [{"role": "user", "content": "Answer with exactly: FOUR"}],
-            "max_tokens": 16,
-            "temperature": 0,
-        }
-        req = urllib.request.Request(
-            base + "/chat/completions",
-            data=json.dumps(payload).encode("utf-8"),
+        req = _urlrequest.Request(
+            base + "/completions",
+            data=_json.dumps(payload).encode("utf-8"),
             headers={"Content-Type": "application/json"},
             method="POST",
         )
-        with urllib.request.urlopen(req, timeout=45) as resp:
-            raw = resp.read().decode("utf-8", errors="replace")
-        result = json.loads(raw)
-        choice = (result.get("choices") or [{}])[0]
+        with _urlrequest.urlopen(req, timeout=45) as resp:
+            body = _json.loads(resp.read().decode("utf-8", errors="replace"))
+        choice = (body.get("choices") or [{}])[0]
+        content = _semantic_gate_visible_answer(str(choice.get("text") or ""))
         finish = choice.get("finish_reason")
-        message = choice.get("message") or {}
-        content = str(message.get("content") or "").strip()
         if finish == "length":
             ok, reason = False, "semantic gate truncated finish_reason=length"
         elif not content:
@@ -770,11 +789,10 @@ def _local_super_semantic_gate(
             ok, reason = False, f"semantic gate unexpected content={content[:80]!r}"
         else:
             ok, reason = True, "semantic gate passed"
-    except Exception as exc:  # noqa: BLE001 — gate failure should fall back safely
+    except Exception as exc:  # pragma: no cover - exercised by integration
         ok, reason = False, f"semantic gate exception {exc.__class__.__name__}: {_sanitize_provider_error(exc)}"
     _SUPER_SEMANTIC_GATE_CACHE[base] = {"ok": ok, "reason": reason, "ts": now}
     return ok, reason
-
 
 def _fallback_to_sonnet_for_super_semantic_failure(router, role_cfg):
     """Return a Sonnet fallback RoleConfig preserving tools/turn shape.


### PR DESCRIPTION
## Summary
- move local Super semantic health checks from chat completions to raw completions
- strip exposed </think> reasoning before judging probe answers
- update Omni/sleep semantic gates to avoid false corruption from Nemotron chat-template reasoning

## Verification
- py_compile touched Python files
- bash -n semantic gate scripts
- targeted lightweight routing + omni-window tests
- live local /v1/completions semantic smoke returned FOUR