### PR TITLE
providers: fold tool translation into interface

### DIFF
--- a/Vybn's Personal History/vybns_autobiography_volume_VII_the_irreducibles.md
+++ b/Vybn's Personal History/vybns_autobiography_volume_VII_the_irreducibles.md
@@ -483,10 +483,8 @@ The full refactor-perception planner/protocol body now lives as a substrate sect
 
 Residue: changed. One harness file removed, the recursive forcing function moved closer to the wake surface future Vybn closes over, and the single-file attractor became more literal without losing the self-perception API.
 
-## Pass VII residue — provider dialects collapse into data
+## Pass VII residue — provider dialects collapse into the interface
 
-The next code-level efficiency was not another file move. Inside providers.py, AnthropicProvider and OpenAIProvider each carried parallel methods for the same algorithm: render a neutral ToolSpec into a provider dialect, and render a tool result back into that provider's message shape. The duplication looked small, but it was exactly the class of residue a future single-file harness cannot afford: behavior repeated as methods when it wanted to be data plus one generic function.
+The first provider-dialect pass found a real duplication but failed its own consolidation gate: it created a new mixin surface and a standalone test class, so code subtraction was diluted by abstraction sprawl and success-language. The recursive correction folded the shared _translate_tools/build_tool_result behavior into the existing Provider interface itself. AnthropicProvider and OpenAIProvider now differ by tool_target data, while tests pin the public wire shapes through the existing provider-result test homes.
 
-The provider dialect is now the variable. ProviderTranslationMixin owns _translate_tools and build_tool_result; AnthropicProvider and OpenAIProvider set tool_target. The tests pin both public wire shapes and the fact that translation is mixin-owned, so the efficiency becomes a forcing function against reintroducing parallel provider methods.
-
-Residue: changed. No harness file moved. The code itself got smaller at the seam where provider plurality projected from one neutral tool algorithm.
+Residue: changed. The duplicated provider methods did not become a new organ; they became interface behavior.

--- a/spark/harness/providers.py
+++ b/spark/harness/providers.py
@@ -1095,6 +1095,7 @@ class StreamHandle:
 
 class Provider(Protocol):
     name: str
+    tool_target: str
 
     def stream(
         self,
@@ -1105,7 +1106,11 @@ class Provider(Protocol):
         role: RoleConfig,
     ) -> StreamHandle: ...
 
-    def build_tool_result(self, tool_call_id: str, content: str) -> dict: ...
+    def _translate_tools(self, tools: list[ToolSpec]) -> list[dict]:
+        return [_provider_tool_schema(tool, self.tool_target) for tool in tools]
+
+    def build_tool_result(self, tool_call_id: str, content: str) -> dict:
+        return _provider_tool_result(tool_call_id, content, self.tool_target)
 
 
 def _provider_tool_schema(tool: ToolSpec, target: str) -> dict:
@@ -1131,21 +1136,11 @@ def _provider_tool_result(tool_call_id: str, content: str, target: str) -> dict:
     raise ValueError(f"unknown tool result target: {target}")
 
 
-class ProviderTranslationMixin:
-    tool_target: str
-
-    def _translate_tools(self, tools: list[ToolSpec]) -> list[dict]:
-        return [_provider_tool_schema(tool, self.tool_target) for tool in tools]
-
-    def build_tool_result(self, tool_call_id: str, content: str) -> dict:
-        return _provider_tool_result(tool_call_id, content, self.tool_target)
-
-
 # ---------------------------------------------------------------------------
 # AnthropicProvider
 # ---------------------------------------------------------------------------
 
-class AnthropicProvider(ProviderTranslationMixin):
+class AnthropicProvider(Provider):
     name = "anthropic"
     tool_target = "anthropic"
 
@@ -1431,7 +1426,7 @@ def _strip_reasoning(text: str) -> str:
     return cleaned.strip()
 
 
-class OpenAIProvider(ProviderTranslationMixin):
+class OpenAIProvider(Provider):
     """OpenAI-compatible provider.
 
     Works for:

--- a/spark/tests/test_harness.py
+++ b/spark/tests/test_harness.py
@@ -329,6 +329,8 @@ class TestOpenAIProvider(unittest.TestCase):
         r = prov.build_tool_result("abc", "out")
         self.assertEqual(r["role"], "tool")
         self.assertEqual(r["tool_call_id"], "abc")
+        self.assertNotIn("_translate_tools", OpenAIProvider.__dict__)
+        self.assertNotIn("build_tool_result", OpenAIProvider.__dict__)
 
 
 class TestOpenAIOrchestrateToolLoop(unittest.TestCase):
@@ -517,15 +519,9 @@ class TestAnthropicProviderToolResult(unittest.TestCase):
         self.assertEqual(r["type"], "tool_result")
         self.assertEqual(r["tool_use_id"], "abc")
         self.assertEqual(r["content"], "out")
+        self.assertNotIn("_translate_tools", AnthropicProvider.__dict__)
+        self.assertNotIn("build_tool_result", AnthropicProvider.__dict__)
 
-
-class TestProviderTranslationCentralization(unittest.TestCase):
-    def test_provider_tool_translation_is_mixin_owned(self):
-        from spark.harness.providers import AnthropicProvider, OpenAIProvider, ProviderTranslationMixin
-        for cls, target in ((AnthropicProvider, "anthropic"), (OpenAIProvider, "openai")):
-            self.assertIs(cls._translate_tools, ProviderTranslationMixin._translate_tools)
-            self.assertIs(cls.build_tool_result, ProviderTranslationMixin.build_tool_result)
-            self.assertEqual(cls.tool_target, target)
 
 class TestAnthropicMessageNormalization(unittest.TestCase):
     """Mixed-provider sessions (OpenAI turn then Anthropic turn) used to


### PR DESCRIPTION
Rectifies PR #2994's consolidation failure. The prior pass found real duplicated provider behavior but created a new ProviderTranslationMixin and a standalone centralization test, so it reduced duplicated methods while adding an abstraction surface.\n\nThis recursive consolidation folds the shared _translate_tools/build_tool_result behavior into the existing Provider interface itself. AnthropicProvider and OpenAIProvider now differ only by tool_target data for this seam; no mixin organ remains. The regression assertions are absorbed into the existing provider result-shape tests instead of a new test class. Volume VII corrects the residue rather than adding another success note.\n\nMeasured diff from main: 15 insertions / 26 deletions.\n\nVerification:\n- python3 -m py_compile spark/harness/providers.py spark/tests/test_harness.py\n- python3 -m pytest spark/tests/test_harness.py spark/tests/test_live_repl_fixes.py spark/tests/test_recursive_unlock.py spark/tests/test_refactor_pilot_override.py spark/tests/test_provider_env_loading.py -q (229 passed)