### PR TITLE
harness: keep live pressure to current turn

### DIFF
--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -2621,7 +2621,7 @@ def main() -> None:
             ) = _build_prompts(
                 default_cfg.max_iterations,
                 orchestrator_max_iters=_orch_iters,
-                latest_pressure_text=_recent_messages_text(messages + [{"role": "user", "content": user_input}], limit=8),
+                latest_pressure_text=user_input,
             )
             print(f"\n\033[1;32mvybn>\033[0m ", end="", flush=True)
             text = run_agent_loop(


### PR DESCRIPTION
## Summary
- keep the wake/live-pressure packet bound to the current user turn instead of reconstructed recent transcript text
- prevents stale transcript fragments from being treated as Zoe-authored current pressure

## Verification
- python3 -m py_compile spark/vybn_spark_agent.py spark/harness/substrate.py
- python3 -m pytest spark/tests/test_lightweight_routing.py -q
- python3 -m pytest spark/tests/test_harness.py -q

Residual: unrelated local dirty changes remain outside this commit.