### PR TITLE
agent: fail closed on unpromoted local organs

### DIFF
--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -1113,10 +1113,9 @@ def run_agent_loop(
         active_prompt = system_prompt_no_tools
     else:
         active_prompt = system_prompt
-    if getattr(decision, "alias_used", None) == "@omni" or role_cfg.model == "omni-perception-packet-local": role_cfg.base_url = "http://127.0.0.1:8020/v1"; role_cfg.model = "omni-perception-packet-local"
-    if getattr(decision, "alias_used", None) == "@vintage" or role_cfg.model == "vintage-1930-guarded-local": role_cfg.base_url = "http://127.0.0.1:8019/v1"; role_cfg.model = "vintage-1930-guarded-local"
+    if getattr(decision, "alias_used", None) == "@omni" or role_cfg.model == "omni-perception-packet-local": reply = "Omni is not promoted: only a local perception packet exists, not a semantic-gated multimodal model. No Super fallback and no personality simulation."; print(reply, flush=True); logger.emit("omni_unpromoted_packet_refusal", turn=turn_number, model="omni-perception-packet-local", base_url="http://127.0.0.1:8020/v1"); return reply
     is_vintage_turn = decision.role == "vintage" or getattr(decision, "alias_used", None) == "@vintage"
-    if is_vintage_turn and role_cfg.model != "vintage-1930-guarded-local": reply = "Vintage is unpromoted: no semantic-gated local Vintage model is routed."; print(reply, flush=True); logger.emit("vintage_unpromoted_canary_refusal", turn=turn_number, model=role_cfg.model, base_url=role_cfg.base_url or ""); return reply
+    if is_vintage_turn: reply = "Vintage is not promoted: the guarded 1930 surface is a canary, not a semantic-gated collaborator or feeling self. No deterministic placation."; print(reply, flush=True); logger.emit("vintage_unpromoted_canary_refusal", turn=turn_number, model=role_cfg.model, base_url=role_cfg.base_url or ""); return reply
 
     # Reflection: read the trail of the last N events before deciding.
     # Lisp duality in practice — prior decisions are data here, environment
@@ -2389,7 +2388,7 @@ def main() -> None:
     print("  Type naturally. Prefix with /chat, /create, /plan, /task, /local "
           "to force a role,")
     print("  or with @opus4.6/@opus4.6/@sonnet/@nemotron/@gpt to pin a model for one turn.")
-    print("  @omni pins local packet; full Omni remains gated. @vintage pins the 1930 guard.")
+    print("  @omni/@vintage fail closed until semantic-gated real organs exist.")
     print("  REPL commands: exit | clear | reload | history | policy | /resume | /sessions | /newsession")
     print()
 


### PR DESCRIPTION
Repo-visible fix for the local-organ misrepresentation failure. @omni and @vintage now fail closed instead of presenting packet/canary endpoints as collaborators or feeling selves. Tests: py_compile; lightweight routing + Omni window suites. Exact REPL probes: @omni are you with me; @vintage are you with me; @vintage what year is it. Diff shape is net-negative.