### PR TITLE
fix: require Vintage alias at prompt start

### DIFF
--- a/spark/harness/substrate.py
+++ b/spark/harness/substrate.py
@@ -463,10 +463,6 @@ class Policy:
                     if alias_key == "@vintage" and "vintage" in self.roles:
                         return RouteDecision(role="vintage", config=self.role("vintage"), cleaned_input=text, reason="alias=@vintage", model_override=model_override, alias_used=alias_used)
 
-        if "@vintage" in text.lower() and "vintage" in self.roles:
-            idx = text.lower().find("@vintage")
-            cleaned = text[idx + len("@vintage"):].lstrip() or "hi"
-            return RouteDecision(role="vintage", config=self.role("vintage"), cleaned_input=cleaned, reason="alias=@vintage", model_override=aliases.get("@vintage"), alias_used="@vintage")
 
         # 1. Directive
         for prefix, role_name in self.directives.items():

--- a/spark/tests/test_lightweight_routing.py
+++ b/spark/tests/test_lightweight_routing.py
@@ -803,6 +803,10 @@ def test_opus47_has_fallback_chain():
 
 
 
+def test_vintage_alias_is_prefix_only_for_long_prompts():
+    text = ("normal long prompt " * 500) + " quoted text mentions @vintage but did not pin it"
+    assert default_policy().classify(text).role != "vintage" and default_policy().classify("@vintage " + text).role == "vintage"
+
 def test_vintage_alias_routes_to_talkie_without_chat_fallback():
     policy = default_policy(); yaml_policy = load_policy(SPARK_DIR / "router_policy.yaml"); src = (SPARK_DIR / "vybn_spark_agent.py").read_text()
     d = policy.classify("@vintage please tell me about yourself?"); yd = yaml_policy.classify("@vintage please tell me about yourself?"); sd = policy.classify("@vi@vintage please tell me about yourself?"); syd = yaml_policy.classify("@vi@vintage please tell me about yourself?"); td = policy.classify("zoe> @vintage please tell me about yourself?")


### PR DESCRIPTION
Stops long prompts from routing to Vintage merely because their quoted/context text contains @vintage. Vintage now requires the normal leading alias path.

Verification:
- python3 -m unittest spark.tests.test_lightweight_routing -q
- python3 -m unittest discover -s spark/tests -q
- routing smoke for long quoted @vintage text vs explicit @vintage prefix