### PR TITLE
harness: fix evolve http error decoding

### DIFF
--- a/spark/harness/substrate.py
+++ b/spark/harness/substrate.py
@@ -11076,7 +11076,7 @@ def _call_local_model(prompt: str) -> str:
         with urlrequest.urlopen(req, timeout=_EVOLVE_TIMEOUT_SECONDS) as resp:
             raw = resp.read().decode("utf-8", errors="replace")
     except HTTPError as exc:
-        raise RuntimeError(f"inference HTTP {exc.code}: {exc.reason}: {exc.read().decode(utf-8, errors=replace)[:800]}") from exc
+        raise RuntimeError(f"inference HTTP {exc.code}: {exc.reason}: {exc.read().decode("utf-8", errors="replace")[:800]}") from exc
     except URLError as exc:
         raise RuntimeError(f"inference unreachable at {_EVOLVE_URL}: {exc.reason}") from exc
     obj = json.loads(raw)


### PR DESCRIPTION
Fixes the compressed HTTPError-body repair: py_compile allowed decode(utf-8, errors=replace), but runtime treated utf/replace as names. Source assertion and py_compile pass.