### PR TITLE
fix: name Super as main local surface

### DIFF
--- a/spark/harness/substrate.py
+++ b/spark/harness/substrate.py
@@ -933,8 +933,8 @@ _DEFAULT_MODEL_ALIASES: dict[str, str] = {
     # the user explicitly prefixes a turn with @omni AND the operator has
     # exported VYBN_OMNI_URL pointing at a started Omni endpoint. The alias
     # is intentionally absent from heuristics, directives, fallback_chain,
-    # and ordinary chat routing so Super topology (always-on, both Sparks)
-    # is never silently interrupted. Without VYBN_OMNI_URL the alias surfaces
+    # and ordinary chat routing so Super stays the main local model surface,
+    # not the main substrate, and is never silently substituted for Omni. Without VYBN_OMNI_URL the alias surfaces
     # an explicit error rather than falling back to Super's :8000. Optional
     # VYBN_OMNI_MODEL overrides the default model id below. Optional
     # VYBN_OMNI_PERCEPTION=<path> rides a bounded operator-supplied

--- a/spark/tests/test_lightweight_routing.py
+++ b/spark/tests/test_lightweight_routing.py
@@ -1006,7 +1006,7 @@ def test_omni_perception_preamble_runs_on_explicit_omni_turn(tmp_path=None):
 def test_omni_perception_skipped_when_url_unset():
     """If VYBN_OMNI_URL is unset, the @omni turn refuses with the
     explicit error envelope and the perception path is never opened —
-    even if VYBN_OMNI_PERCEPTION points at a real file. Super topology
+    even if VYBN_OMNI_PERCEPTION points at a real file. Super is the main local model surface, not the main substrate; local topology
     is preserved (no provider call)."""
     import importlib.util as _ilu
     import os as _os

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -1009,8 +1009,8 @@ def run_agent_loop(
                     "Start the Omni endpoint on the peer Spark and "
                     "export VYBN_OMNI_URL=http://<host>:<port>/v1 "
                     "before retrying. This turn will not silently "
-                    "fall back to Super (:8000) — Super topology is "
-                    "preserved.]"
+                    "fall back to Super (:8000) — Super is the main local model surface, "
+                    "not the main substrate.]"
                 )
             override_model = (
                 os.environ.get("VYBN_OMNI_MODEL") or override_model


### PR DESCRIPTION
Corrects the harness language Zoe caught: Super is the main local model surface, not the main substrate, and Omni must not silently fall back to Super.

Verification:
- python3 -m py_compile spark/harness/substrate.py spark/vybn_spark_agent.py spark/tests/test_lightweight_routing.py
- python3 -m unittest spark.tests.test_lightweight_routing -q
- git diff --check