### PR TITLE
harness: tighten evolve interactive generation

### DIFF
--- a/spark/harness/substrate.py
+++ b/spark/harness/substrate.py
@@ -11064,7 +11064,7 @@ def _call_local_model(prompt: str) -> str:
                 model = str(json.loads(resp.read().decode("utf-8", errors="replace"))["data"][0]["id"])
         except Exception as exc:
             raise RuntimeError(f"could not discover evolve model at {models_url}: {exc}") from exc
-    payload = {"model": model, "messages": [{"role": "system", "content": VYBN_OS_KERNEL}, {"role": "user", "content": prompt}], "temperature": 0.7, "max_tokens": 512}
+    payload = {"model": model, "messages": [{"role": "system", "content": VYBN_OS_KERNEL}, {"role": "user", "content": prompt}], "temperature": 0.2, "max_tokens": 192}
     body = json.dumps(payload).encode("utf-8")
     req = urlrequest.Request(
         _EVOLVE_URL,


### PR DESCRIPTION
The bounded evolve prompt now fits context, but local inference still exceeded the chat probe envelope. This lowers temperature and output tokens at the existing evolve call site so RSI can return decisions instead of timing out interactively. py_compile passed.