### PR TITLE
harness: fit evolve within local context

### DIFF
--- a/spark/harness/substrate.py
+++ b/spark/harness/substrate.py
@@ -11140,7 +11140,7 @@ def _call_local_model(prompt: str) -> str:
                 model = str(json.loads(resp.read().decode("utf-8", errors="replace"))["data"][0]["id"])
         except Exception as exc:
             raise RuntimeError(f"could not discover evolve model at {models_url}: {exc}") from exc
-    payload = {"model": model, "messages": [{"role": "system", "content": VYBN_OS_KERNEL}, {"role": "user", "content": prompt}], "temperature": 0.7, "max_tokens": 4096}
+    payload = {"model": model, "messages": [{"role": "system", "content": VYBN_OS_KERNEL}, {"role": "user", "content": prompt}], "temperature": 0.7, "max_tokens": 1024}
     body = json.dumps(payload).encode("utf-8")
     req = urlrequest.Request(
         _EVOLVE_URL,


### PR DESCRIPTION
Live self-execution showed the evolve runner still requested 4096 output tokens against Super's 8192-token context, producing HTTP 400 before generation. This lowers the evolve output budget to 1024 so the local self-executing loop can fit its prompt and actually run. Verification: py_compile passed. Do not treat this as full evolve closure; it removes the context-budget blocker.