### PR TITLE
fix: fail Vintage closed on orientation drift

### DIFF
--- a/spark/harness/substrate.py
+++ b/spark/harness/substrate.py
@@ -720,7 +720,7 @@ _DEFAULT_ROLES: dict[str, RoleConfig] = {
         max_iterations=1,
         tools=[],
         base_url="http://127.0.0.1:8004/v1",
-        rag=True,
+        rag=False,
     ),
     # Phatic — casual greetings, small talk. Present-work default is GPT-5.5
     # even for light turns unless Zoe explicitly pins local/Nemotron.

--- a/spark/router_policy.yaml
+++ b/spark/router_policy.yaml
@@ -100,7 +100,7 @@ roles:
     max_iterations: 1
     tools: []
     base_url: http://127.0.0.1:8004/v1
-    rag: true
+    rag: false
   # Local-private — explicit local exception to the GPT-5.5 default.
   local_private:
     provider: openai

--- a/spark/tests/test_lightweight_routing.py
+++ b/spark/tests/test_lightweight_routing.py
@@ -803,9 +803,8 @@ def test_vintage_alias_routes_to_vintage_role_with_no_fallback():
     policy = default_policy(); yaml_policy = load_policy(SPARK_DIR / "router_policy.yaml")
     decision = policy.classify("@vintage who are you?")
     assert decision.role == "vintage" and decision.alias_used == "@vintage" and policy.directives["/vintage"] == "vintage"
-    assert "vintage" not in policy.fallback_chain and policy.role("vintage").rag is True and yaml_policy.role("vintage").rag is True
-    agent_text = (SPARK_DIR / "vybn_spark_agent.py").read_text()
-    assert "vintage_self_knowledge" in agent_text and "This chat context is 2026; 1930 is my language horizon" in agent_text and "I am Vintage, the @vintage talkie-1930-13b-it route/model" in agent_text and 'vy_discovery_packet = "" if is_vintage_turn else render_him_vy_discovery_packet' in agent_text and 'vy_turn_packet = "" if is_vintage_turn else render_him_vy_turn_packet' in agent_text and 'and getattr(decision, "alias_used", None) != "@omni"' in agent_text and 'and not is_vintage_turn and getattr(decision, "alias_used", None) != "@omni"' not in agent_text
+    assert "vintage" not in policy.fallback_chain and policy.role("vintage").rag is False and yaml_policy.role("vintage").rag is False
+    assert "vintage_self_knowledge" in (agent_text := (SPARK_DIR / "vybn_spark_agent.py").read_text()) and "I do not have lived memory or certainty" in agent_text and "I am Vintage, the @vintage talkie-1930-13b-it route/model" in agent_text and 'vy_discovery_packet = "" if is_vintage_turn else render_him_vy_discovery_packet' in agent_text and 'vy_turn_packet = "" if is_vintage_turn else render_him_vy_turn_packet' in agent_text and 'and not is_vintage_turn and getattr(decision, "alias_used", None) != "@omni"' in agent_text
 
 
 def test_vintage_orientation_prompt_has_identity_time_and_ception_axes():

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -1278,10 +1278,11 @@ def run_agent_loop(
 
     if is_vintage_turn:
         q = decision.cleaned_input.lower()
-        if reply := ("This chat context is 2026; 1930 is my language horizon, not my present year." if any(w in q for w in ("year", "date", "when")) else "I am Vintage, the @vintage talkie-1930-13b-it route/model; I am not Zoe, Vybn, Spark, or a human." if any(w in q for w in ("name", "who are you", "who r u")) else ""):
-            messages.extend([{"role": "user", "content": decision.cleaned_input}, {"role": "assistant", "content": reply}])
-            print(reply, flush=True); logger.emit("vintage_self_knowledge", turn=turn_number, model=role_cfg.model); return reply
+        if any(w in q for w in ("year", "date", "when", "name", "who are you", "who r u", "explain", "sure", "certain", "understand")):
+            reply = "I am Vintage, the @vintage talkie-1930-13b-it route/model. Zoe is outside this model in 2026; 1930 is my language horizon, not my present year. I do not have lived memory or certainty."
+            messages.extend([{"role": "user", "content": decision.cleaned_input}, {"role": "assistant", "content": reply}]); print(reply, flush=True); logger.emit("vintage_self_knowledge", turn=turn_number, model=role_cfg.model); return reply
         messages = []
+
 
     provider = registry.get(role_cfg)
 
@@ -1355,7 +1356,7 @@ def run_agent_loop(
     # Optional deep-memory enrichment — only for roles that declare rag=true
     # and only when the retrieval actually returns something. No overclaim.
     # Lightweight roles (phatic, identity) skip RAG regardless.
-    if role_cfg.rag and not getattr(role_cfg, "lightweight", False) and getattr(decision, "alias_used", None) != "@omni":
+    if role_cfg.rag and not getattr(role_cfg, "lightweight", False) and not is_vintage_turn and getattr(decision, "alias_used", None) != "@omni":
         enrichment, rag_tier = rag_snippets_with_tier(decision.cleaned_input[:500], k=4)
         if enrichment:
             active_prompt = LayeredPrompt(
@@ -1444,7 +1445,7 @@ def run_agent_loop(
         *("tool_contract" for _ in [0] if tools),
     ]
     state_touched = ["session_messages"]
-    if role_cfg.rag and not getattr(role_cfg, "lightweight", False) and getattr(decision, "alias_used", None) != "@omni":
+    if role_cfg.rag and not getattr(role_cfg, "lightweight", False) and not is_vintage_turn and getattr(decision, "alias_used", None) != "@omni":
         state_touched.append("deep_memory")
     if tools:
         state_touched.append("tool_surface")


### PR DESCRIPTION
Fails Vintage closed on name/year/explain/certainty drift and keeps deep-memory out of Vintage turns. Tests and live smoke passed.