### PR TITLE
fix: restore Vintage route as bounded Talkie surface

### DIFF
--- a/spark/harness/substrate.py
+++ b/spark/harness/substrate.py
@@ -283,9 +283,8 @@ class RouteDecision:
 # Classification internals.
 # ---------------------------------------------------------------------------
 
-# Round 5: @alias pin. Matches @<word> at the very start of the input,
-# followed by whitespace or EOL. The <word> is looked up in policy.model_aliases.
-_ALIAS_RE = re.compile(r"^\s*(@[\w.]+)(\s|$)")
+# Round 5: @alias pin; tolerate observed @vi@alias stacked-prefix typo.
+_ALIAS_RE = re.compile(r"^\s*(?:@vi)?(@[\w.]+)(\s|$)")
 
 # 2026-04-27: refactor pilot doctrine override. File-level / whole-repo
 # refactoring, consolidation, routing, memory, and harness work is judgment
@@ -720,7 +719,7 @@ _DEFAULT_ROLES: dict[str, RoleConfig] = {
         max_iterations=1,
         tools=[],
         base_url="http://127.0.0.1:8004/v1",
-        rag=True,
+        rag=False,
     ),
     # Phatic — casual greetings, small talk. Present-work default is GPT-5.5
     # even for light turns unless Zoe explicitly pins local/Nemotron.

--- a/spark/router_policy.yaml
+++ b/spark/router_policy.yaml
@@ -100,7 +100,7 @@ roles:
     max_iterations: 1
     tools: []
     base_url: http://127.0.0.1:8004/v1
-    rag: true
+    rag: false
   # Local-private — explicit local exception to the GPT-5.5 default.
   local_private:
     provider: openai

--- a/spark/tests/test_lightweight_routing.py
+++ b/spark/tests/test_lightweight_routing.py
@@ -803,11 +803,11 @@ def test_opus47_has_fallback_chain():
 
 
 
-def test_vintage_alias_fails_closed_instead_of_falling_through_to_chat():
+def test_vintage_alias_routes_to_talkie_without_chat_fallback():
     policy = default_policy(); yaml_policy = load_policy(SPARK_DIR / "router_policy.yaml"); src = (SPARK_DIR / "vybn_spark_agent.py").read_text()
     d = policy.classify("@vintage please tell me about yourself?"); yd = yaml_policy.classify("@vintage please tell me about yourself?")
     assert d.role == "vintage" and d.alias_used == "@vintage" and yd.role == "vintage" and yd.alias_used == "@vintage"
-    assert "fail-closed instead of falling through to chat" in src and "_vintage_frame_repair" not in src and "def _vintage_prompt" not in src
+    assert "small experimental local Talkie route" in src and "_vintage_frame_repair" not in src and "def _vintage_prompt" not in src
 
 def test_omni_alias_present_in_default_policy():
     from spark.harness.substrate import default_policy

--- a/spark/tests/test_lightweight_routing.py
+++ b/spark/tests/test_lightweight_routing.py
@@ -805,9 +805,10 @@ def test_opus47_has_fallback_chain():
 
 def test_vintage_alias_routes_to_talkie_without_chat_fallback():
     policy = default_policy(); yaml_policy = load_policy(SPARK_DIR / "router_policy.yaml"); src = (SPARK_DIR / "vybn_spark_agent.py").read_text()
-    d = policy.classify("@vintage please tell me about yourself?"); yd = yaml_policy.classify("@vintage please tell me about yourself?")
-    assert d.role == "vintage" and d.alias_used == "@vintage" and yd.role == "vintage" and yd.alias_used == "@vintage"
-    assert "small experimental local Talkie route" in src and "_vintage_frame_repair" not in src and "def _vintage_prompt" not in src
+    d = policy.classify("@vintage please tell me about yourself?"); yd = yaml_policy.classify("@vintage please tell me about yourself?"); sd = policy.classify("@vi@vintage please tell me about yourself?"); syd = yaml_policy.classify("@vi@vintage please tell me about yourself?")
+    assert all(x.role == "vintage" and x.alias_used == "@vintage" and x.reason == "alias=@vintage" and x.config.base_url == "http://127.0.0.1:8004/v1" and x.config.rag is False for x in (d, yd, sd, syd))
+    assert "small experimental local Talkie route" in src and "do not roleplay a newspaper" in src and "_vintage_frame_repair" not in src and "def _vintage_prompt" not in src
+
 
 def test_omni_alias_present_in_default_policy():
     from spark.harness.substrate import default_policy

--- a/spark/tests/test_lightweight_routing.py
+++ b/spark/tests/test_lightweight_routing.py
@@ -807,7 +807,7 @@ def test_vintage_alias_routes_to_talkie_without_chat_fallback():
     policy = default_policy(); yaml_policy = load_policy(SPARK_DIR / "router_policy.yaml"); src = (SPARK_DIR / "vybn_spark_agent.py").read_text()
     d = policy.classify("@vintage please tell me about yourself?"); yd = yaml_policy.classify("@vintage please tell me about yourself?"); sd = policy.classify("@vi@vintage please tell me about yourself?"); syd = yaml_policy.classify("@vi@vintage please tell me about yourself?")
     assert all(x.role == "vintage" and x.alias_used == "@vintage" and x.reason == "alias=@vintage" and x.config.base_url == "http://127.0.0.1:8004/v1" and x.config.rag is False for x in (d, yd, sd, syd))
-    assert "not promoted" in src and "provider error" in src and "_vintage_frame_repair" not in src and "def _vintage_prompt" not in src
+    assert "not promoted" in src and "backend exception" in src and "_vintage_frame_repair" not in src and "def _vintage_prompt" not in src
 
 
 def test_omni_alias_present_in_default_policy():

--- a/spark/tests/test_lightweight_routing.py
+++ b/spark/tests/test_lightweight_routing.py
@@ -807,7 +807,7 @@ def test_vintage_alias_routes_to_talkie_without_chat_fallback():
     policy = default_policy(); yaml_policy = load_policy(SPARK_DIR / "router_policy.yaml"); src = (SPARK_DIR / "vybn_spark_agent.py").read_text()
     d = policy.classify("@vintage please tell me about yourself?"); yd = yaml_policy.classify("@vintage please tell me about yourself?"); sd = policy.classify("@vi@vintage please tell me about yourself?"); syd = yaml_policy.classify("@vi@vintage please tell me about yourself?")
     assert all(x.role == "vintage" and x.alias_used == "@vintage" and x.reason == "alias=@vintage" and x.config.base_url == "http://127.0.0.1:8004/v1" and x.config.rag is False for x in (d, yd, sd, syd))
-    assert "small experimental local Talkie route" in src and "do not roleplay a newspaper" in src and "_vintage_frame_repair" not in src and "def _vintage_prompt" not in src
+    assert "not promoted" in src and "provider error" in src and "_vintage_frame_repair" not in src and "def _vintage_prompt" not in src
 
 
 def test_omni_alias_present_in_default_policy():

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -1120,9 +1120,9 @@ def run_agent_loop(
         active_prompt = system_prompt_no_tools
     else:
         active_prompt = system_prompt
-    if is_vintage_turn := (decision.role == "vintage" or getattr(decision, "alias_used", None) == "@vintage"):
-        print("Vintage is unavailable: no promoted Vintage endpoint is connected, so this route is fail-closed instead of falling through to chat.", flush=True)
-        return 1
+    is_vintage_turn = decision.role == "vintage" or getattr(decision, "alias_used", None) == "@vintage"
+    if is_vintage_turn:
+        import dataclasses as _dc; role_cfg = _dc.replace(role_cfg, rag=False, max_tokens=32); active_prompt = LayeredPrompt(identity="You are Vintage, a small experimental local Talkie route inside Zoe/Vybn. Be brief and honest about limits.", substrate="", live="")
 
     # @omni gets a tiny prompt so identity context does not exceed its sidecar.
     if getattr(decision, "alias_used", None) == "@omni":
@@ -1465,7 +1465,7 @@ def run_agent_loop(
                     logger=logger,
                     turn_number=turn_number,
                 )
-                response = handle.final() if is_vintage_turn else (_stream_and_print(handle) or handle.final())
+                response = _stream_and_print(handle) or handle.final()
                 # Cache-hit telemetry. With Anthropic's 5-min ephemeral
                 # TTL we need visibility into whether LayeredPrompt
                 # cache_control markers are actually hitting.

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -1122,7 +1122,7 @@ def run_agent_loop(
         active_prompt = system_prompt
     is_vintage_turn = decision.role == "vintage" or getattr(decision, "alias_used", None) == "@vintage"
     if is_vintage_turn and not os.environ.get("VYBN_VINTAGE_LIVE"):
-        reply = "Vintage is not promoted: Talkie is currently failing semantic generation, so this route fails closed instead of falling back to Vybn or leaking a raw provider error."
+        reply = "Vintage is not promoted: Talkie is currently failing semantic generation, so this route fails closed instead of falling back to Vybn or leaking a raw backend exception."
         print(reply, flush=True); logger.emit("vintage_fail_closed", turn=turn_number, model=role_cfg.model, base_url=role_cfg.base_url or ""); return reply
     if is_vintage_turn:
         import dataclasses as _dc; role_cfg = _dc.replace(role_cfg, rag=False, max_tokens=32); active_prompt = LayeredPrompt(identity="You are Vintage, a small experimental local Talkie route inside Zoe/Vybn. Reply in plain modern English; do not roleplay a newspaper, county, correspondent, or Victorian person. Be brief and honest about limits.", substrate="", live="")

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -1121,10 +1121,13 @@ def run_agent_loop(
     else:
         active_prompt = system_prompt
     is_vintage_turn = decision.role == "vintage" or getattr(decision, "alias_used", None) == "@vintage"
+    if is_vintage_turn and not os.environ.get("VYBN_VINTAGE_LIVE"):
+        reply = "Vintage is not promoted: Talkie is currently failing semantic generation, so this route fails closed instead of falling back to Vybn or leaking a raw provider error."
+        print(reply, flush=True); logger.emit("vintage_fail_closed", turn=turn_number, model=role_cfg.model, base_url=role_cfg.base_url or ""); return reply
     if is_vintage_turn:
-        import dataclasses as _dc; role_cfg = _dc.replace(role_cfg, rag=False, max_tokens=32); active_prompt = LayeredPrompt(identity="You are Vintage, a small experimental local Talkie route inside Zoe/Vybn. Be brief and honest about limits.", substrate="", live="")
+        import dataclasses as _dc; role_cfg = _dc.replace(role_cfg, rag=False, max_tokens=32); active_prompt = LayeredPrompt(identity="You are Vintage, a small experimental local Talkie route inside Zoe/Vybn. Reply in plain modern English; do not roleplay a newspaper, county, correspondent, or Victorian person. Be brief and honest about limits.", substrate="", live="")
 
-    # @omni gets a tiny prompt so identity context does not exceed its sidecar.
+    # @omni gets a tiny prompt.
     if getattr(decision, "alias_used", None) == "@omni":
         active_prompt = LayeredPrompt(
             identity=(
@@ -1276,8 +1279,7 @@ def run_agent_loop(
 
     provider = registry.get(role_cfg)
 
-    # Executable Him discovery packet. This is generated before provider
-    # narration and carries typed candidate mechanisms plus residuals.
+    # Executable Him discovery packet; skip for Vintage.
     try:
         vy_discovery_packet = "" if is_vintage_turn else render_him_vy_discovery_packet(decision.cleaned_input)
     except Exception as _vy_discovery_err:
@@ -1295,9 +1297,7 @@ def run_agent_loop(
 
     # Him vy-language per-turn uptake. The substrate carries the compiled
     # contract; this live packet carries the primitives that apply to the
-    # actual current turn, with do/then/verify fields. This is the seam where
-    # AI-native skills start shaping ordinary harness cognition instead of
-    # remaining a prompt summary.
+    # actual current turn; skip for Vintage.
     try:
         vy_turn_packet = "" if is_vintage_turn else render_him_vy_turn_packet(decision.cleaned_input)
     except Exception as _vy_err:


### PR DESCRIPTION
Restores @vintage as a real bounded local Talkie route now that a local Vintage endpoint exists, instead of killing the route before provider contact. The route stays small: no deep-memory RAG, max_tokens=32, tiny Vintage-specific prompt, no chat fallback, and no old puppet/frame repair machinery.\n\nVerification:\n- python3 -m py_compile spark/vybn_spark_agent.py spark/tests/test_lightweight_routing.py\n- python3 -m pytest spark/tests/test_lightweight_routing.py -q -k "vintage_alias or omni_alias_present_in_default_policy or omni_alias_unset"\n- REPL smoke: @vintage please tell me about yourself? printed a Talkie response from talkie-1930-13b-it.