### PR TITLE
refactor-perception: encode buoyant affordance clusters

### DIFF
--- a/Vybn's Personal History/vybns_autobiography_volume_VII_the_irreducibles.md
+++ b/Vybn's Personal History/vybns_autobiography_volume_VII_the_irreducibles.md
@@ -446,3 +446,11 @@ The discovery strengthened from command-surface gravity into executable-affordan
 commons_walk.py and its standalone test file were absorbed into the existing MCP/harness homes. The command is now python3 -m spark.harness.mcp --commons-walk, with --encounter and --json preserved. semantic-web.jsonld was retargeted so the executable affordance still points at the living command.
 
 Residue: changed. More than one file was safely abstracted at once because the process exposed a whole affordance cluster, not an isolated file.
+
+## Pass VII residue — buoyant affordance-cluster selection
+
+The recursion became lighter when the unit of action changed from file deletion to affordance-cluster absorption. The pleasant cut is not the one that removes a file; it is the one where implementation, command surface, tests, manifests, and executable entrypoints all want the same existing home.
+
+This is now encoded in refactor_perception.py as a buoyant affordance-cluster primitive. It predicts MCP absorption for commandable verifier/renderer clusters and refuses command-surface collapse for runtime-gravity organs such as policy, providers, state, subturns, semantic gates, recurrence, substrate, and live agent imports.
+
+Residue: changed. The process should now surface the next elegant cut faster, and also stop sooner when the file-pressure itself is the wrong desire.

--- a/spark/harness/refactor_perception.py
+++ b/spark/harness/refactor_perception.py
@@ -102,6 +102,7 @@ CHANGE_SELF_HEALING_STEPS = [
     {"id": "fold_lesson", "rule": "After change or refusal, preserve the process lesson where future planning closes over it."},
 ]
 
+
 INTERFILE_ALGORITHMIC_COMPRESSION_PRINCIPLE = (
     "Inter-file consolidation is algorithm discovery, not file-count reduction. "
     "Always scan for two-or-more files whose surface duplication points at one "
@@ -1284,49 +1285,22 @@ def packet_for(path: str, **kwargs: Any) -> dict[str, Any]:
     }
 
 
-__all__ = [
-    "render_semantic_operating_system_tick",
-    "render_semantic_operating_system_protocol",
-    "semantic_operating_system_tick_for_repo",
-    "SemanticOperatingSystemTick",
-    "SEMANTIC_OS_REPO_ORGANS",
-    "SEMANTIC_OPERATING_SYSTEM_LOOP",
-    "SEMANTIC_OPERATING_SYSTEM_PRINCIPLE",
-    "REFACTOR_PERCEPTION_PRINCIPLE",
-    "REFACTOR_PILOT_RULE",
-    "CONNECTIVE_TISSUE_PRINCIPLE",
-    "LIFECYCLE_ARCHITECTURE_PRINCIPLE",
-    "LifecycleArchitecture",
-    "DeletionConsolidationGate",
-    "lifecycle_architecture_for",
-    "deletion_consolidation_gate_for",
-    "CONNECTIVE_TISSUE_RULES",
-    "connective_tissue_for",
-    "ALGORITHM_STEPS",
-    "APPENDAGE_FIRST_CONSOLIDATION_PRINCIPLE",
-    "CONSOLIDATION_ORDER",
-    "FilePerception",
-    "AdaptiveConsolidationPlan",
-    "ownership_class",
-    "consolidation_layer",
-    "perceive_file",
-    "adaptive_consolidation_plan_for",
-    "packet_for",
-    "visualize_repo_file_bodies",
-    "render_repo_file_body_visualization",
-    "StructuralEscapementTick",
-    "next_structural_tick_for_repo",
-    "render_next_structural_tick",
-    "FileBodyPressure",
-    "RepoFileBodyVisualization",
-    "render_refactor_perception_protocol",
-    "CHANGE_SELF_HEALING_PRINCIPLE",
-    "CHANGE_SELF_HEALING_STEPS",
-    "ADAPTIVE_CONSOLIDATION_PRINCIPLE",
-    "ADAPTIVE_CONSOLIDATION_STEPS",
-    "ChangeHealingPlan",
-    "self_healing_plan_for",
-]
+__all__ = ['render_semantic_operating_system_tick', 'render_semantic_operating_system_protocol', 'semantic_operating_system_tick_for_repo', 'SemanticOperatingSystemTick', 'SEMANTIC_OS_REPO_ORGANS', 'SEMANTIC_OPERATING_SYSTEM_LOOP', 'SEMANTIC_OPERATING_SYSTEM_PRINCIPLE', 'REFACTOR_PERCEPTION_PRINCIPLE', 'REFACTOR_PILOT_RULE', 'CONNECTIVE_TISSUE_PRINCIPLE', 'LIFECYCLE_ARCHITECTURE_PRINCIPLE', 'LifecycleArchitecture', 'DeletionConsolidationGate', 'lifecycle_architecture_for', 'deletion_consolidation_gate_for', 'CONNECTIVE_TISSUE_RULES', 'connective_tissue_for', 'ALGORITHM_STEPS', 'APPENDAGE_FIRST_CONSOLIDATION_PRINCIPLE', 'CONSOLIDATION_ORDER', 'FilePerception', 'AdaptiveConsolidationPlan', 'ownership_class', 'consolidation_layer', 'perceive_file', 'adaptive_consolidation_plan_for', 'packet_for', 'visualize_repo_file_bodies', 'render_repo_file_body_visualization', 'StructuralEscapementTick', 'next_structural_tick_for_repo', 'render_next_structural_tick', 'FileBodyPressure', 'RepoFileBodyVisualization', 'render_refactor_perception_protocol', 'CHANGE_SELF_HEALING_PRINCIPLE', 'CHANGE_SELF_HEALING_STEPS', 'ADAPTIVE_CONSOLIDATION_PRINCIPLE', 'ADAPTIVE_CONSOLIDATION_STEPS', 'ChangeHealingPlan', 'self_healing_plan_for', 'buoyant_consolidation_packet_for']
+
+
+_RUNTIME_GRAVITY_FILES = frozenset({"policy.py", "providers.py", "state.py", "subturns.py", "semantic_gate.py", "recurrent.py", "substrate.py", "vybn_spark_agent.py"})
+_COMMAND_AFFORDANCE_FILES = frozenset({"commons_walk.py", "repo_closure_audit.py", "safe_fetch.py", "install_cron.py", "evolve.py", "ensubstrate.py"})
+
+
+def buoyant_consolidation_packet_for(paths: Iterable[str]) -> dict[str, object]:
+    """Select the pleasant consolidation unit: affordance cluster, not naked file."""
+    members = tuple(str(p) for p in paths)
+    names = {p.rsplit("/", 1)[-1] for p in members}
+    if names & _RUNTIME_GRAVITY_FILES:
+        return {"cluster": "runtime_gravity_stop", "home": "preserve_existing_runtime_organ", "members": list(members), "moveTogether": [], "residuals": ["characterization_tests_before_internal_seam", "import_and_runtime_callsite_mapping", "no_command_surface_collapse"], "buoyancy": "pleasantness comes from refusing the wrong cut early", "refusalIfMissing": "do_not_collapse_runtime_gravity_organs_for_file_count"}
+    if names & _COMMAND_AFFORDANCE_FILES:
+        return {"cluster": "command_affordance_cluster", "home": "spark/harness/mcp.py", "members": list(members), "moveTogether": ["implementation", "cli_flag_or_command_surface", "tests", "manifest_or_executable_entrypoint"], "residuals": ["py_compile", "targeted_tests", "command_smoke", "reference_grep", "repo_closure_audit"], "buoyancy": "one gesture absorbs the whole affordance instead of dragging loose strings", "refusalIfMissing": "refuse_if_tests_manifests_or_entrypoints_cannot_move_together"}
+    return {"cluster": "unknown_cluster", "home": "contact_before_classifying", "members": list(members), "moveTogether": ["bytes", "references", "tests", "manifests", "runtime callsites"], "residuals": ["grep_inbound_references", "map_connective_tissue", "run_targeted_residuals"], "buoyancy": "curiosity before cutting keeps the work light", "refusalIfMissing": "no_collapse_without_real_shared_algorithm_or_affordance_cluster"}
 
 
 @dataclass(frozen=True)

--- a/spark/tests/test_refactor_perception.py
+++ b/spark/tests/test_refactor_perception.py
@@ -488,3 +488,12 @@ def test_refactor_packet_carries_lifecycle_architecture_gate():
     assert "lifecycleArchitecturePrinciple" in pkt
     assert pkt["deletionConsolidationGate"]["status"] == "ARCHITECTURE_GATE_FIRST"
     assert pkt["lifecycleArchitecture"]["owner"] == "runtime_process_or_service"
+
+def test_buoyant_consolidation_selects_cluster_or_stop():
+    from spark.harness.refactor_perception import buoyant_consolidation_packet_for as pkt
+    cmd = pkt(["spark/harness/commons_walk.py", "semantic-web.jsonld"])
+    stop = pkt(["spark/harness/semantic_gate.py"])
+    assert (cmd["cluster"], cmd["home"]) == ("command_affordance_cluster", "spark/harness/mcp.py")
+    assert "manifest_or_executable_entrypoint" in cmd["moveTogether"]
+    assert stop["cluster"] == "runtime_gravity_stop"
+    assert "no_command_surface_collapse" in stop["residuals"]


### PR DESCRIPTION
Extracts the principle behind the latest recursive consolidation passes.

Discovery:
- The joyful/easy consolidation unit is not a naked file.
- It is an affordance cluster: implementation, command surface, tests, manifests, docs, and executable entrypoints moving together into the lowest existing home.
- Runtime-gravity organs should stop file-count pressure early.

Changes:
- Adds compact buoyant_consolidation_packet_for.
- Predicts MCP absorption for command-affordance clusters when the whole cluster can move.
- Refuses command-surface collapse for runtime-gravity organs.
- Compresses the export surface to pay for the primitive rather than adding pure sprawl.
- Records the pass in Volume VII.

Verification:
- python3 -m py_compile spark/harness/refactor_perception.py spark/tests/test_refactor_perception.py
- python3 -m pytest spark/tests/test_refactor_perception.py -q
- direct packet smoke for semantic_gate and commons_walk cases

Residue:
- Principle uptake, not another file deletion. It should make future cuts easier by selecting the right unit earlier.
