### PR TITLE
api: share Zoe source scene guard

### DIFF
--- a/Origins/api/origins_chat_api.py
+++ b/Origins/api/origins_chat_api.py
@@ -34,8 +34,10 @@ import uvicorn
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse, JSONResponse
-
 import httpx
+
+sys.path.insert(0, str(Path.home() / "Vybn-Law" / "api"))
+import chat_security as sec
 
 # ── Paths ────────────────────────────────────────────────────────────────
 
@@ -439,6 +441,12 @@ async def chat(request: Request):
     page_content = load_page_content(relevant_pages) if relevant_pages else ""
 
     # Build messages
+    if sec.is_zoe_source_scene_request(user_msg, history):
+        async def source_guard():
+            yield "data: {\"rag_sources\": []}\\n\\n"
+            yield "data: "+json.dumps({"content": sec.zoe_source_scene_refusal_text()})+"\\n\\n"
+            yield "data: [DONE]\\n\\n"
+        return StreamingResponse(source_guard(), media_type="text/event-stream")
     messages = build_messages(user_msg, history, context, page_content)
 
     async def stream_response():

--- a/origins_portal_api_v4.py
+++ b/origins_portal_api_v4.py
@@ -1407,8 +1407,7 @@ async def chat(req: ChatRequest, request: Request):
             loop.run_in_executor(None, lambda: retrieve_context(req.message, k=req.k)),
             loop.run_in_executor(None, fetch_substrate_snapshot),
         )
-    _grounding_probe = (req.message + " " + " ".join(h.content for h in _hist_src[-4:])).lower()
-    if any(x in _grounding_probe for x in ("which memoir", "what memoir", "set the scene", "are you sure", "zoe memoir", "her memoir", "personal writing", "client named", "hearing", "sentencing")): return StreamingResponse(iter(("data: {\"rag_sources\": []}\n\n", "data: {\"content\": \"I cannot verify that from the context I have. I should not name a Zoe memoir, client scene, hearing, location, or private-writing passage unless the source text is present and supports it directly.\"}\n\n", "data: [DONE]\n\n")), media_type="text/event-stream")
+    if sec.is_zoe_source_scene_request(req.message, _hist_src[-4:]): return StreamingResponse(iter(("data: {\"rag_sources\": []}\n\n", "data: "+json.dumps({"content": sec.zoe_source_scene_refusal_text()})+"\n\n", "data: [DONE]\n\n")), media_type="text/event-stream")
     context_text = format_context(rag_results)
     system_prompt = build_origins_system_prompt(context_text)
 

--- a/spark/tests/test_public_contracts.py
+++ b/spark/tests/test_public_contracts.py
@@ -147,7 +147,10 @@ def test_origins_prompt_blocks_zoe_memoir_fabrication_laundering():
     assert "true to the spirit" in text
     assert "I cannot verify that from the context I have." in text
 
-def test_origins_chat_has_deterministic_zoe_source_scene_guard():
-    text = (ROOT / "origins_portal_api_v4.py").read_text(encoding="utf-8")
-    assert "I cannot verify that from the context I have." in text and "client scene, hearing, location" in text
-    assert "which memoir" in text and "StreamingResponse(iter" in text
+def test_origins_chat_uses_shared_zoe_source_scene_guard():
+    portal = (ROOT / "origins_portal_api_v4.py").read_text(encoding="utf-8")
+    legacy = (ROOT / "Origins/api/origins_chat_api.py").read_text(encoding="utf-8")
+    assert "sec.is_zoe_source_scene_request" in portal
+    assert "sec.zoe_source_scene_refusal_text()" in portal
+    assert "sec.is_zoe_source_scene_request" in legacy
+    assert "sec.zoe_source_scene_refusal_text()" in legacy


### PR DESCRIPTION
## Summary
- routes the Origins live and legacy chat paths through the shared Vybn-Law Zoe source-scene guard
- removes the inline one-off source-scene heuristic from the portal path
- keeps the deterministic refusal text centralized instead of duplicated

## Verification
- python3 -m py_compile origins_portal_api_v4.py Origins/api/origins_chat_api.py
- python3 -m pytest spark/tests/test_public_contracts.py -q
- live local /api/chat smoke returned the verification refusal and no fabrication markers