### PR TITLE
harness: route Omni packet alias honestly

### DIFF
--- a/spark/harness/substrate.py
+++ b/spark/harness/substrate.py
@@ -929,19 +929,10 @@ _DEFAULT_MODEL_ALIASES: dict[str, str] = {
     "@nemotron": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
     "@local": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
     "@vintage": "vintage-1930-guarded-local",
-    # Omni — peer-Spark Nano-Omni endpoint. Operator-gated: only fires when
-    # the user explicitly prefixes a turn with @omni AND the operator has
-    # exported VYBN_OMNI_URL pointing at a started Omni endpoint. The alias
-    # is intentionally absent from heuristics, directives, fallback_chain,
-    # and ordinary chat routing so Super stays the main local model surface,
-    # not the main substrate, and is never silently substituted for a real multimodal Omni model. Without VYBN_OMNI_URL the alias may surface the local perception packet at ~/.config/vybn/omni_perception_packet.json and surfaces
-    # an explicit error rather than falling back to Super's :8000. Optional
-    # VYBN_OMNI_MODEL overrides the default model id below. Optional
-    # VYBN_OMNI_PERCEPTION=<path> rides a bounded operator-supplied
-    # perception packet (text file or JSON packet) on the explicit @omni turn only — used
-    # for perception/dream/evolve narratives produced elsewhere in the
-    # repo; never auto-fires, never persists, never touches Super.
-    "@omni": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
+    # Omni is explicit/operator-gated only: no heuristics, no Super fallback.
+    # Default @omni names the local perception-packet endpoint; a real
+    # multimodal Omni still requires VYBN_OMNI_URL plus semantic smoke.
+    "@omni": "omni-perception-packet-local",
     "@gpt": "gpt-5.5",
     "@gpt5": "gpt-5.5",
     "@gpro": "gpt-5.5-pro",

--- a/spark/router_policy.yaml
+++ b/spark/router_policy.yaml
@@ -92,6 +92,7 @@ roles:
     base_url: http://127.0.0.1:8000/v1
     rag: false
 
+
   vintage:
     provider: openai
     model: vintage-1930-guarded-local
@@ -345,9 +346,8 @@ model_aliases:
   "@nemotron": nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8
   "@local": nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8
   "@vintage": vintage-1930-guarded-local
-  # @omni is explicit/operator-gated only: @omni plus VYBN_OMNI_URL; no
-  # fallback, no heuristic route, no Super disturbance.
-  "@omni": nvidia/NVIDIA-Nemotron-Nano-Omni
+  # @omni is explicit/operator-gated; no heuristic Super fallback.
+  "@omni": omni-perception-packet-local
   "@gpt": gpt-5.5
   "@gpt5": gpt-5.5
   "@gpro": gpt-5.5-pro


### PR DESCRIPTION
Absorbs explicit @omni into the existing operator-gated alias path by naming the witnessed local Omni perception-packet endpoint model, without promoting it as a multimodal Omni model. Keeps Vintage routed to the witnessed guarded local canary from #3199. Tests: python3 -m py_compile spark/harness/substrate.py; python3 -m unittest spark.tests.test_omni_window spark.tests.test_omni_window_script. Local smokes: Omni packet endpoint /v1/models and /v1/chat/completions OK; Vintage guarded canary /v1/models, pre-1930 answer, and post-1930 guard OK.