### PR TITLE
fix: align Omni alias model id

### DIFF
--- a/spark/router_policy.yaml
+++ b/spark/router_policy.yaml
@@ -347,7 +347,7 @@ model_aliases:
   "@vintage": vintage-unavailable
   # @omni is explicit/operator-gated only: @omni plus VYBN_OMNI_URL; no
   # fallback, no heuristic route, no Super disturbance.
-  "@omni": nvidia/NVIDIA-Nemotron-Nano-Omni
+  "@omni": nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4
   "@gpt": gpt-5.5
   "@gpt5": gpt-5.5
   "@gpro": gpt-5.5-pro


### PR DESCRIPTION
Aligns the tracked router-policy @omni alias with the substrate default model id. Tests: python3 -m pytest spark/tests/test_lightweight_routing.py spark/tests/test_omni_window.py spark/tests/test_omni_window_script.py -q