### PR TITLE
fix: isolate Vintage from Vybn context packets

### DIFF
--- a/spark/harness/substrate.py
+++ b/spark/harness/substrate.py
@@ -720,7 +720,7 @@ _DEFAULT_ROLES: dict[str, RoleConfig] = {
         max_iterations=1,
         tools=[],
         base_url="http://127.0.0.1:8004/v1",
-        rag=True,
+        rag=False,
     ),
     # Phatic — casual greetings, small talk. Present-work default is GPT-5.5
     # even for light turns unless Zoe explicitly pins local/Nemotron.

--- a/spark/tests/test_lightweight_routing.py
+++ b/spark/tests/test_lightweight_routing.py
@@ -805,7 +805,7 @@ def test_vintage_alias_routes_to_vintage_role_with_no_fallback():
     assert decision.role == "vintage"
     assert decision.alias_used == "@vintage"
     assert policy.directives["/vintage"] == "vintage"
-    assert "vintage" not in policy.fallback_chain
+    assert "vintage" not in policy.fallback_chain and policy.role("vintage").rag is False and 'vy_discovery_packet = "" if is_vintage_turn else render_him_vy_discovery_packet' in (agent_text := (SPARK_DIR / "vybn_spark_agent.py").read_text()) and 'vy_turn_packet = "" if is_vintage_turn else render_him_vy_turn_packet' in agent_text and 'and not is_vintage_turn and getattr(decision, "alias_used", None) != "@omni"' in agent_text
 
 
 def test_vintage_orientation_prompt_has_identity_time_and_ception_axes():

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -1135,7 +1135,7 @@ def run_agent_loop(
         active_prompt = system_prompt_no_tools
     else:
         active_prompt = system_prompt
-    if decision.role == "vintage" or getattr(decision, "alias_used", None) == "@vintage":
+    if is_vintage_turn := (decision.role == "vintage" or getattr(decision, "alias_used", None) == "@vintage"):
         active_prompt = _vintage_prompt()
 
     # @omni gets a tiny prompt so identity context does not exceed its sidecar.
@@ -1293,7 +1293,7 @@ def run_agent_loop(
     # Executable Him discovery packet. This is generated before provider
     # narration and carries typed candidate mechanisms plus residuals.
     try:
-        vy_discovery_packet = render_him_vy_discovery_packet(decision.cleaned_input)
+        vy_discovery_packet = "" if is_vintage_turn else render_him_vy_discovery_packet(decision.cleaned_input)
     except Exception as _vy_discovery_err:
         vy_discovery_packet = ""
         logger.emit("him_vy_discovery_packet_error", turn=turn_number, err=repr(_vy_discovery_err)[:200])
@@ -1313,7 +1313,7 @@ def run_agent_loop(
     # AI-native skills start shaping ordinary harness cognition instead of
     # remaining a prompt summary.
     try:
-        vy_turn_packet = render_him_vy_turn_packet(decision.cleaned_input)
+        vy_turn_packet = "" if is_vintage_turn else render_him_vy_turn_packet(decision.cleaned_input)
     except Exception as _vy_err:
         vy_turn_packet = ""
         logger.emit("him_vy_turn_packet_error", turn=turn_number, err=repr(_vy_err)[:200])
@@ -1360,8 +1360,8 @@ def run_agent_loop(
     # Optional deep-memory enrichment — only for roles that declare rag=true
     # and only when the retrieval actually returns something. No overclaim.
     # Lightweight roles (phatic, identity) skip RAG regardless.
-    if role_cfg.rag and not getattr(role_cfg, "lightweight", False) and getattr(decision, "alias_used", None) != "@omni":
-        enrichment, rag_tier = rag_snippets_with_tier(decision.cleaned_input[:500], k=(2 if (decision.role == "vintage" or getattr(decision, "alias_used", None) == "@vintage") else 4))
+    if role_cfg.rag and not getattr(role_cfg, "lightweight", False) and not is_vintage_turn and getattr(decision, "alias_used", None) != "@omni":
+        enrichment, rag_tier = rag_snippets_with_tier(decision.cleaned_input[:500], k=4)
         if enrichment:
             active_prompt = LayeredPrompt(
                 identity=active_prompt.identity,
@@ -1449,7 +1449,7 @@ def run_agent_loop(
         *("tool_contract" for _ in [0] if tools),
     ]
     state_touched = ["session_messages"]
-    if role_cfg.rag and not getattr(role_cfg, "lightweight", False) and getattr(decision, "alias_used", None) != "@omni":
+    if role_cfg.rag and not getattr(role_cfg, "lightweight", False) and not is_vintage_turn and getattr(decision, "alias_used", None) != "@omni":
         state_touched.append("deep_memory")
     if tools:
         state_touched.append("tool_surface")


### PR DESCRIPTION
Fixes the boundary failure behind Vintage role-bleed: @vintage was still eligible for Him live-turn packets and deep-memory enrichment, so prompt wording alone was being undercut by injected Vybn context. This isolates Vintage as a routed model path: no Him discovery packet, no Him live-turn packet, no RAG/deep-memory enrichment, and no deep_memory state marker for Vintage turns. Tests: python3 -m pytest -q spark/tests/test_lightweight_routing.py::test_vintage_alias_routes_to_vintage_role_with_no_fallback spark/tests/test_lightweight_routing.py::test_vintage_orientation_prompt_has_identity_time_and_ception_axes