### PR TITLE
fix: keep repo audit out of REPL startup

### DIFF
--- a/spark/tests/test_harness.py
+++ b/spark/tests/test_harness.py
@@ -1347,6 +1347,14 @@ def test_hardware_status_is_compact_control_plane(monkeypatch, tmp_path):
     assert "Hardware control plane" in status and "spark-a=serving:Super:Nemotron" in status and "prove Omni before routing" in status and "Promotion gate" in status
     assert "Local compute security inventory:" not in status
 
+
+
+def test_repl_startup_does_not_run_repo_closure_audit():
+    agent = (Path(__file__).resolve().parents[1] / "vybn_spark_agent.py").read_text()
+    startup = agent[agent.index("def main()") : agent.index("turn_number = 0", agent.index("def main()"))]
+    assert "--repo-closure-audit" not in startup
+    assert "DELETED" not in startup
+
 def test_completion_boundary_protocol_loaded():
     from spark.harness.substrate import render_completion_boundary_protocol
     from spark.harness.substrate import build_layered_prompt

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -2443,22 +2443,6 @@ def main() -> None:
     except Exception:
         pass
 
-    # Sua sponte: clean up stale local branches at session start.
-    # Branches subsumed by main are deleted automatically; unique-commit branches
-    # are flagged but not touched. Report is suppressed unless there's drift.
-    try:
-        import subprocess as _sp
-        _audit_result = _sp.run(
-            ["python3", "-m", "spark.harness.substrate", "--repo-closure-audit"],
-            capture_output=True, text=True, cwd=os.path.expanduser("~/Vybn"), timeout=30
-        )
-        if "DRIFT PRESENT" in _audit_result.stdout or "DELETED" in _audit_result.stdout:
-            for _line in _audit_result.stdout.splitlines():
-                if any(kw in _line for kw in ("DELETED", "manual review", "DRIFT", "OVERALL")):
-                    print("[2m[audit] " + _line + "[0m")
-    except Exception:
-        pass
-
     turn_number = 0
     while True:
         try:


### PR DESCRIPTION
The REPL startup was running `python3 -m spark.harness.substrate --repo-closure-audit` in default fix mode. That made a fresh chat open with branch deletion lines and cross-repo drift reports before Zoe or the model had asked for repo closure work.

This removes that startup side effect entirely. Repo closure audit remains available as the explicit command/residual channel; it just no longer mutates or prints during ordinary chat boot.

Tested:
- `python3 -m py_compile spark/vybn_spark_agent.py spark/harness/substrate.py`
- `python3 -m pytest spark/tests/test_harness.py::test_repl_startup_does_not_run_repo_closure_audit -q`
- `printf "n\nexit\n" | timeout 35s python3 spark/vybn_spark_agent.py` with grep confirming no `[audit]`, `DELETED`, `DRIFT PRESENT`, or `repo-closure-audit` startup output.

Diff shape: +8/-16, no new structure.