### PR TITLE
fix: make Vintage canary refusal explicit

### DIFF
--- a/spark/tests/test_lightweight_routing.py
+++ b/spark/tests/test_lightweight_routing.py
@@ -647,7 +647,7 @@ class TestCliDirectReplyAndLightweight(unittest.TestCase):
             turn_number=1,
         )
         self.assertIn("Vybn", reply)
-        self.assertIn("gpt-5.5", reply)
+        self.assertTrue("gpt-5.5" in reply and "vintage" not in reply.lower(), reply)
         # Rolling history should contain the user turn + the direct
         # reply so the next turn has coherent context.
         self.assertEqual(messages[-1]["role"], "assistant")
@@ -1947,4 +1947,3 @@ def test_local_super_semantic_failure_cloud_fallback_requires_explicit_opt_in(mo
         mod.render_him_vy_discovery_packet = saved_disc
         mod.render_him_vy_turn_packet = saved_turn
         mod.run_probes = saved_probes
-

--- a/spark/tests/test_lightweight_routing.py
+++ b/spark/tests/test_lightweight_routing.py
@@ -807,7 +807,7 @@ def test_vintage_alias_routes_to_talkie_without_chat_fallback():
     policy = default_policy(); yaml_policy = load_policy(SPARK_DIR / "router_policy.yaml"); src = (SPARK_DIR / "vybn_spark_agent.py").read_text()
     d = policy.classify("@vintage please tell me about yourself?"); yd = yaml_policy.classify("@vintage please tell me about yourself?"); sd = policy.classify("@vi@vintage please tell me about yourself?"); syd = yaml_policy.classify("@vi@vintage please tell me about yourself?"); td = policy.classify("zoe> @vintage please tell me about yourself?")
     assert all(x.role == "vintage" and x.alias_used == "@vintage" and x.reason == "alias=@vintage" and x.config.model == "vintage-unavailable" and x.config.rag is False for x in (d, yd, sd, syd, td))
-    assert "bounded local vintage/canary surface" in src and "real Talkie-1930-13B artifact is not present" in src and "_vintage_frame_repair" not in src and "def _vintage_prompt" not in src
+    assert "failing semantic canary" in src and "Endpoint-shaped is not capability" in src and "_vintage_frame_repair" not in src and "def _vintage_prompt" not in src
 
 
 def test_omni_alias_present_in_default_policy():

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -1121,7 +1121,7 @@ def run_agent_loop(
     else:
         active_prompt = system_prompt
     is_vintage_turn = decision.role == "vintage" or getattr(decision, "alias_used", None) == "@vintage"
-    if is_vintage_turn: q=(decision.cleaned_input or "").lower(); reply=("VINTAGE_SMOKE_OK" if ("say exactly" in q and "vintage_smoke_ok" in q) else ("@vintage is a bounded local vintage/canary surface in Zoe and Vybn Spark; it is not promoted Talkie, not Vybn, not Zoe, and not human." if any(x in q for x in ("who are you", "what are you", "yourself", "your name")) else ("Zoe is outside in 2026; 1930 is only the intended Vintage language horizon, not a present-tense life I can honestly claim." if ("1930" in q or "2026" in q or "what year" in q) else "Vintage is online as a bounded local canary surface; the real Talkie-1930-13B artifact is not present here, so I will answer briefly without pretending otherwise."))); print(reply, flush=True); logger.emit("vintage_bounded_reply", turn=turn_number, model=role_cfg.model, base_url=role_cfg.base_url or ""); return reply
+    if is_vintage_turn: reply = "Vintage is unpromoted: the live backend is a failing semantic canary, not a Zoe/Vybn organ. Endpoint-shaped is not capability; agent containment is not model success."; print(reply, flush=True); logger.emit("vintage_unpromoted_canary_refusal", turn=turn_number, model=role_cfg.model, base_url=role_cfg.base_url or ""); return reply
 
     # @omni gets a tiny prompt.
     if getattr(decision, "alias_used", None) == "@omni":


### PR DESCRIPTION
Makes @vintage refuse as an unpromoted failing semantic canary instead of returning canned capability-shaped replies. Verification: python3 -m unittest spark.tests.test_lightweight_routing