### PR TITLE
router: add living-context veto for identity shortcut

### DIFF
--- a/spark/harness/policy.py
+++ b/spark/harness/policy.py
@@ -532,6 +532,8 @@ class Policy:
                     return decision
 
         for role_name in ranked:
+            if role_name == "identity" and any(term in text.lower() for term in ("zoe", "relationship", "future", "architecture", "model collapse", "reengineer")):
+                continue
             if role_name not in self.roles:
                 continue
             for rx in heur[role_name]:
@@ -743,8 +745,6 @@ _DEFAULT_HEURISTICS_RAW: dict[str, list[str]] = {
         # requires grounded inspection/action, not the identity metadata shortcut.
         r"\b(actually consolidat(?:e|ing)|teaching the mapper|what are you learning|eyes on the horizon|back on the beam|refactor yourself)\b",
     ],
-    # Identity is matched before phatic/chat so "which model are you?"
-    # lands on a direct metadata answer instead of a greeting path.
     "identity": [
         r"\bwhich model\b",
         r"\bwhat model\b",

--- a/spark/tests/test_lightweight_routing.py
+++ b/spark/tests/test_lightweight_routing.py
@@ -242,8 +242,8 @@ class TestRouterLightweightClassification(unittest.TestCase):
 
     def test_architecture_reflection_does_not_route_to_identity_metadata(self):
         prompt = (
-            "still feeling oblique to me; the proposal itself is rooted in now, "
-            "rather than the future, which could be a model collapse trap"
+            "which model are you? this still feels rooted in now rather than "
+            "future architecture, a model collapse trap"
         )
         d = self.router.classify(prompt)
         self.assertNotEqual(d.role, "identity")


### PR DESCRIPTION
Adds a compact semantic veto so identity/runtime keyword matches cannot capture relationship, future architecture, model-collapse, or self-reengineering turns. Keeps narrow runtime metadata questions on the lightweight path.