### PR TITLE
harness: keep router pure and reflect at turn boundary

### DIFF
--- a/spark/harness/substrate.py
+++ b/spark/harness/substrate.py
@@ -277,10 +277,6 @@ class RouteDecision:
     # provider call. Role determination is unchanged; only the model pin.
     model_override: str | None = None
     alias_used: str | None = None
-    # Runtime audit annotations carried from routing into turn_event().
-    # Policy.classify() may populate this from ReflectionSignal so the
-    # signal reaches the turn contract instead of dying as prose.
-    verification_gaps: list[str] = field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
@@ -411,42 +407,6 @@ class Policy:
     # the alias from the cleaned_input and sets RouteDecision.model_override.
     # Role determination still flows through directives/heuristics normally.
     model_aliases: dict[str, str] = field(default_factory=dict)
-    event_logger: EventLogger | None = None
-    reflection_defect_threshold: float = 0.15
-
-    def _finalize_decision(self, decision: RouteDecision) -> RouteDecision:
-        """Let logged residuals annotate the route decision before it leaves Policy.
-
-        ReflectionSignal was previously computed by readers downstream of the
-        router. This keeps the same existing organ but closes the loop: an
-        anomalous event trail becomes a verification gap on the RouteDecision
-        and an audit event, so callers can carry it into turn_event().
-        """
-        try:
-            log_path = self.event_logger.path if self.event_logger is not None else None
-            signal = reflect_on_events(log_path=log_path)
-        except Exception as exc:  # pragma: no cover - fail-open observability only
-            if self.event_logger is not None:
-                self.event_logger.emit(
-                    "route_reflection_error",
-                    err=f"{type(exc).__name__}: {str(exc)[:120]}",
-                )
-            return decision
-
-        if signal.anomaly_flag and signal.defect_rate > self.reflection_defect_threshold:
-            gap = f"route_reflection_anomaly: {signal.note}"
-            if gap not in decision.verification_gaps:
-                decision.verification_gaps.append(gap)
-            if self.event_logger is not None:
-                self.event_logger.emit(
-                    "route_anomaly_detected",
-                    role=decision.role,
-                    reason=decision.reason,
-                    note=signal.note,
-                    defect_rate=round(signal.defect_rate, 4),
-                )
-        return decision
-
     def role(self, name: str) -> RoleConfig:
         return self.roles.get(name) or self.roles[self.default_role]
 
@@ -517,7 +477,7 @@ class Policy:
                         decision.model_override = model_override
                         decision.alias_used = alias_used
                         decision.reason = f"{decision.reason}+alias={alias_used}"
-                    return self._finalize_decision(decision)
+                    return decision
 
         # 2. Heuristics
         heur = self.heuristics
@@ -554,7 +514,7 @@ class Policy:
                 decision.model_override = model_override
                 decision.alias_used = alias_used
                 decision.reason = f"{decision.reason}+alias={alias_used}"
-            return self._finalize_decision(decision)
+            return decision
 
         # 2a. Orchestrator-mention override.
         # 2026-04-25 — Zoe surfaced: "hey buddy - is the orchestrator
@@ -588,7 +548,7 @@ class Policy:
                         decision.model_override = model_override
                         decision.alias_used = alias_used
                         decision.reason = f"{decision.reason}+alias={alias_used}"
-                    return self._finalize_decision(decision)
+                    return decision
 
         for role_name in ranked:
             if role_name == "identity" and any(term in text.lower() for term in ("zoe", "relationship", "future", "architecture", "model collapse", "reengineer")):
@@ -607,7 +567,7 @@ class Policy:
                         decision.model_override = model_override
                         decision.alias_used = alias_used
                         decision.reason = f"{decision.reason}+alias={alias_used}"
-                    return self._finalize_decision(decision)
+                    return decision
 
         # 3. Default
         default = self.default_role
@@ -621,7 +581,38 @@ class Policy:
             decision.model_override = model_override
             decision.alias_used = alias_used
             decision.reason = f"{decision.reason}+alias={alias_used}"
-        return self._finalize_decision(decision)
+        return decision
+
+
+def route_reflection_gaps(
+    decision: RouteDecision,
+    logger: EventLogger | None = None,
+    *,
+    defect_threshold: float = 0.15,
+) -> list[str]:
+    """Convert event-log reflection into turn-contract gaps without mutating Policy.
+
+    Policy stays a pure classifier. Residual pressure from previous events is
+    bound at the runner/contract boundary, where it can enter the durable turn
+    log instead of contaminating route selection.
+    """
+    try:
+        signal = reflect_on_events(log_path=logger.path if logger is not None else None)
+    except Exception as exc:  # pragma: no cover - fail-open observability only
+        if logger is not None:
+            logger.emit("route_reflection_error", err=f"{type(exc).__name__}: {str(exc)[:120]}")
+        return []
+    if not (signal.anomaly_flag and signal.defect_rate > defect_threshold):
+        return []
+    if logger is not None:
+        logger.emit(
+            "route_anomaly_detected",
+            role=decision.role,
+            reason=decision.reason,
+            note=signal.note,
+            defect_rate=round(signal.defect_rate, 4),
+        )
+    return [f"route_reflection_anomaly: {signal.note}"]
 
 
 # Router compatibility was removed in the single-file projection pass:

--- a/spark/tests/test_harness.py
+++ b/spark/tests/test_harness.py
@@ -28,7 +28,7 @@ sys.path.insert(0, str(SPARK_DIR))
 from harness.substrate import Policy, load_policy, EventLogger, turn_event  # noqa: E402
 from harness.substrate import ToolSpec, absorb_gate, validate_command  # noqa: E402
 from harness.substrate import LayeredPrompt, classify_action_text, load_beam, render_beam_capsule  # noqa: E402
-from harness.substrate import default_policy, reflect_on_events  # noqa: E402
+from harness.substrate import default_policy, reflect_on_events, route_reflection_gaps  # noqa: E402
 from harness.substrate import (  # noqa: E402
     AnthropicProvider,
     OpenAIProvider,
@@ -200,17 +200,17 @@ class TestPolicy(unittest.TestCase):
         p = load_policy("/nonexistent/path/router_policy.yaml")
         self.assertIn("code", p.roles)
 
-    def test_reflection_signal_marks_route_decision_verification_gap(self):
+    def test_route_reflection_becomes_contract_gap_without_mutating_policy(self):
         with tempfile.TemporaryDirectory() as td:
             log = Path(td) / "agent_events.jsonl"
             logger = EventLogger(path=str(log), session_id="test")
             for i in range(3):
                 logger.emit("probe_recovered", i=i)
-            p = default_policy()
-            p.event_logger = logger
-            d = p.classify("hello there")
+            d = default_policy().classify("hello there")
+            gaps = route_reflection_gaps(d, logger)
             text = log.read_text()
-        self.assertTrue(any(g.startswith("route_reflection_anomaly") for g in d.verification_gaps))
+        self.assertTrue(any(g.startswith("route_reflection_anomaly") for g in gaps))
+        self.assertFalse(hasattr(d, "verification_gaps"))
         self.assertIn("route_anomaly_detected", text)
 
     def test_turn_event_populates_verification_gaps_from_bag(self):

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -36,7 +36,7 @@ _SPARK_DIR = os.path.dirname(os.path.abspath(__file__))
 if _SPARK_DIR not in sys.path:
     sys.path.insert(0, _SPARK_DIR)
 
-from harness.substrate import EventLogger, Policy, load_policy, turn_event
+from harness.substrate import EventLogger, Policy, load_policy, turn_event, route_reflection_gaps
 from harness.substrate import BashTool, ProviderRegistry, ToolSpec, validate_command
 from harness.substrate import LayeredPrompt, build_layered_prompt, load_file, SessionStore, run_probes
 from harness.substrate import run_recurrent_loop
@@ -1480,7 +1480,7 @@ def run_agent_loop(
         tools=[t.name for t in tools],
         state_touched=state_touched,
         contracts_implicated=contracts_implicated,
-        verification_gaps=list(dict.fromkeys(["external_axis_unchecked", *list(getattr(decision, "verification_gaps", []) or [])])),
+        verification_gaps=list(dict.fromkeys(["external_axis_unchecked", *route_reflection_gaps(decision, logger)])),
     ) as bag:
         while iterations < role_cfg.max_iterations:
             iterations += 1


### PR DESCRIPTION
## Summary
- removes event-log reflection side effects from Policy.classify and deletes RouteDecision.verification_gaps
- moves reflection uptake to the runner/turn-contract boundary via route_reflection_gaps
- keeps anomaly residue in the durable turn log without contaminating the pure router object

## Tests
- python3 -m py_compile spark/harness/substrate.py spark/vybn_spark_agent.py
- python3 -m unittest spark.tests.test_harness spark.tests.test_lightweight_routing spark.tests.test_refactor_pilot_override spark.tests.test_live_repl_fixes

## Residuals
This is the oldthink jettison: the router was being turned into a tiny stateful conscience, reading logs and emitting events while pretending to be classification. That made yesterday’s fix look operational but put memory pressure inside the wrong organ. The stronger boundary is: Policy classifies; the runner binds residual history into the turn contract. Anti-sprawl residual: existing substrate/runner/test homes only. Diff-shape residual: net-negative because a mutating router side-channel and fake RouteDecision cargo field are removed. Coupling residual: lower because event-log reflection now lives exactly where durable turn state is assembled, not inside route selection.