### PR TITLE
providers: absorb tool dialect impasse

### DIFF
--- a/spark/harness/providers.py
+++ b/spark/harness/providers.py
@@ -47,7 +47,7 @@ import urllib.request
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Iterable, Iterator, Protocol
+from typing import Any, Callable, Iterable, Iterator
 
 from .policy import (
     ABSORB_EXCLUDE_SUBSTR,
@@ -1093,7 +1093,7 @@ class StreamHandle:
         return self.finalize()
 
 
-class Provider(Protocol):
+class Provider:
     name: str
     tool_target: str
 
@@ -1104,36 +1104,32 @@ class Provider(Protocol):
         messages: list[dict],
         tools: list[ToolSpec],
         role: RoleConfig,
-    ) -> StreamHandle: ...
+    ) -> StreamHandle:
+        raise NotImplementedError
 
     def _translate_tools(self, tools: list[ToolSpec]) -> list[dict]:
-        return [_provider_tool_schema(tool, self.tool_target) for tool in tools]
+        return [self._tool_schema(tool) for tool in tools]
+
+    def _tool_schema(self, tool: ToolSpec) -> dict:
+        parameters = tool.parameters or {"type": "object", "properties": {}}
+        if self.tool_target == "anthropic" and tool.anthropic_type:
+            return {"type": tool.anthropic_type, "name": tool.name}
+        if self.tool_target == "anthropic":
+            return {"name": tool.name, "description": tool.description, "input_schema": parameters}
+        if self.tool_target == "openai":
+            return {
+                "type": "function",
+                "function": {"name": tool.name, "description": tool.description, "parameters": parameters},
+            }
+        raise ValueError(f"unknown tool schema target: {self.tool_target}")
 
     def build_tool_result(self, tool_call_id: str, content: str) -> dict:
-        return _provider_tool_result(tool_call_id, content, self.tool_target)
-
-
-def _provider_tool_schema(tool: ToolSpec, target: str) -> dict:
-    parameters = tool.parameters or {"type": "object", "properties": {}}
-    if target == "anthropic" and tool.anthropic_type:
-        return {"type": tool.anthropic_type, "name": tool.name}
-    if target == "anthropic":
-        return {"name": tool.name, "description": tool.description, "input_schema": parameters}
-    if target == "openai":
-        return {
-            "type": "function",
-            "function": {"name": tool.name, "description": tool.description, "parameters": parameters},
-        }
-    raise ValueError(f"unknown tool schema target: {target}")
-
-
-def _provider_tool_result(tool_call_id: str, content: str, target: str) -> dict:
-    body = content or "(no output)"
-    if target == "anthropic":
-        return {"type": "tool_result", "tool_use_id": tool_call_id, "content": body}
-    if target == "openai":
-        return {"role": "tool", "tool_call_id": tool_call_id, "content": body}
-    raise ValueError(f"unknown tool result target: {target}")
+        body = content or "(no output)"
+        if self.tool_target == "anthropic":
+            return {"type": "tool_result", "tool_use_id": tool_call_id, "content": body}
+        if self.tool_target == "openai":
+            return {"role": "tool", "tool_call_id": tool_call_id, "content": body}
+        raise ValueError(f"unknown tool result target: {self.tool_target}")
 
 
 # ---------------------------------------------------------------------------

--- a/spark/tests/test_harness.py
+++ b/spark/tests/test_harness.py
@@ -292,6 +292,7 @@ class TestOpenAIProvider(unittest.TestCase):
         tools = prov._translate_tools([BASH_TOOL_SPEC])
         self.assertEqual(tools[0]["type"], "function")
         self.assertEqual(tools[0]["function"]["name"], "bash")
+        self.assertNotIn("_translate_tools", OpenAIProvider.__dict__)
 
     def test_message_translation_flattens_tool_result(self):
         prov = OpenAIProvider(api_key="x")
@@ -329,7 +330,6 @@ class TestOpenAIProvider(unittest.TestCase):
         r = prov.build_tool_result("abc", "out")
         self.assertEqual(r["role"], "tool")
         self.assertEqual(r["tool_call_id"], "abc")
-        self.assertNotIn("_translate_tools", OpenAIProvider.__dict__)
         self.assertNotIn("build_tool_result", OpenAIProvider.__dict__)
 
 


### PR DESCRIPTION
Isolates and resolves the consolidation impasse inside spark/harness. The failed shape was treating shared provider tool behavior as something that needed a parallel abstraction surface: first a mixin, then a Protocol with real implementation plus standalone helper functions. That left the algorithm split across Provider, tool_target data, and external helpers.\n\nThis pass absorbs the behavior into the existing Provider base inside spark/harness/providers.py. Provider is now the concrete harness interface for common provider behavior: _translate_tools delegates to _tool_schema, build_tool_result renders native tool results, and AnthropicProvider/OpenAIProvider inherit that shared behavior with only tool_target data at this seam. The external provider-tool helper functions disappear.\n\nThe regression assertion is folded into existing provider-shape tests; no new test class or non-harness surface is added.\n\nMeasured diff: spark/harness/providers.py 24 insertions / 28 deletions; spark/tests/test_harness.py neutral 1/1.\n\nVerification:\n- python3 -m py_compile spark/harness/providers.py spark/tests/test_harness.py\n- python3 -m pytest spark/tests/test_harness.py spark/tests/test_live_repl_fixes.py spark/tests/test_recursive_unlock.py spark/tests/test_refactor_pilot_override.py spark/tests/test_provider_env_loading.py -q (229 passed)