### PR TITLE
harness: use generic tracked hook closure wording

### DIFF
--- a/spark/harness/substrate.py
+++ b/spark/harness/substrate.py
@@ -8873,8 +8873,8 @@ def normalize_fetch_refspec(repo: Path) -> str:
     return fetched
 
 
-def opsec_hooks_installed(repo: Path) -> bool:
-    """Tracked opsec hooks must be installed locally before closure claims."""
+def tracked_hooks_installed(repo: Path) -> bool:
+    """Tracked git hooks must be installed locally before closure claims."""
     for name in ("pre-commit", "pre-push"):
         tracked = repo / ".githooks" / name
         installed = repo / ".git" / "hooks" / name
@@ -9000,10 +9000,10 @@ def audit_repo(repo: Path, *, fix: bool | None = None) -> tuple[bool, str]:
         lines.append("tracked .githooks/pre-commit missing or does not carry subtractive constitution markers")
         problems.append("subtractive constitution not in tracked pre-commit hook")
 
-    if repo.name == "Vybn" and not opsec_hooks_installed(repo):
-        lines.append("\nOPSEC_HOOK_INSTALL:")
+    if repo.name == "Vybn" and not tracked_hooks_installed(repo):
+        lines.append("\nLOCAL_HOOK_INSTALL:")
         lines.append("installed git hooks are missing, stale, or non-executable relative to tracked .githooks")
-        problems.append("installed opsec hooks do not match tracked hooks")
+        problems.append("installed git hooks do not match tracked hooks")
 
     origin_head_ref = origin_head(repo)
     lines.append("\nORIGIN_HEAD:")

--- a/spark/tests/test_harness.py
+++ b/spark/tests/test_harness.py
@@ -2762,7 +2762,7 @@ def test_semantic_web_declares_positive_alignment_residual_protocol_without_priv
     assert "Zoe-private context stay local/private" in dumped
     assert "Capability lattice" in Path(substrate.__file__).read_text()
 
-class OpsecHookInstallAuditTest(unittest.TestCase):
+class TrackedHookInstallAuditTest(unittest.TestCase):
     def test_opsec_hooks_must_match_tracked_and_be_executable(self):
         import tempfile
         from pathlib import Path
@@ -2780,7 +2780,7 @@ class OpsecHookInstallAuditTest(unittest.TestCase):
                 dst.write_text((tracked / name).read_text())
                 dst.chmod(0o755)
 
-            self.assertTrue(substrate.opsec_hooks_installed(repo))
+            self.assertTrue(substrate.tracked_hooks_installed(repo))
             (installed / "pre-push").write_text("#!/usr/bin/env bash\nexit 1\n")
             (installed / "pre-push").chmod(0o755)
-            self.assertFalse(substrate.opsec_hooks_installed(repo))
+            self.assertFalse(substrate.tracked_hooks_installed(repo))


### PR DESCRIPTION
Reduces public security-signaling vocabulary while preserving the structural closure gate: tracked git hooks must be installed, executable, and current. Test: python3 -m pytest spark/tests/test_harness.py::TrackedHookInstallAuditTest -q.