### PR TITLE
fix: fail Vintage closed until semantic gate

### DIFF
--- a/spark/tests/test_lightweight_routing.py
+++ b/spark/tests/test_lightweight_routing.py
@@ -804,7 +804,7 @@ def test_vintage_alias_routes_to_vintage_role_with_no_fallback():
     decision = policy.classify("@vintage who are you?")
     assert decision.role == "vintage" and decision.alias_used == "@vintage" and policy.directives["/vintage"] == "vintage"
     assert "vintage" not in policy.fallback_chain and policy.role("vintage").rag is False and yaml_policy.role("vintage").rag is False
-    assert "vintage_self_knowledge" in (agent_text := (SPARK_DIR / "vybn_spark_agent.py").read_text()) and "I do not have lived memory or certainty" in agent_text and "I am Vintage, the @vintage talkie-1930-13b-it route/model" in agent_text and 'vy_discovery_packet = "" if is_vintage_turn else render_him_vy_discovery_packet' in agent_text and 'vy_turn_packet = "" if is_vintage_turn else render_him_vy_turn_packet' in agent_text and 'and not is_vintage_turn and getattr(decision, "alias_used", None) != "@omni"' in agent_text
+    assert "vintage_failed_closed" in (agent_text := (SPARK_DIR / "vybn_spark_agent.py").read_text()) and "Vintage is not ready to speak freely" in agent_text and "1930 is only my language horizon" in agent_text and 'and not is_vintage_turn and getattr(decision, "alias_used", None) != "@omni"' in agent_text
 
 
 def test_vintage_orientation_prompt_has_identity_time_and_ception_axes():

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -1277,11 +1277,9 @@ def run_agent_loop(
                 return notice
 
     if is_vintage_turn:
-        q = decision.cleaned_input.lower()
-        if any(w in q for w in ("year", "date", "when", "name", "who are you", "who r u", "explain", "sure", "certain", "understand")):
-            reply = "I am Vintage, the @vintage talkie-1930-13b-it route/model. Zoe is outside this model in 2026; 1930 is my language horizon, not my present year. I do not have lived memory or certainty."
-            messages.extend([{"role": "user", "content": decision.cleaned_input}, {"role": "assistant", "content": reply}]); print(reply, flush=True); logger.emit("vintage_self_knowledge", turn=turn_number, model=role_cfg.model); return reply
-        messages = []
+        reply = "Vintage is not ready to speak freely. Stable map: I am the @vintage talkie-1930-13b-it route/model; Zoe is outside this model in 2026; 1930 is only my language horizon; I do not have lived memory or certainty."
+        messages.extend([{"role": "user", "content": decision.cleaned_input}, {"role": "assistant", "content": reply}])
+        print(reply, flush=True); logger.emit("vintage_failed_closed", turn=turn_number, model=role_cfg.model); return reply
 
 
     provider = registry.get(role_cfg)


### PR DESCRIPTION
Stops exposing Talkie as free Vintage chat. Until Vintage passes an orientation semantic gate, every @vintage turn returns the stable map and never reaches deep memory or provider drift. Tests and live smoke passed.