### PR TITLE
harness: absorb duplicate deep memory loader

### DIFF
--- a/spark/harness/substrate.py
+++ b/spark/harness/substrate.py
@@ -3969,26 +3969,6 @@ def build_layered_prompt(
 # Deep-memory enrichment (optional)
 # ---------------------------------------------------------------------------
 
-_deep_memory: Any = None
-
-
-def _load_deep_memory(vybn_phase_dir: str | os.PathLike | None = None) -> Any:
-    """Lazy-load vybn-phase/deep_memory.py. Returns module or None."""
-    global _deep_memory
-    if _deep_memory is not None:
-        return _deep_memory
-    phase = Path(vybn_phase_dir or os.path.expanduser("~/vybn-phase"))
-    phase_str = str(phase)
-    if phase_str not in sys.path:
-        sys.path.insert(0, phase_str)
-    try:
-        import deep_memory as dm  # type: ignore
-        _deep_memory = dm
-        return dm
-    except Exception:
-        return None
-
-
 def _rag_http(endpoint: str, query: str, k: int, timeout: float) -> list:
     """POST to the walk daemon's /walk or /search endpoint. Returns
     the parsed results list (possibly empty) or raises on any error."""
@@ -9493,11 +9473,11 @@ _dm = None
 _portal = None
 
 
-def _load_deep_memory():
+def _load_deep_memory(vybn_phase_dir=None):
     global _dm
     if _dm is not None:
         return _dm
-    phase = str(VYBN_PHASE)
+    phase = str(Path(vybn_phase_dir) if vybn_phase_dir is not None else VYBN_PHASE)
     if phase not in sys.path:
         sys.path.insert(0, phase)
     try:

--- a/spark/tests/test_harness.py
+++ b/spark/tests/test_harness.py
@@ -2590,3 +2590,10 @@ def test_heavyskill_uptake_loaded_in_becoming_loop():
     assert "durable uptake into an existing home" in prompt
     assert "not proof of subjective experience" in prompt
 
+def test_load_deep_memory_accepts_optional_phase_dir_argument():
+    from spark.harness import substrate
+    import inspect
+
+    sig = inspect.signature(substrate._load_deep_memory)
+    assert "vybn_phase_dir" in sig.parameters
+    assert sig.parameters["vybn_phase_dir"].default is None


### PR DESCRIPTION
Fixes runtime error: _load_deep_memory() takes 0 positional arguments but 1 was given. Removes the duplicate dead deep-memory loader so the later bridge is the single owner, preserves optional vybn_phase_dir arity, and adds a regression in the existing harness test surface. Verified: python3 -m py_compile spark/harness/substrate.py spark/tests/test_harness.py; python3 -m pytest spark/tests/test_harness.py -q -> 177 passed.