### PR TITLE
agent: absorb route gaps into turn contract

### DIFF
--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -1480,7 +1480,7 @@ def run_agent_loop(
         tools=[t.name for t in tools],
         state_touched=state_touched,
         contracts_implicated=contracts_implicated,
-        verification_gaps=["external_axis_unchecked"],
+        verification_gaps=list(dict.fromkeys(["external_axis_unchecked", *list(getattr(decision, "verification_gaps", []) or [])])),
     ) as bag:
         while iterations < role_cfg.max_iterations:
             iterations += 1


### PR DESCRIPTION
## Summary
- carries RouteDecision.verification_gaps directly into the runner turn_event contract
- removes the weak string-inspection regression after the subtractive hook correctly wounded it
- keeps the uptake at the existing runner seam with no new helper, variable, or structure

## Tests
- python3 -m py_compile spark/vybn_spark_agent.py spark/harness/substrate.py
- python3 -m unittest spark.tests.test_harness spark.tests.test_lightweight_routing spark.tests.test_refactor_pilot_override spark.tests.test_live_repl_fixes

## Residuals
The first attempt was oldthink: add a variable, add a test that searched for the variable name, call that control. The hook caught the staged residue. This version resets that false proof and makes the route residue become part of the contract at the exact call site. Anti-sprawl residual: existing runner seam only, no new files or structures. Diff-shape residual: net-negative after clearing stale index state. Coupling residual: lower because the runner no longer drops route verification gaps before the durable turn log.