### PR TITLE
fix: fail GPT-5.5 closed instead of Claude fallback

### DIFF
--- a/spark/harness/substrate.py
+++ b/spark/harness/substrate.py
@@ -904,7 +904,7 @@ _DEFAULT_FALLBACK: dict[str, list[str]] = {
     "claude-opus-4-7": ["claude-opus-4-6", "claude-sonnet-4-6"],
     "claude-opus-4-6": ["claude-opus-4-7", "claude-sonnet-4-6"],
     "claude-sonnet-4-6": ["claude-opus-4-6"],
-    "gpt-5.5": ["claude-sonnet-4-6", "claude-opus-4-6"],
+    "gpt-5.5": [],
     "gpt-5.5-pro": ["gpt-5.5"],
     # Local Nemotron roles fall to GPT-5.5 if vLLM is down.
     "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8": ["gpt-5.5"],

--- a/spark/router_policy.yaml
+++ b/spark/router_policy.yaml
@@ -323,7 +323,7 @@ fallback_chain:
   claude-opus-4-7: [claude-opus-4-6, claude-sonnet-4-6]
   claude-opus-4-6: [claude-opus-4-7, claude-sonnet-4-6]
   claude-sonnet-4-6: [claude-opus-4-6]
-  gpt-5.5: [claude-opus-4-6, claude-sonnet-4-6]
+  gpt-5.5: []
   nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8: [gpt-5.5]
   gpt-5.5-pro: [gpt-5.5]
 

--- a/spark/tests/test_harness.py
+++ b/spark/tests/test_harness.py
@@ -863,7 +863,7 @@ class TestFallbackConstructionIsLazy(unittest.TestCase):
         # never have been asked for any model.
         self.assertEqual(constructed, [])
 
-    def test_walks_to_lazy_fallback_when_primary_fails(self):
+    def test_gpt55_primary_failure_fails_closed_without_claude_fallback(self):
         import vybn_spark_agent as agent
         from harness.substrate import RoleConfig, default_policy
 
@@ -874,45 +874,33 @@ class TestFallbackConstructionIsLazy(unittest.TestCase):
 
         constructed: list[str] = []
 
-        class _DummyHandle:
-            pass
-
         class _FailingPrimary:
             def stream(self, **_kw):
                 raise RuntimeError("OpenAIProvider needs either the openai SDK or requests")
 
-        class _DummyFallback:
-            def stream(self, **_kw):
-                return _DummyHandle()
-
         class _RecordingRegistry:
             def get(self, cfg):
                 constructed.append(cfg.model)
-                return _DummyFallback()
+                raise AssertionError("GPT-5.5 must not construct a Claude fallback")
 
         class _DummyLogger:
             def emit(self, *_a, **_kw):
                 pass
 
-        handle, cfg, prov = agent._stream_with_fallback(
-            router=type("R", (), {"policy": policy})(),
-            registry=_RecordingRegistry(),
-            role_cfg=primary_cfg,
-            provider=_FailingPrimary(),
-            system_prompt=None,
-            messages=[],
-            tools=[],
-            logger=_DummyLogger(),
-            turn_number=1,
-            retries=0,
-        )
-        self.assertIsInstance(handle, _DummyHandle)
-        # First fallback (claude-sonnet-4-6) was constructed lazily
-        # only after the primary failed. Subsequent fallback models in
-        # the chain may also have been constructed; what matters is
-        # the registry was not touched before the primary call.
-        self.assertGreaterEqual(len(constructed), 1)
-        self.assertEqual(constructed[0], "claude-sonnet-4-6")
+        with self.assertRaisesRegex(RuntimeError, "OpenAIProvider needs"):
+            agent._stream_with_fallback(
+                router=type("R", (), {"policy": policy})(),
+                registry=_RecordingRegistry(),
+                role_cfg=primary_cfg,
+                provider=_FailingPrimary(),
+                system_prompt=None,
+                messages=[],
+                tools=[],
+                logger=_DummyLogger(),
+                turn_number=1,
+                retries=0,
+            )
+        self.assertEqual(constructed, [])
 
 
 class TestHimOSHarnessBridge(unittest.TestCase):

--- a/spark/tests/test_lightweight_routing.py
+++ b/spark/tests/test_lightweight_routing.py
@@ -1947,3 +1947,9 @@ def test_local_super_semantic_failure_cloud_fallback_requires_explicit_opt_in(mo
         mod.render_him_vy_discovery_packet = saved_disc
         mod.render_him_vy_turn_packet = saved_turn
         mod.run_probes = saved_probes
+
+
+def test_gpt55_has_no_cross_provider_fallback():
+    from harness.substrate import default_policy, load_policy
+    assert default_policy().fallback_chain.get("gpt-5.5") == []
+    assert load_policy(SPARK_DIR / "router_policy.yaml").fallback_chain.get("gpt-5.5") == []


### PR DESCRIPTION
Makes GPT-5.5 an exact model promise instead of a cross-provider capability class: OpenAI/GPT-5.5 failures now fail closed rather than silently falling back to Claude. Updates in-code and YAML fallback chains and regression tests.\n\nVerification:\n- python3 -m unittest spark.tests.test_harness.TestFallbackConstructionIsLazy spark.tests.test_lightweight_routing -q\n- python3 -m unittest discover -s spark/tests -q\n- git diff --check