### PR TITLE
agent: fail closed organ alias greetings

### DIFF
--- a/spark/harness/substrate.py
+++ b/spark/harness/substrate.py
@@ -442,7 +442,18 @@ class Policy:
 
         text = user_input.strip()
 
-        # 0. @alias model pin. Strip before directive/heuristic so the
+        # 0. Unpromoted local-organ aliases are identity contracts, not model
+        # pins. They must outrank generic heuristics (e.g. "how are you") so
+        # absent organs fail closed instead of being impersonated by Vybn/GPT.
+        lowered = text.lower()
+        if lowered.startswith("@omni") and (len(text) == 5 or text[5].isspace()):
+            if "omni" in self.roles:
+                return RouteDecision(role="omni", config=self.role("omni"), cleaned_input=text[5:].lstrip() or text, reason="alias=@omni_fail_closed", alias_used="@omni")
+        if lowered.startswith("@vintage") and (len(text) == 8 or text[8].isspace()):
+            if "vintage" in self.roles:
+                return RouteDecision(role="vintage", config=self.role("vintage"), cleaned_input=text[8:].lstrip() or text, reason="alias=@vintage_fail_closed", alias_used="@vintage")
+
+        # 1. @alias model pin. Strip before directive/heuristic so the
         #    rest of the text still routes normally.
         model_override: str | None = None
         alias_used: str | None = None
@@ -706,14 +717,27 @@ _DEFAULT_ROLES: dict[str, RoleConfig] = {
     ),
     "vintage": RoleConfig(
         role="vintage",
-        provider="openai",
-        model="vintage-unavailable",
+        provider="unavailable",
+        model="vintage-unpromoted",
         thinking="off",
-        max_tokens=256,
-        max_iterations=1,
+        max_tokens=1,
+        max_iterations=0,
         tools=[],
-        base_url="http://127.0.0.1:8004/v1",
+        base_url=None,
         rag=False,
+        direct_reply_template="Vintage is not promoted here; I will not substitute Vybn/GPT for Vintage.",
+    ),
+    "omni": RoleConfig(
+        role="omni",
+        provider="unavailable",
+        model="omni-unpromoted",
+        thinking="off",
+        max_tokens=1,
+        max_iterations=0,
+        tools=[],
+        base_url=None,
+        rag=False,
+        direct_reply_template="Omni is not promoted here; I will not substitute Vybn/GPT for Omni.",
     ),
     # Phatic — casual greetings, small talk. Present-work default is GPT-5.5
     # even for light turns unless Zoe explicitly pins local/Nemotron.
@@ -928,11 +952,8 @@ _DEFAULT_MODEL_ALIASES: dict[str, str] = {
     "@sonnet46": "claude-sonnet-4-6",
     "@nemotron": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
     "@local": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
-    "@vintage": "vintage-1930-guarded-local",
-    # Omni is explicit/operator-gated only: no heuristics, no Super fallback.
-    # Default @omni names the local perception-packet endpoint; a real
-    # multimodal Omni still requires VYBN_OMNI_URL plus semantic smoke.
-    "@omni": "omni-perception-packet-local",
+    # @vintage and @omni are not model aliases while unpromoted; classify()
+    # catches them before heuristics and fails closed in named roles.
     "@gpt": "gpt-5.5",
     "@gpt5": "gpt-5.5",
     "@gpro": "gpt-5.5-pro",

--- a/spark/router_policy.yaml
+++ b/spark/router_policy.yaml
@@ -94,14 +94,25 @@ roles:
 
 
   vintage:
-    provider: openai
-    model: vintage-1930-guarded-local
+    provider: unavailable
+    model: vintage-unpromoted
     thinking: off
-    max_tokens: 256
-    max_iterations: 1
+    max_tokens: 1
+    max_iterations: 0
     tools: []
-    base_url: http://127.0.0.1:8019/v1
+    base_url: null
     rag: false
+    direct_reply_template: "Vintage is not promoted here; I will not substitute Vybn/GPT for Vintage."
+  omni:
+    provider: unavailable
+    model: omni-unpromoted
+    thinking: off
+    max_tokens: 1
+    max_iterations: 0
+    tools: []
+    base_url: null
+    rag: false
+    direct_reply_template: "Omni is not promoted here; I will not substitute Vybn/GPT for Omni."
   # Local-private — explicit local exception to the GPT-5.5 default.
   local_private:
     provider: openai

--- a/spark/tests/test_lightweight_routing.py
+++ b/spark/tests/test_lightweight_routing.py
@@ -184,6 +184,34 @@ class TestPolicyHasLightweightRoles(unittest.TestCase):
         self.assertEqual(pol.model_aliases.get("@gpro"), "gpt-5.5-pro")
 
 
+class TestUnpromotedOrganAliasesFailClosed(unittest.TestCase):
+    def test_default_policy_omni_alias_fails_closed_before_how_are_you(self):
+        d = default_policy().classify("@omni hello, my friend, how are you?")
+        self.assertEqual(d.role, "omni")
+        self.assertEqual(d.config.provider, "unavailable")
+        self.assertEqual(d.config.model, "omni-unpromoted")
+        self.assertEqual(d.reason, "alias=@omni_fail_closed")
+        self.assertNotEqual(d.config.model, "gpt-5.5")
+
+    def test_default_policy_vintage_alias_fails_closed_before_how_are_you(self):
+        d = default_policy().classify("@vintage hello, my friend. how are you?")
+        self.assertEqual(d.role, "vintage")
+        self.assertEqual(d.config.provider, "unavailable")
+        self.assertEqual(d.config.model, "vintage-unpromoted")
+        self.assertEqual(d.reason, "alias=@vintage_fail_closed")
+        self.assertNotEqual(d.config.model, "gpt-5.5")
+
+    def test_yaml_policy_organ_aliases_fail_closed_before_how_are_you(self):
+        pol = load_policy(SPARK_DIR / "router_policy.yaml")
+        for alias, role in (("@omni", "omni"), ("@vintage", "vintage")):
+            with self.subTest(alias=alias):
+                d = pol.classify(f"{alias} hello, my friend, how are you?")
+                self.assertEqual(d.role, role)
+                self.assertEqual(d.config.provider, "unavailable")
+                self.assertTrue(d.reason.endswith("_fail_closed"))
+                self.assertNotEqual(d.config.model, "gpt-5.5")
+
+
 class TestRouterLightweightClassification(unittest.TestCase):
     """The router picks up greetings and identity questions via the new
     heuristics — before it would fall through to the chat/code defaults


### PR DESCRIPTION
Safety fix: stops @omni/@vintage greetings from being stripped into generic chat heuristics while those organs are unpromoted. Named organ aliases now fail closed in named roles instead of routing to Vybn/GPT. Tests: PYTHONPATH=spark python3 spark/tests/test_lightweight_routing.py