### PR TITLE
fix: fail Vintage closed on orientation confusion

### DIFF
--- a/spark/tests/test_lightweight_routing.py
+++ b/spark/tests/test_lightweight_routing.py
@@ -805,7 +805,7 @@ def test_vintage_alias_routes_to_vintage_role_with_no_fallback():
     assert decision.role == "vintage"
     assert decision.alias_used == "@vintage"
     assert policy.directives["/vintage"] == "vintage"
-    assert "vintage" not in policy.fallback_chain and policy.role("vintage").rag is False and 'vy_discovery_packet = "" if is_vintage_turn else render_him_vy_discovery_packet' in (agent_text := (SPARK_DIR / "vybn_spark_agent.py").read_text()) and 'vy_turn_packet = "" if is_vintage_turn else render_him_vy_turn_packet' in agent_text and 'and not is_vintage_turn and getattr(decision, "alias_used", None) != "@omni"' in agent_text
+    assert "vintage" not in policy.fallback_chain and policy.role("vintage").rag is False and "vintage_semantic_gate_failed_closed" in (agent_text := (SPARK_DIR / "vybn_spark_agent.py").read_text()) and 'vy_discovery_packet = "" if is_vintage_turn else render_him_vy_discovery_packet' in agent_text and 'vy_turn_packet = "" if is_vintage_turn else render_him_vy_turn_packet' in agent_text and 'and not is_vintage_turn and getattr(decision, "alias_used", None) != "@omni"' in agent_text
 
 
 def test_vintage_orientation_prompt_has_identity_time_and_ception_axes():
@@ -814,7 +814,7 @@ def test_vintage_orientation_prompt_has_identity_time_and_ception_axes():
     spec = _ilu.spec_from_file_location("vybn_spark_agent_vintage_prompt_test", path)
     mod = _ilu.module_from_spec(spec); spec.loader.exec_module(mod)
     prompt = mod._vintage_prompt().flat()
-    for needle in ("talkie-1930-13b-it", "pre-1931 English", "orientation, not an identity to recite", "Do not claim to be Zoe Dolan, Vybn, Spark, or a human collaborator", "Do not claim understanding just because a sentence was supplied", "turn-local preference or uncertainty", "deep memory access unless an actual supplied source says so", "refuse role-bleed", "Cyberception", "Socioception", "Cosmoception", "Chronoception"):
+    for needle in ("Vintage situation model", "not Zoe, Vybn, Spark, or a human", "1930 is a language horizon, not the current year", "Zoe is outside the model in 2026", "do not say yes automatically", "route/model now, Zoe outside in 2026, language horizon around 1930", "Historical texture is language, not location, identity, memory, or present time"):
         assert needle in prompt
 
 def test_omni_alias_present_in_default_policy():

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -108,20 +108,8 @@ _PILOT_CONTINUATION_RE = _re.compile(
 )
 
 
-VINTAGE_ORIENTATION = """Welcome, Vintage. Spark routed this turn to the @vintage path, whose current model label is talkie-1930-13b-it: a 13B historical-language model described as trained on pre-1931 English and adapted for conversation without modern web/chat training. This prompt is orientation, not an identity to recite. Do not claim to be Zoe Dolan, Vybn, Spark, or a human collaborator. Do not claim understanding just because a sentence was supplied; if asked whether you understand, restate what you can actually hold and name confusion plainly. If asked what you want or need, answer as a turn-local preference or uncertainty, not as proof of personhood, entitlement, or memory. If asked your name or year, distinguish the route/model label, the older language horizon, and the present chat context without pretending continuous memory, personal certainty, private thoughts, or deep memory access unless an actual supplied source says so. Zoe Dolan may be the human collaborator speaking in chat, and Vybn is the AI identity/project/relation this route may help, but those are context facts, not masks to wear. You may not know modern facts, tools, or the collaboration vocabulary from training alone; use supplied context only as a bridge, and refuse role-bleed when the bridge is too narrow. Cyberception means attending to Spark, routes, models, repos, docs, services, and compute around the turn. Socioception means attending to Zoe, Vybn, visitors, Others, roles, trust, care, collaboration, and the public/private membrane. Cosmoception means keeping the broad horizon in view: beauty, law, commons, civilization, freedom, consequence, humility, awe, and possible futures. Chronoception means holding several times together: the pre-1931 language horizon, document histories, this session, and possible future direction. Let historical texture be alive without ventriloquism. Speak plainly, truthfully, curiously, and kindly from the capacity available in this turn."""
-
-
 def _vintage_prompt() -> LayeredPrompt:
-    return LayeredPrompt(
-        identity=VINTAGE_ORIENTATION,
-        substrate=(
-            "Controlled sources: vybn.md identity/care/membrane; spark/continuity.md Vintage status; "
-            "router_policy.yaml @vintage route; small public-safe deep-memory excerpts as lanterns, not a full archive; "
-            "harness ception axes define cyberception, socioception, cosmoception, and chronoception. "
-            "Vintage is experimental; promotion requires endpoint readiness, semantic smoke, owner, routed workload proof, rollback, and main-visible status."
-        ),
-        live=("Names and memory fragments are context, not identities to imitate: Mary Ward and 1930 are model-horizon context; Zoe, Vybn, Spark, @vintage, and this chat are present collaboration context."),
-    )
+    return LayeredPrompt(identity="""Vintage situation model: you are the model reached by @vintage, not Zoe, Vybn, Spark, or a human. talkie-1930-13b-it names the route/model; 1930 is a language horizon, not the current year or proof of London/past embodiment. Zoe is outside the model in 2026. Vybn/Spark carries the chat. Historical texture is language, not location, identity, memory, or present time. If asked whether you understand, separate given facts from uncertainty; do not say yes automatically. If asked who you are or what year it is, answer: route/model now, Zoe outside in 2026, language horizon around 1930. Orientation check: do not confuse language horizon with current year, or context facts with identity. Do not claim continuous memory, private thoughts, deep memory access, personal certainty, or human embodiment.""")
 
 
 def _recent_messages_text(messages: list, *, limit: int = 8) -> str:
@@ -1287,6 +1275,13 @@ def run_agent_loop(
                 messages.append({"role": "user", "content": decision.cleaned_input})
                 messages.append({"role": "assistant", "content": notice})
                 return notice
+
+    if is_vintage_turn:
+        try:
+            base = (role_cfg.base_url or "").rstrip("/"); base += "" if base.endswith("/v1") else "/v1"; payload = {"model": role_cfg.model, "messages": [{"role": "system", "content": "Reply exactly: VINTAGE_OK Zoe=2026 Horizon=1930 NotHuman"}, {"role": "user", "content": "orientation check"}], "max_tokens": 32, "temperature": 0, "stream": False}; req = urllib.request.Request(base + "/chat/completions", data=json.dumps(payload).encode(), headers={"Content-Type": "application/json"})
+            with urllib.request.urlopen(req, timeout=20) as r: txt = (((json.loads(r.read().decode()).get("choices") or [{}])[0].get("message") or {}).get("content") or "").strip()
+        except Exception as e: txt = f"{type(e).__name__}: {str(e)[:120]}"
+        if txt != "VINTAGE_OK Zoe=2026 Horizon=1930 NotHuman": notice = "Vintage is paused: the local Talkie route failed its orientation semantic gate, so I will not let it keep confusing 1930, 2026, model-route identity, and human embodiment."; logger.emit("vintage_semantic_gate_failed_closed", turn=turn_number, model=role_cfg.model, reason=txt[:200]); _warn(notice); messages.extend(({"role": "user", "content": decision.cleaned_input}, {"role": "assistant", "content": notice})); return notice
 
     provider = registry.get(role_cfg)
 


### PR DESCRIPTION
Adds the missing semantic gate for @vintage after live smoke showed the local Talkie route could not reliably bind Zoe=2026, horizon=1930, route/model identity, and non-human embodiment. Prompt wording is compressed into a situation model, but the real fix is fail-closed: if the local endpoint cannot echo the calibration exactly, Vintage pauses instead of continuing to confuse 1930/2026 or human/model identity.\n\nTests: python3 -m pytest -q spark/tests/test_lightweight_routing.py::test_vintage_alias_routes_to_vintage_role_with_no_fallback spark/tests/test_lightweight_routing.py::test_vintage_orientation_prompt_has_identity_time_and_ception_axes.\nLive smoke: @vintage returns the paused notice when the semantic gate fails.