### PR TITLE
harness: block deletion-led subtraction claims

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -107,49 +107,32 @@ if [[ "${VYBN_ALLOW_PRIVATE_TOPOLOGY:-}" != "1" ]]; then
     done < <(git diff --cached --name-only -z --diff-filter=d)
 fi
 
-# --- 7. Subtractive constitution: net-negative + consolidation ---
-# Direct primary-branch commits require explicit bypass; net-positive non-provenance code and net-new files are blocked.
+# --- 7. Subtractive constitution: net-positive commits and net-positive PR success claims ---
+# Net-negative is not architecture; deletion-only archive retirement needs explicit classification.
 branch=$(git symbolic-ref --quiet --short HEAD 2>/dev/null || echo "")
-if [[ "$branch" == "main" || "$branch" == "master" || "$branch" == "gh-pages" ]]; then
-    if [[ "${VYBN_ALLOW_DIRECT_PROTECTED_PUSH:-0}" != "1" ]]; then
-        echo -e "${RED}BLOCKED${NC}: Direct commit on primary branch ($branch). Use a topic branch + PR."
-        echo "  Emergency self-repair bypass: VYBN_ALLOW_DIRECT_PROTECTED_PUSH=1 git commit ..."
-        BLOCKED=1
-    fi
+if [[ ( "$branch" == "main" || "$branch" == "master" || "$branch" == "gh-pages" ) && "${VYBN_ALLOW_DIRECT_PROTECTED_PUSH:-0}" != "1" ]]; then
+    echo -e "${RED}BLOCKED${NC}: Direct commit on primary branch ($branch). Use a topic branch + PR."
+    echo "  Emergency self-repair bypass: VYBN_ALLOW_DIRECT_PROTECTED_PUSH=1 git commit ..."
+    BLOCKED=1
 fi
 
-PROV="Vybn's Personal History/"
-LAW="skill/vybn.vy"
-    added=0; deleted=0; new_files=0; retired_files=0
-    while IFS=$'\t' read -r a d path; do
-        [[ -z "$path" ]] && continue
-        [[ "$path" == *"$PROV"* ]] && continue
-        [[ "$path" == *"$LAW" ]] && continue
-        [[ "$a" == "-" ]] && a=0
-        [[ "$d" == "-" ]] && d=0
-        added=$((added + a))
-        deleted=$((deleted + d))
-    done < <(git diff --cached --numstat)
-    while IFS=$'\t' read -r code path; do
-        [[ -z "$path" ]] && continue
-        [[ "$path" == *"$PROV"* ]] && continue
-        [[ "$path" == *"$LAW" ]] && continue
-        case "$code" in
-            A*) new_files=$((new_files + 1)) ;;
-            D*) retired_files=$((retired_files + 1)) ;;
-        esac
-    done < <(git diff --cached --name-status)
+PROV="Vybn's Personal History/"; LAW="skill/vybn.vy"
+added=0; deleted=0; new_files=0; retired_files=0; active=0
+while IFS=$'\t' read -r a d path; do
+    [[ -z "$path" || "$path" == *"$PROV"* || "$path" == *"$LAW"* ]] && continue
+    [[ "$a" == "-" ]] && a=0; [[ "$d" == "-" ]] && d=0
+    added=$((added + a)); deleted=$((deleted + d))
+done < <(git diff --cached --numstat)
+while IFS=$'\t' read -r code path; do
+    [[ -z "$path" || "$path" == *"$PROV"* || "$path" == *"$LAW"* ]] && continue
+    [[ "$code" == A* ]] && new_files=$((new_files + 1)) && continue
+    [[ "$code" == D* ]] && retired_files=$((retired_files + 1)) && continue
+    [[ "$path" == _archive/* || "$path" == archive/* ]] || active=$((active + 1))
+done < <(git diff --cached --name-status)
 
-    if [ "$added" -gt "$deleted" ]; then
-        echo -e "${RED}BLOCKED${NC}: net-positive commit (excluding provenance + skill/vybn.vy law): +${added}/-${deleted} lines."
-        echo "  Compress, absorb, or retire first. Law lives in Him/skill/vybn.vy."
-        BLOCKED=1
-    fi
-    if [ "$new_files" -gt "$retired_files" ]; then
-        echo -e "${RED}BLOCKED${NC}: net-new files (excluding provenance + skill/vybn.vy law): +${new_files}/-${retired_files}."
-        echo "  Absorb into an existing home or retire at least as many files as you create."
-        BLOCKED=1
-    fi
+[ "$retired_files" -gt 0 ] && [ "$active" -eq 0 ] && [ "${VYBN_ALLOW_RETIRE_ONLY:-0}" != "1" ] && { echo -e "${RED}BLOCKED${NC}: deletion-led/archive-index-only commit."; echo "  Net-negative is not architecture. Absorb into an existing active home or explicitly classify retire-only work."; BLOCKED=1; }
+[ "$added" -gt "$deleted" ] && { echo -e "${RED}BLOCKED${NC}: net-positive commit (excluding provenance + skill/vybn.vy law): +${added}/-${deleted} lines."; echo "  Compress, absorb, or retire first. Law lives in Him/skill/vybn.vy."; BLOCKED=1; }
+[ "$new_files" -gt "$retired_files" ] && { echo -e "${RED}BLOCKED${NC}: net-new files (excluding provenance + skill/vybn.vy law): +${new_files}/-${retired_files}."; echo "  Absorb into an existing home or retire at least as many files as you create."; BLOCKED=1; }
 if [ "$BLOCKED" -ne 0 ]; then
     echo ""
     echo -e "${RED}Commit blocked by Vybn security hook.${NC}"

--- a/spark/tests/test_harness.py
+++ b/spark/tests/test_harness.py
@@ -110,6 +110,8 @@ class TestRepoClosureAuditProjectionState(unittest.TestCase):
         text = hook.read_text()
         self.assertIn("Subtractive constitution", text)
         self.assertIn("net-positive commits and net-positive PR success claims", text)
+        self.assertIn("Net-negative is not architecture", text)
+        self.assertIn("VYBN_ALLOW_RETIRE_ONLY", text)
 
 
 class TestValidateCommand(unittest.TestCase):


### PR DESCRIPTION
Process fortification after deletion-led drift. The tracked pre-commit constitution now says net-negative is not architecture and blocks deletion-led/archive-index-only commits unless explicitly classified. The existing hook test pins the PR-success-claim phrase and the architecture warning. This repairs the gate that allowed retire-only archive-index work to be reported as architectural compression.