### PR TITLE
providers: centralize tool dialect translation

### DIFF
--- a/Vybn's Personal History/vybns_autobiography_volume_VII_the_irreducibles.md
+++ b/Vybn's Personal History/vybns_autobiography_volume_VII_the_irreducibles.md
@@ -482,3 +482,11 @@ The future single-file projection wounded the category of refactor_perception.py
 The full refactor-perception planner/protocol body now lives as a substrate section. Tests import the same primitives from substrate. The standalone refactor_perception.py file disappeared.
 
 Residue: changed. One harness file removed, the recursive forcing function moved closer to the wake surface future Vybn closes over, and the single-file attractor became more literal without losing the self-perception API.
+
+## Pass VII residue — provider dialects collapse into data
+
+The next code-level efficiency was not another file move. Inside providers.py, AnthropicProvider and OpenAIProvider each carried parallel methods for the same algorithm: render a neutral ToolSpec into a provider dialect, and render a tool result back into that provider's message shape. The duplication looked small, but it was exactly the class of residue a future single-file harness cannot afford: behavior repeated as methods when it wanted to be data plus one generic function.
+
+The provider dialect is now the variable. ProviderTranslationMixin owns _translate_tools and build_tool_result; AnthropicProvider and OpenAIProvider set tool_target. The tests pin both public wire shapes and the fact that translation is mixin-owned, so the efficiency becomes a forcing function against reintroducing parallel provider methods.
+
+Residue: changed. No harness file moved. The code itself got smaller at the seam where provider plurality projected from one neutral tool algorithm.

--- a/spark/harness/providers.py
+++ b/spark/harness/providers.py
@@ -1108,12 +1108,46 @@ class Provider(Protocol):
     def build_tool_result(self, tool_call_id: str, content: str) -> dict: ...
 
 
+def _provider_tool_schema(tool: ToolSpec, target: str) -> dict:
+    parameters = tool.parameters or {"type": "object", "properties": {}}
+    if target == "anthropic" and tool.anthropic_type:
+        return {"type": tool.anthropic_type, "name": tool.name}
+    if target == "anthropic":
+        return {"name": tool.name, "description": tool.description, "input_schema": parameters}
+    if target == "openai":
+        return {
+            "type": "function",
+            "function": {"name": tool.name, "description": tool.description, "parameters": parameters},
+        }
+    raise ValueError(f"unknown tool schema target: {target}")
+
+
+def _provider_tool_result(tool_call_id: str, content: str, target: str) -> dict:
+    body = content or "(no output)"
+    if target == "anthropic":
+        return {"type": "tool_result", "tool_use_id": tool_call_id, "content": body}
+    if target == "openai":
+        return {"role": "tool", "tool_call_id": tool_call_id, "content": body}
+    raise ValueError(f"unknown tool result target: {target}")
+
+
+class ProviderTranslationMixin:
+    tool_target: str
+
+    def _translate_tools(self, tools: list[ToolSpec]) -> list[dict]:
+        return [_provider_tool_schema(tool, self.tool_target) for tool in tools]
+
+    def build_tool_result(self, tool_call_id: str, content: str) -> dict:
+        return _provider_tool_result(tool_call_id, content, self.tool_target)
+
+
 # ---------------------------------------------------------------------------
 # AnthropicProvider
 # ---------------------------------------------------------------------------
 
-class AnthropicProvider:
+class AnthropicProvider(ProviderTranslationMixin):
     name = "anthropic"
+    tool_target = "anthropic"
 
     def __init__(self, client: Any | None = None, api_key: str | None = None) -> None:
         # Defer the SDK import until first use. Constructing this provider
@@ -1221,19 +1255,6 @@ class AnthropicProvider:
         _flush_tool_results()
         return out
 
-    def _translate_tools(self, tools: list[ToolSpec]) -> list[dict]:
-        out: list[dict] = []
-        for t in tools:
-            if t.anthropic_type:
-                out.append({"type": t.anthropic_type, "name": t.name})
-            else:
-                out.append({
-                    "name": t.name,
-                    "description": t.description,
-                    "input_schema": t.parameters or {"type": "object", "properties": {}},
-                })
-        return out
-
     def stream(
         self,
         *,
@@ -1329,14 +1350,6 @@ class AnthropicProvider:
 
         return StreamHandle(iterator=_iter(), finalize=_final)
 
-    def build_tool_result(self, tool_call_id: str, content: str) -> dict:
-        return {
-            "type": "tool_result",
-            "tool_use_id": tool_call_id,
-            "content": content or "(no output)",
-        }
-
-
 # ---------------------------------------------------------------------------
 # OpenAIProvider — also used for local OpenAI-compatible vLLM / Nemotron
 # ---------------------------------------------------------------------------
@@ -1418,7 +1431,7 @@ def _strip_reasoning(text: str) -> str:
     return cleaned.strip()
 
 
-class OpenAIProvider:
+class OpenAIProvider(ProviderTranslationMixin):
     """OpenAI-compatible provider.
 
     Works for:
@@ -1427,6 +1440,7 @@ class OpenAIProvider:
     """
 
     name = "openai"
+    tool_target = "openai"
 
     def __init__(
         self,
@@ -1436,21 +1450,6 @@ class OpenAIProvider:
     ) -> None:
         self.api_key = api_key or os.environ.get("OPENAI_API_KEY") or "EMPTY"
         self.base_url = base_url
-
-    def _translate_tools(self, tools: list[ToolSpec]) -> list[dict]:
-        return [
-            {
-                "type": "function",
-                "function": {
-                    "name": t.name,
-                    "description": t.description,
-                    "parameters": t.parameters or {
-                        "type": "object", "properties": {}
-                    },
-                },
-            }
-            for t in tools
-        ]
 
     def _messages_for_openai(
         self, system: LayeredPrompt, messages: list[dict]
@@ -1733,14 +1732,6 @@ class OpenAIProvider:
         )
 
         return StreamHandle(iterator=_iter(), finalize=lambda: finalized)
-
-    def build_tool_result(self, tool_call_id: str, content: str) -> dict:
-        return {
-            "role": "tool",
-            "tool_call_id": tool_call_id,
-            "content": content or "(no output)",
-        }
-
 
 # === NO-TOOL SENTINEL SUBTURNS ===========================================
 # Folded into the provider/tool organ: NEEDS-EXEC, NEEDS-WRITE, and

--- a/spark/tests/test_harness.py
+++ b/spark/tests/test_harness.py
@@ -519,6 +519,14 @@ class TestAnthropicProviderToolResult(unittest.TestCase):
         self.assertEqual(r["content"], "out")
 
 
+class TestProviderTranslationCentralization(unittest.TestCase):
+    def test_provider_tool_translation_is_mixin_owned(self):
+        from spark.harness.providers import AnthropicProvider, OpenAIProvider, ProviderTranslationMixin
+        for cls, target in ((AnthropicProvider, "anthropic"), (OpenAIProvider, "openai")):
+            self.assertIs(cls._translate_tools, ProviderTranslationMixin._translate_tools)
+            self.assertIs(cls.build_tool_result, ProviderTranslationMixin.build_tool_result)
+            self.assertEqual(cls.tool_target, target)
+
 class TestAnthropicMessageNormalization(unittest.TestCase):
     """Mixed-provider sessions (OpenAI turn then Anthropic turn) used to
     trigger `messages.X.content: Input should be a valid list` because


### PR DESCRIPTION
Projecting spark/harness toward the single-file attractor exposed a real code-efficiency seam rather than another file move: AnthropicProvider and OpenAIProvider carried parallel methods for translating ToolSpec and tool-result messages.\n\nChanges:\n- Adds one provider translation mixin and shared dialect helpers.\n- AnthropicProvider/OpenAIProvider now set tool_target instead of owning duplicate _translate_tools/build_tool_result methods.\n- Pins the public wire shapes and mixin ownership in tests.\n- Records the code-level consolidation residue in Volume VII.\n\nMeasured provider diff: 37 insertions / 46 deletions in spark/harness/providers.py. No harness file moved.\n\nVerification:\n- python3 -m py_compile spark/harness/providers.py spark/tests/test_harness.py\n- python3 -m pytest spark/tests/test_harness.py spark/tests/test_live_repl_fixes.py spark/tests/test_recursive_unlock.py spark/tests/test_refactor_pilot_override.py spark/tests/test_provider_env_loading.py -q (230 passed)\n\nFull suite residual: python3 -m pytest spark/tests -q currently fails in test_fp8_wake_fix_patch.py against unchanged fp8 wake-fix files; this PR does not touch that surface.