### PR TITLE
fix: fit local delegate within vLLM 8192 context

### DIFF
--- a/spark/harness/substrate.py
+++ b/spark/harness/substrate.py
@@ -696,11 +696,11 @@ _DEFAULT_ROLES: dict[str, RoleConfig] = {
         provider="openai",
         model="nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
         thinking="off",
-        max_tokens=4096,
+        max_tokens=1024,
         max_iterations=3,
         tools=[],
         base_url="http://127.0.0.1:8000/v1",
-        rag=True,
+        rag=False,
     ),
     # Phatic — casual greetings, small talk. Present-work default is GPT-5.5
     # even for light turns unless Zoe explicitly pins local/Nemotron.

--- a/spark/router_policy.yaml
+++ b/spark/router_policy.yaml
@@ -86,21 +86,21 @@ roles:
     provider: openai
     model: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8
     thinking: off
-    max_tokens: 4096
+    max_tokens: 1024
     max_iterations: 3
     tools: []
     base_url: http://127.0.0.1:8000/v1
-    rag: true
+    rag: false
   # Local-private — explicit local exception to the GPT-5.5 default.
   local_private:
     provider: openai
     model: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8
     thinking: off
-    max_tokens: 8192
+    max_tokens: 1024
     max_iterations: 3
     tools: []
     base_url: http://127.0.0.1:8000/v1
-    rag: true
+    rag: false
 
   # Phatic — casual greetings. GPT-5.5 by default, no RAG.
   phatic:


### PR DESCRIPTION
The `local` and `local_private` roles were requesting 4096/8192 max_tokens with RAG enabled. On the Nemotron vLLM endpoint (max_model_len=8192), prompt + RAG chunks + requested output exceeds the context window, producing:

```
Error code: 400 - This model's maximum context length is 8192 tokens.
However, you requested 4096 output tokens and your prompt contains
at least 4097 input tokens...
```

This was causing all delegations to the `local` specialist (and `local_private`) to fail with HTTP 400 before any inference happened.

**Fix:** drop max_tokens to 1024 and disable RAG for both local roles in both `router_policy.yaml` and the `_DEFAULT_ROLES` fallback in `substrate.py`.

**Tests:** 69 passed, 6 skipped across routing, harness, and chat-routing suites.