### PR TITLE
harness: unshadow github pr operations

### DIFF
--- a/spark/harness/substrate.py
+++ b/spark/harness/substrate.py
@@ -6644,15 +6644,12 @@ def github_cli_env(base: dict[str, str] | None = None) -> dict[str, str]:
 
 
 def normalize_github_cli_command(command: str) -> str:
-    """Make shell-authored PR creation use the stored gh credential.
-
-    This is intentionally narrow: only `gh pr create` is rewritten. Other
-    gh calls keep their original environment, and explicit `env -u
-    GITHUB_TOKEN gh pr create` commands are left alone.
-    """
-    if "gh pr create" not in command or "env -u GITHUB_TOKEN gh pr create" in command:
+    """Make shell-authored PR operations use the stored gh credential."""
+    if "gh pr " not in command:
         return command
-    return re.sub(r"(?<![\w./-])gh\s+pr\s+create\b", "env -u GITHUB_TOKEN gh pr create", command)
+    pr_ops = "create|merge|close|view"
+    pattern = rf"(?<!GITHUB_TOKEN )(?<![\w./-])gh\s+pr\s+({pr_ops})\b"
+    return re.sub(pattern, r"env -u GITHUB_TOKEN gh pr \1", command)
 
 
 def execute_readonly(command: str, timeout: int = DEFAULT_TIMEOUT) -> str:

--- a/spark/tests/test_harness.py
+++ b/spark/tests/test_harness.py
@@ -1664,12 +1664,13 @@ def test_github_cli_env_strips_shadowing_github_token(monkeypatch):
     assert env["GH_TOKEN"] == "kept-token"
 
 
-def test_normalize_github_cli_command_unshadows_pr_create():
+def test_normalize_github_cli_command_unshadows_pull_request_commands():
     from spark.harness.substrate import normalize_github_cli_command
 
-    cmd = "git push -u origin branch && gh pr create --base main --head branch"
+    cmd = "gh pr create --base main && gh pr merge branch && gh pr close 35 && gh pr view branch"
     fixed = normalize_github_cli_command(cmd)
-    assert "env -u GITHUB_TOKEN gh pr create --base main --head branch" in fixed
+    for op in ("create", "merge", "close", "view"):
+        assert f"env -u GITHUB_TOKEN gh pr {op}" in fixed
     assert normalize_github_cli_command(fixed) == fixed
 
 


### PR DESCRIPTION
Absorbs the GitHub locality scar into the existing command normalization surface: gh pr create/merge/close/view now use the stored gh credential instead of the weaker env token. Targeted GitHub CLI tests pass.