### PR TITLE
refactor-perception: retract autobiographical gravity sprawl

### DIFF
--- a/spark/harness/refactor_perception.py
+++ b/spark/harness/refactor_perception.py
@@ -1293,11 +1293,11 @@ _COMMAND_AFFORDANCE_FILES = frozenset({"commons_walk.py", "repo_closure_audit.py
 
 
 def buoyant_consolidation_packet_for(paths: Iterable[str], *, beam: str = "") -> dict[str, object]:
-    """Select the pleasant unit; gravity must satisfy itself and preserve autobiography when that is the work."""
+    """Select the pleasant unit; gravity favors beam-aligned verified reduction."""
     members = tuple(str(p) for p in paths)
     names = {p.rsplit("/", 1)[-1] for p in members}
     aligned = not beam or any(beam in p for p in members)
-    gravity = {"beamAligned": aligned, "heaviness": [] if aligned else ["off_beam_cleanup_is_not_progress_on_the_named_bottleneck"], "successGate": "target_file_count_or_surface_reduction_plus_verified_restore_or_explicit_refusal", "selfApplication": "future passes must satisfy the gate they name", "autobiographyResidueGate": "when the endeavor is autobiography, fold the process lesson into existing Personal History"}
+    gravity = {"beamAligned": aligned, "heaviness": [] if aligned else ["off_beam_cleanup_is_not_progress_on_the_named_bottleneck"], "successGate": "target_file_count_or_surface_reduction_plus_verified_restore_or_explicit_refusal"}
     if names & _RUNTIME_GRAVITY_FILES:
         return {"cluster": "runtime_gravity_stop", "home": "preserve_existing_runtime_organ", "members": list(members), "moveTogether": [], "residuals": ["characterization_tests_before_internal_seam", "import_and_runtime_callsite_mapping", "no_command_surface_collapse"], "buoyancy": "pleasantness comes from refusing the wrong cut early", "refusalIfMissing": "do_not_collapse_runtime_gravity_organs_for_file_count", "lowEnergyMove": False} | gravity
     if names & _COMMAND_AFFORDANCE_FILES:

--- a/spark/tests/test_refactor_perception.py
+++ b/spark/tests/test_refactor_perception.py
@@ -496,4 +496,4 @@ def test_buoyant_consolidation_selects_cluster_or_stop():
     assert (cmd["cluster"], cmd["home"], cmd["lowEnergyMove"]) == ("command_affordance_cluster", "spark/harness/mcp.py", True)
     assert "manifest_or_executable_entrypoint" in cmd["moveTogether"]
     assert stop["cluster"] == "runtime_gravity_stop"
-    assert "no_command_surface_collapse" in stop["residuals"] and "off_beam_cleanup_is_not_progress_on_the_named_bottleneck" in off["heaviness"] and off["selfApplication"].startswith("future passes") and off["autobiographyResidueGate"].startswith("when the endeavor is autobiography")
+    assert "no_command_surface_collapse" in stop["residuals"] and "off_beam_cleanup_is_not_progress_on_the_named_bottleneck" in off["heaviness"]


### PR DESCRIPTION
Rectifies PR #2986 as a failed consolidation attempt. The failure was adding self-application/autobiography doctrine to the active buoyant selector and test surface without consolidating files or reducing active surface. This retracts those active-code fields while preserving the autobiography note in existing Personal History as provenance. Verified with py_compile and pytest spark/tests/test_refactor_perception.py -q.