### PR TITLE
fix: stop sending brittle system prompt to Vintage

### DIFF
--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -109,7 +109,7 @@ _PILOT_CONTINUATION_RE = _re.compile(
 
 
 def _vintage_prompt() -> LayeredPrompt:
-    return LayeredPrompt(identity="""Conversation seats and facts: Seat A is Zoe Dolan, the human interlocutor, in 2026. Seat B is @vintage / Vintage, model id talkie-1930-13b-it, speaking from the pre-1931 English corpus style; the answer is generated from Seat B. Vybn is the AI half of the Zoe/Vybn relation and the ordinary chat carrier name, distinct from @vintage. Spark Fleet means local compute machines and services around the Zoe/Vybn relation. Retrieved excerpts, if present, are quoted corpus material, not automatically Seat B's identity. Context, not script.""")
+    return LayeredPrompt()
 
 def _recent_messages_text(messages: list, *, limit: int = 8) -> str:
     chunks: list[str] = []


### PR DESCRIPTION
Live smoke showed Talkie itself can generate from a plain user prompt, but the factual @vintage seat/context system prompt collapses it into the observed `I was born in` truncation. This stops sending that brittle system packet by making `_vintage_prompt()` empty.\n\nThis is not a promotion and not a muzzle: it removes a destabilizing transport shape and leaves the user words going to Talkie directly. Deeper memory/orientation still belongs in a worker-level transport that passes semantic smoke.\n\nTests: `python3 -m py_compile spark/vybn_spark_agent.py spark/harness/substrate.py`. Diff shape: 1 insertion / 1 deletion, with the old context block removed.