### PR TITLE
fix: route Vintage about-yourself questions through identity membrane

### DIFF
--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -111,7 +111,7 @@ _PILOT_CONTINUATION_RE = _re.compile(
 def _vintage_prompt() -> LayeredPrompt:
     return LayeredPrompt()
 
-_VINTAGE_IDENTITY_RE = _re.compile(r"\b(?:who are you|what(?:\x27s| is) your name|do you have a name|your name)\b", _re.IGNORECASE)
+_VINTAGE_IDENTITY_RE = _re.compile(r"\b(?:who are you|tell me about yourself|about yourself|what(?:\x27s| is) your name|do you have a name|your name)\b", _re.IGNORECASE)
 
 def _recent_messages_text(messages: list, *, limit: int = 8) -> str:
     chunks: list[str] = []


### PR DESCRIPTION
The remaining @vintage failure is not lack of factual context: direct Talkie smoke shows system, user-context, and quoted-source context all collapse into old-text autobiography for “please tell me about yourself?”\n\nThis keeps the boundary where it belongs: Spark answers system-identity/about-yourself questions at the carrier layer instead of asking Talkie to integrate facts it demonstrably cannot hold in that channel. Vintage remains free to speak for ordinary turns; identity/about-yourself questions return the local @vintage route identity and mark corpus personae as not system identity.\n\nChange: extend `_VINTAGE_IDENTITY_RE` to include “tell me about yourself” / “about yourself”.\n\nTests: `python3 -m pytest spark/tests/test_lightweight_routing.py -k vintage -q`.\n\nDiff shape: 1 insertion / 1 deletion in the existing Vintage identity membrane, no new structure.