### PR TITLE
api: restore shared chat security import path

### DIFF
--- a/origins_portal_api_v4.py
+++ b/origins_portal_api_v4.py
@@ -41,8 +41,7 @@ import numpy as np
 # ---------------------------------------------------------------------------
 # Path setup — must happen before any local imports
 # ---------------------------------------------------------------------------
-sys.path.insert(0, os.path.expanduser("~/vybn-phase"))       # deep_memory
-sys.path.insert(0, str(Path.home() / "Vybn"))                # creature_dgm_h
+sys.path[:0] = [str(Path.home() / "Vybn-Law" / "api"), str(Path.home() / "Vybn"), os.path.expanduser("~/vybn-phase")]
 
 from fastapi import FastAPI, Request, HTTPException
 from fastapi.middleware.cors import CORSMiddleware

--- a/spark/tests/test_public_contracts.py
+++ b/spark/tests/test_public_contracts.py
@@ -124,6 +124,7 @@ def test_realtime_voice_uses_gpt_realtime_2():
     assert '@app.post("/api/voice/realtime/sdp")' in src
     assert "client.realtime.calls.create" in src
     assert '"model": OPENAI_REALTIME_MODEL' in src
+    assert 'Path.home() / "Vybn-Law" / "api"' in src
 
 def test_portal_semantic_gate_restarts_super_on_quality_failure():
     src = _portal_source()


### PR DESCRIPTION
Restores portal startup by adding the shared Vybn-Law chat_security membrane to the API import path, compresses path setup instead of adding a line, and pins the dependency in the public contract test. Verified py_compile, import resolution, and public contracts.