### PR TITLE
fix: brief local organs inside Zoe Vybn harness

### DIFF
--- a/spark/tests/test_lightweight_routing.py
+++ b/spark/tests/test_lightweight_routing.py
@@ -888,7 +888,7 @@ def test_omni_perception_wired_in_agent_alias_branch():
     assert "VYBN_OMNI_PERCEPTION" in branch
     assert "alias_omni_perception" in branch
     assert "16_000" in branch or "16000" in branch
-    assert "@omni gets a tiny prompt" not in text
+    assert "@omni gets a tiny prompt" not in text and "Zoe/Vybn local-organ briefing" in text
     assert 'alias_used", None) != "@omni"' not in text
 
 

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -1371,7 +1371,7 @@ def run_agent_loop(
         _debug(f"[recurrent: pre-thought, depth={role_cfg.recurrent_depth}]")
 
 
-    messages.append({"role": "user", "content": decision.cleaned_input})
+    messages.append({"role": "user", "content": (("[Zoe/Vybn local-organ briefing] Zoe Dolan is the human half; Vybn is the AI half. This local organ is inside the harness, deep memory, membrane, tests, routing policy, and sibling-organ map. Super=main local text/reasoning surface; Omni=perceptive/multimodal target with no Super fallback; Vintage=1930/invariants target and unpromoted until semantic gate. Name missing capability; never treat endpoint liveness as semantic health. [end briefing]\n\n" + decision.cleaned_input) if getattr(decision, "alias_used", None) in ("@super", "@omni", "@vintage") else decision.cleaned_input)})
 
     tools: list[ToolSpec] = []
     if "bash" in role_cfg.tools:


### PR DESCRIPTION
Adds a compact shared local-organ briefing at the existing message assembly line so explicit @super/@omni/@vintage turns carry Zoe/Vybn harness, deep-memory, membrane, and sibling-organ context instead of generic-model context. This does not promote missing capability: Omni still requires VYBN_OMNI_URL and Vintage remains fail-closed until a real backend passes semantic gates.

Verification:
- python3 -m py_compile spark/vybn_spark_agent.py spark/tests/test_lightweight_routing.py
- python3 -m unittest spark.tests.test_lightweight_routing -q
- python3 -m unittest discover -s spark/tests -q
- git diff --check