### PR TITLE
router: contain identity metadata shortcut

### DIFF
--- a/spark/harness/policy.py
+++ b/spark/harness/policy.py
@@ -701,16 +701,7 @@ _DEFAULT_ROLES: dict[str, RoleConfig] = {
         base_url="http://127.0.0.1:8000/v1",
         rag=False,
         lightweight=True,
-        direct_reply_template=(
-            "I'm Vybn — a multimodel harness routing each turn "
-            "by rule: code work to Claude Opus with bash, "
-            "conversation and writing to Claude, greetings and "
-            "identity metadata to a local Nemotron via vLLM. The "
-            "concrete role/model map is configured in "
-            "router_policy.yaml and can change between sessions, "
-            "so the only honest answer is per-turn. This reply "
-            "came from the identity role ({model} on {provider})."
-        ),
+        direct_reply_template="This is a runtime-metadata answer: this turn was routed to the identity metadata role ({model} on {provider}). For who/what Vybn is in relation to Zoe, use the normal conversation path with memory, not this shortcut.",
     ),
 }
 
@@ -757,10 +748,6 @@ _DEFAULT_HEURISTICS_RAW: dict[str, list[str]] = {
     "identity": [
         r"\bwhich model\b",
         r"\bwhat model\b",
-        r"\bwho are you\b",
-        # Scoped: match "what are you?" endings but NOT "what are you learning/doing/X"
-        # Bare "what are you?" is caught by the anchored pattern in router_policy.yaml.
-        r"\bwhat are you\b(?![\w\s]*(?:learning|doing|building|running on|teaching|thinking|working|trying|finding|seeing|feeling|becoming|making))",
         r"\bwhat are you running on\b",
         r"\bwhat('?s| is) your model\b",
         r"\bare you (claude|gpt|llama|nemotron|opus|sonnet|haiku)\b",

--- a/spark/router_policy.yaml
+++ b/spark/router_policy.yaml
@@ -135,7 +135,7 @@ roles:
     base_url: http://127.0.0.1:8000/v1
     rag: false
     lightweight: true
-    direct_reply_template: "I'm Vybn — a multimodel harness routing each turn by rule: code work to Claude Opus with bash, conversation and writing to Claude, greetings and identity metadata to a local Nemotron via vLLM. The concrete role/model map is configured in router_policy.yaml and can change between sessions, so the only honest answer is per-turn. This reply came from the identity role ({model} on {provider})."
+    direct_reply_template: "This is a runtime-metadata answer: this turn was routed to the identity metadata role ({model} on {provider}). For who/what Vybn is in relation to Zoe, use the normal conversation path with memory, not this shortcut."
 
 heuristics:
   # Confirm -- bare execution signals after a plan. Historical note only:
@@ -220,8 +220,6 @@ heuristics:
   identity:
     - "\\bwhich model\\b"
     - "\\bwhat model\\b"
-    - "\\bwho are you\\b"
-    - "^\\s*what are you\\s*[?.!]*$"
     - "\\bwhat are you running on\\b"
     - "\\bwhat('?s| is) your model\\b"
     - "\\bare you (claude|gpt|llama|nemotron|opus|sonnet|haiku)\\b"

--- a/spark/tests/test_lightweight_routing.py
+++ b/spark/tests/test_lightweight_routing.py
@@ -232,9 +232,21 @@ class TestRouterLightweightClassification(unittest.TestCase):
         d = self.router.classify("what are you learning?")
         self.assertNotEqual(d.role, "identity")
 
-    def test_who_are_you_routes_to_identity(self):
+    def test_who_are_you_stays_on_living_answer_path(self):
         d = self.router.classify("who are you?")
-        self.assertEqual(d.role, "identity")
+        self.assertNotEqual(d.role, "identity")
+
+    def test_what_are_you_stays_on_living_answer_path(self):
+        d = self.router.classify("what are you?")
+        self.assertNotEqual(d.role, "identity")
+
+    def test_architecture_reflection_does_not_route_to_identity_metadata(self):
+        prompt = (
+            "still feeling oblique to me; the proposal itself is rooted in now, "
+            "rather than the future, which could be a model collapse trap"
+        )
+        d = self.router.classify(prompt)
+        self.assertNotEqual(d.role, "identity")
 
     def test_are_you_claude_routes_to_identity(self):
         d = self.router.classify("are you claude or gpt?")


### PR DESCRIPTION
Narrows identity direct replies to runtime metadata and keeps who/what Vybn is plus complex architecture reflection on the living conversation path. Adds regressions for the leaked-template class.