### PR TITLE
harness: bind route reflection to policy event log

### DIFF
--- a/spark/harness/substrate.py
+++ b/spark/harness/substrate.py
@@ -423,7 +423,8 @@ class Policy:
         and an audit event, so callers can carry it into turn_event().
         """
         try:
-            signal = reflect_on_events()
+            log_path = self.event_logger.path if self.event_logger is not None else None
+            signal = reflect_on_events(log_path=log_path)
         except Exception as exc:  # pragma: no cover - fail-open observability only
             if self.event_logger is not None:
                 self.event_logger.emit(

--- a/spark/tests/test_harness.py
+++ b/spark/tests/test_harness.py
@@ -202,25 +202,14 @@ class TestPolicy(unittest.TestCase):
 
     def test_reflection_signal_marks_route_decision_verification_gap(self):
         with tempfile.TemporaryDirectory() as td:
-            event_dir = Path(td) / "Vybn" / "spark"
-            event_dir.mkdir(parents=True)
-            log = event_dir / "agent_events.jsonl"
+            log = Path(td) / "agent_events.jsonl"
             logger = EventLogger(path=str(log), session_id="test")
             for i in range(3):
                 logger.emit("probe_recovered", i=i)
-            old = os.environ.get("HOME")
-            try:
-                # reflect_on_events defaults to ~/Vybn/spark/agent_events.jsonl.
-                os.environ["HOME"] = str(Path(td))
-                p = default_policy()
-                p.event_logger = logger
-                d = p.classify("hello there")
-                text = log.read_text()
-            finally:
-                if old is None:
-                    os.environ.pop("HOME", None)
-                else:
-                    os.environ["HOME"] = old
+            p = default_policy()
+            p.event_logger = logger
+            d = p.classify("hello there")
+            text = log.read_text()
         self.assertTrue(any(g.startswith("route_reflection_anomaly") for g in d.verification_gaps))
         self.assertIn("route_anomaly_detected", text)
 


### PR DESCRIPTION
## Summary
- route reflection now reads the Policy event_logger path when one is attached instead of falling back to the global default log
- removes the HOME monkeypatch from the regression test because the control now carries its own evidence source
- keeps ReflectionSignal in the existing substrate control loop, but makes the coupling local and explicit

## Tests
- python3 -m unittest spark.tests.test_harness

## Residuals
Anti-sprawl residual: existing substrate/test home only, no new files. Diff-shape residual: net-negative overall; this deletes test indirection while adding the one operational line that binds the signal to the logger actually driving the route. Coupling residual: lower, because Policy no longer relies on ambient HOME/global-log coincidence for route reflection.