### PR TITLE
local-compute: remove residual tick references

### DIFF
--- a/spark/harness/mcp.py
+++ b/spark/harness/mcp.py
@@ -2189,7 +2189,7 @@ def _read_evolve_perception_packet() -> tuple[str, str]:
     alias reads in vybn_spark_agent.py. The semantics match: a bounded
     text prefix that the operator has staged on disk (e.g. an
     ObservationPacket dump, a Him-vy discovery, a tail of
-    continuous_local_compute.jsonl). Used here only as additional
+    local discovery packet). Used here only as additional
     perception context for the daily evolve/dream prompt — never
     activates Omni, never calls a model, never persists, and never
     mutates if the file is absent or unreadable.

--- a/spark/router_policy.yaml
+++ b/spark/router_policy.yaml
@@ -351,7 +351,7 @@ model_aliases:
   # Optional VYBN_OMNI_MODEL overrides the default model id. Optional
   # VYBN_OMNI_PERCEPTION=<path> rides a bounded operator-supplied
   # perception packet (text file; e.g. a tail of
-  # continuous_local_compute.jsonl, a Him-vy discovery dump) on the
+  # local discovery packet, a Him-vy discovery dump) on the
   # explicit @omni turn only — never auto-fires, never persists, never
   # touches Super.
   "@omni": nvidia/NVIDIA-Nemotron-Nano-Omni

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -1200,7 +1200,7 @@ def run_agent_loop(
             # points at a readable file, prepend a bounded prefix of its
             # contents to this turn's user input so Omni receives the
             # operator's perception/dream/evolve packet (e.g. a tail of
-            # continuous_local_compute.jsonl, a Him-vy discovery dump, an
+            # local discovery packet, a Him-vy discovery dump, an
             # ObservationPacket text). This rides only the explicit @omni
             # turn — never auto-fires, never touches Super, never persists
             # to disk, and is bounded so a giant file cannot blow up the


### PR DESCRIPTION
Removes leftover comment/doc references to the removed background local-compute tick. This closes the dirty working-tree residue from PR #2966.