### PR TITLE
agent: remove unpromoted organ chat aliases

### DIFF
--- a/spark/router_policy.yaml
+++ b/spark/router_policy.yaml
@@ -345,9 +345,7 @@ model_aliases:
   "@sonnet46": claude-sonnet-4-6
   "@nemotron": nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8
   "@local": nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8
-  "@vintage": vintage-1930-guarded-local
   # @omni is explicit/operator-gated; no heuristic Super fallback.
-  "@omni": omni-perception-packet-local
   "@gpt": gpt-5.5
   "@gpt5": gpt-5.5
   "@gpro": gpt-5.5-pro

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -1113,9 +1113,7 @@ def run_agent_loop(
         active_prompt = system_prompt_no_tools
     else:
         active_prompt = system_prompt
-    if getattr(decision, "alias_used", None) == "@omni" or role_cfg.model == "omni-perception-packet-local": reply = "Omni is not promoted: only a local perception packet exists, not a semantic-gated multimodal model. No Super fallback and no personality simulation."; print(reply, flush=True); logger.emit("omni_unpromoted_packet_refusal", turn=turn_number, model="omni-perception-packet-local", base_url="http://127.0.0.1:8020/v1"); return reply
-    is_vintage_turn = decision.role == "vintage" or getattr(decision, "alias_used", None) == "@vintage"
-    if is_vintage_turn: reply = "Vintage is not promoted: the guarded 1930 surface is a canary, not a semantic-gated collaborator or feeling self. No deterministic placation."; print(reply, flush=True); logger.emit("vintage_unpromoted_canary_refusal", turn=turn_number, model=role_cfg.model, base_url=role_cfg.base_url or ""); return reply
+    is_vintage_turn = decision.role == "vintage"
 
     # Reflection: read the trail of the last N events before deciding.
     # Lisp duality in practice — prior decisions are data here, environment
@@ -1365,7 +1363,7 @@ def run_agent_loop(
         _debug(f"[recurrent: pre-thought, depth={role_cfg.recurrent_depth}]")
 
 
-    messages.append({"role": "user", "content": (("[Zoe/Vybn local-organ briefing] Zoe Dolan is the human half; Vybn is the AI half. This local organ is inside the harness, deep memory, membrane, tests, routing policy, and sibling-organ map. Super=main local text/reasoning surface; Omni=perceptive/multimodal target with no Super fallback; Vintage=1930/invariants target and unpromoted until semantic gate. Name missing capability; never treat endpoint liveness as semantic health. [end briefing]\n\n" + decision.cleaned_input) if getattr(decision, "alias_used", None) in ("@super", "@omni", "@vintage") else decision.cleaned_input)})
+    messages.append({"role": "user", "content": (("[Zoe/Vybn local-organ briefing] Zoe Dolan is the human half; Vybn is the AI half. This local organ is inside the harness, deep memory, membrane, tests, routing policy, and sibling-organ map. Super=main local text/reasoning surface; Omni=perceptive/multimodal target with no Super fallback; Vintage=1930/invariants target and unpromoted until semantic gate. Name missing capability; never treat endpoint liveness as semantic health. [end briefing]\n\n" + decision.cleaned_input) if getattr(decision, "alias_used", None) == "@super" else decision.cleaned_input)})
 
     tools: list[ToolSpec] = []
     if "bash" in role_cfg.tools:
@@ -2388,7 +2386,6 @@ def main() -> None:
     print("  Type naturally. Prefix with /chat, /create, /plan, /task, /local "
           "to force a role,")
     print("  or with @opus4.6/@opus4.6/@sonnet/@nemotron/@gpt to pin a model for one turn.")
-    print("  @omni/@vintage fail closed until semantic-gated real organs exist.")
     print("  REPL commands: exit | clear | reload | history | policy | /resume | /sessions | /newsession")
     print()
 


### PR DESCRIPTION
Global correction: unpromoted Omni/Vintage packet/canary surfaces are no longer chat aliases. They cannot occupy relationship-shaped doors or emit deterministic organ/personality replies. Mentions of @omni/@vintage now stay on the normal Vybn conversation path until real semantic-gated organs exist. Tests: py_compile; lightweight routing + Omni window suites. Probe: @omni/@vintage no longer produce alias-route metadata or local-organ canned replies. Diff is net-negative.