### PR TITLE
local-compute: fix circadian tick imports

### DIFF
--- a/spark/local_compute_tick.py
+++ b/spark/local_compute_tick.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import subprocess
 import sys
 
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 DEFAULT_PRESSURE = (
     "bounded circadian local compute should improve the Him vy language and "
@@ -27,10 +28,8 @@ def _tail(text: str, limit: int) -> str:
 
 
 def _packet_path() -> Path:
-    return Path(os.environ.get(
-        "VYBN_CONTINUOUS_TICK_OUT",
-        str(Path.home() / ".local" / "state" / "vybn" / "continuous_local_compute.jsonl"),
-    )).expanduser()
+    raw = os.environ.get("VYBN_CONTINUOUS_TICK_OUT", str(Path.home() / ".local" / "state" / "vybn" / "continuous_local_compute.jsonl"))
+    return Path(raw).expanduser()
 
 
 def _him_dir() -> Path:
@@ -92,7 +91,7 @@ def build_packet() -> dict:
         packet.update(stderr="Him vy runtime not found at " + str(vy), returncode=127)
         return packet
 
-    command = ("python3", "spark/vy.py", "discover", pressure, "--json")
+    command = ("python3", "-m", "spark.vy", "discover", pressure, "--json")
     packet.update(command=" ".join(command))
     try:
         proc = subprocess.run(command, cwd=him, text=True, capture_output=True, timeout=60, check=False)

--- a/spark/tests/test_continuous_local_compute.py
+++ b/spark/tests/test_continuous_local_compute.py
@@ -6,7 +6,7 @@ ROOT = Path(__file__).resolve().parents[1]
 
 def test_continuous_tick_invokes_him_vy_discover_with_timeout():
     text = (ROOT / "local_compute_tick.py").read_text(encoding="utf-8")
-    assert "spark/vy.py" in text
+    assert "spark.vy" in text
     assert "discover" in text
     assert "--json" in text
     assert "timeout=60" in text


### PR DESCRIPTION
Fixes the live circadian tick import path and invokes Him vy via python -m spark.vy. Verified with py_compile, targeted tests, and a live local tick.