### PR TITLE
repo mapper: fit local model context

### DIFF
--- a/Vybn_Mind/repo_mapper.py
+++ b/Vybn_Mind/repo_mapper.py
@@ -68,13 +68,11 @@ DEEP_MEMORY_PORT  = 8100
 WALK_PORT         = 8101
 READ_SIZE_LIMIT   = 120_000
 
-# Each pass must fit comfortably under 32k tokens total.
-# ~4 chars/token, 32768 tokens → ~131k chars total per call.
-# System prompt ~200 chars, user prefix ~100 chars → ~130k chars for content.
-# We reserve 2500 tokens for output → leaves ~120k chars for input per pass.
-PASS_CONTENT_CAP  = 55_000   # chars of domain content per pass
-SUBSTRATE_CAP     =  8_000   # chars of substrate included in pass 1
-MAX_TOKENS_OUT    =  2_500   # output tokens per pass
+# Fit the local Super server normal profile: 8k context. Keep pass 1
+# comfortably below the cap after substrate + prompt framing.
+PASS_CONTENT_CAP  = 35_000   # chars of domain content per pass
+SUBSTRATE_CAP     =  6_000   # chars of substrate included in pass 1
+MAX_TOKENS_OUT    =  1_024   # output tokens per pass
 
 MODEL_TIMEOUT     = 360
 


### PR DESCRIPTION
Live self-evolution launch showed repo_mapper.py failing before evolve because Pass 1 requested 2500 output tokens while the prompt used 5693 tokens, exceeding Super's current 8192-token context. This updates the repo-mapper budget comments and caps to fit the local Super normal profile: smaller domain/substrate slices and 1024 output tokens. Verification: py_compile passed. This repairs the preflight blocker so the layered system-prompt builder evolve cycle can proceed.