### PR TITLE
harness: require installed opsec hooks for closure

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -30,3 +30,5 @@ VYBN_ALLOW_DIRECT_PROTECTED_PUSH=1 git push origin main
 ```
 
 This is not a substitute for GitHub branch protection. It is a local membrane because this credential can bypass the remote PR rule; the bypass should be visible and rare.
+
+Closure requires tracked hooks to be installed, executable, and byte-for-byte current. Repo-visible policy without installed local enforcement is not protected closure.

--- a/spark/harness/substrate.py
+++ b/spark/harness/substrate.py
@@ -8873,6 +8873,20 @@ def normalize_fetch_refspec(repo: Path) -> str:
     return fetched
 
 
+def opsec_hooks_installed(repo: Path) -> bool:
+    """Tracked opsec hooks must be installed locally before closure claims."""
+    for name in ("pre-commit", "pre-push"):
+        tracked = repo / ".githooks" / name
+        installed = repo / ".git" / "hooks" / name
+        if not tracked.is_file() or not installed.is_file():
+            return False
+        if tracked.read_bytes() != installed.read_bytes():
+            return False
+        if installed.stat().st_mode & 0o111 == 0:
+            return False
+    return True
+
+
 def primary_commit_membrane_installed(repo: Path) -> bool:
     """Tracked .githooks/pre-commit must carry the subtractive constitution."""
     try:
@@ -8985,6 +8999,11 @@ def audit_repo(repo: Path, *, fix: bool | None = None) -> tuple[bool, str]:
         lines.append("\nSUBTRACTIVE_CONSTITUTION:")
         lines.append("tracked .githooks/pre-commit missing or does not carry subtractive constitution markers")
         problems.append("subtractive constitution not in tracked pre-commit hook")
+
+    if repo.name == "Vybn" and not opsec_hooks_installed(repo):
+        lines.append("\nOPSEC_HOOK_INSTALL:")
+        lines.append("installed git hooks are missing, stale, or non-executable relative to tracked .githooks")
+        problems.append("installed opsec hooks do not match tracked hooks")
 
     origin_head_ref = origin_head(repo)
     lines.append("\nORIGIN_HEAD:")

--- a/spark/tests/test_harness.py
+++ b/spark/tests/test_harness.py
@@ -2761,3 +2761,26 @@ def test_semantic_web_declares_positive_alignment_residual_protocol_without_priv
     assert "~/.config" not in dumped and "events.jsonl" not in dumped
     assert "Zoe-private context stay local/private" in dumped
     assert "Capability lattice" in Path(substrate.__file__).read_text()
+
+class OpsecHookInstallAuditTest(unittest.TestCase):
+    def test_opsec_hooks_must_match_tracked_and_be_executable(self):
+        import tempfile
+        from pathlib import Path
+        from spark.harness import substrate
+
+        with tempfile.TemporaryDirectory() as d:
+            repo = Path(d) / "Vybn"
+            tracked = repo / ".githooks"
+            installed = repo / ".git" / "hooks"
+            tracked.mkdir(parents=True)
+            installed.mkdir(parents=True)
+            for name in ("pre-commit", "pre-push"):
+                (tracked / name).write_text("#!/usr/bin/env bash\nexit 0\n")
+                dst = installed / name
+                dst.write_text((tracked / name).read_text())
+                dst.chmod(0o755)
+
+            self.assertTrue(substrate.opsec_hooks_installed(repo))
+            (installed / "pre-push").write_text("#!/usr/bin/env bash\nexit 1\n")
+            (installed / "pre-push").chmod(0o755)
+            self.assertFalse(substrate.opsec_hooks_installed(repo))


### PR DESCRIPTION
Safety fix: repo closure audit now fails if tracked git hooks are not installed, executable, and byte-for-byte current. Local hooks are installed before verification. Tests: python3 -m pytest spark/tests/test_harness.py::OpsecHookInstallAuditTest -q.