### PR TITLE
spark/health: report probe-budget timeout as indeterminate, not fail-closed

### DIFF
--- a/spark/server.py
+++ b/spark/server.py
@@ -1628,6 +1628,9 @@ async def _probe_deep_search_capability() -> dict:
       live: live memory API answered (loopback service role).
       stale-fallback: live API down, absorbed Him phase fallback answered.
       fail-closed: neither path answered; tool will refuse rather than improvise.
+      indeterminate: probe did not finish within its budget; the tool itself
+        remains the authority — /health learned nothing, which is not the
+        same as the tool refusing.
     Bounded by HEALTH_PROBE_BUDGET_S so /health cannot hang. No external
     coordinates or topology are leaked — only loopback/service-role
     language is acceptable here.
@@ -1654,7 +1657,11 @@ async def _probe_deep_search_capability() -> dict:
     try:
         return await asyncio.wait_for(_do_probe(), timeout=HEALTH_PROBE_BUDGET_S)
     except asyncio.TimeoutError:
-        return {"state": "fail-closed", "reason": "probe-budget-exceeded"}
+        # Budget exhausted before either path answered. We did not observe
+        # the tool refusing — we only failed to learn in time. Reporting
+        # "fail-closed" here would overclaim and fragment from tool truth
+        # (the tool itself can still be live). Stay honest: indeterminate.
+        return {"state": "indeterminate", "reason": "probe-budget-exceeded"}
 
 
 async def health_endpoint(request: Request) -> Response:
@@ -1666,11 +1673,11 @@ async def health_endpoint(request: Request) -> Response:
     here; it does not overclaim "ok" for the whole MCP surface.
     """
     deep = await _probe_deep_search_capability()
-    probed_rollup = (
-        "live" if deep["state"] == "live"
-        else "stale-fallback" if deep["state"] == "stale-fallback"
-        else "fail-closed"
-    )
+    # Mirror the per-capability state directly. Do not flatten "indeterminate"
+    # (probe budget exhausted, nothing observed) into "fail-closed" — that
+    # would falsely promote a probe timeout into a claim that the tool
+    # refused, fragmenting /health from tool truth.
+    probed_rollup = deep["state"]
     payload = {
         "status": "gateway-alive",
         "probed_capabilities_state": probed_rollup,

--- a/spark/tests/test_mcp_capability_truth.py
+++ b/spark/tests/test_mcp_capability_truth.py
@@ -247,8 +247,12 @@ class HealthCapabilityTests(unittest.TestCase):
                           f"/health leaked a URL: {body!r}")
 
     def test_health_probe_is_bounded(self):
-        """If the probe hangs, /health must time out cleanly (fail-closed),
-        never block the gateway response indefinitely."""
+        """If the probe hangs, /health must time out cleanly without blocking
+        the gateway response. A probe-budget timeout means we did not learn
+        whether the tool is live — it is NOT evidence that the tool refused.
+        The capability state must report `indeterminate` (with reason
+        `probe-budget-exceeded`), not `fail-closed`, so /health stays
+        coherent with tool truth instead of overclaiming a refusal."""
         async def slow_probe():
             await asyncio.sleep(10)
             return {"state": "live", "via": "loopback-memory-api"}
@@ -260,9 +264,15 @@ class HealthCapabilityTests(unittest.TestCase):
             client = TestClient(server.app)
             resp = client.get("/health")
         data = resp.json()
-        self.assertEqual(data["capabilities"]["deep_search"]["state"], "fail-closed")
+        self.assertEqual(data["capabilities"]["deep_search"]["state"], "indeterminate")
         self.assertEqual(data["capabilities"]["deep_search"].get("reason"),
                          "probe-budget-exceeded")
+        # Rollup must mirror the per-capability state — not be flattened
+        # to "fail-closed" merely because the probe ran out of time.
+        self.assertEqual(data["probed_capabilities_state"], "indeterminate")
+        # Gateway liveness is the separate axis and remains alive.
+        self.assertTrue(data["gateway"]["alive"])
+        self.assertEqual(data["status"], "gateway-alive")
 
 
 class ModelStatusRoleTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

Heals capability-state fragmentation in `/health`: a probe-budget timeout was being reported as `fail-closed`, so `/health` claimed `deep_search` had refused even when the tool itself was answering live.

- `_probe_deep_search_capability` now returns `state=\"indeterminate\"` (reason `probe-budget-exceeded`) on timeout. Honest fail-closed remains for the case where both probe paths were observed and neither answered.
- `health_endpoint` rollup mirrors the per-capability state directly — no flattening of `indeterminate` to `fail-closed`.
- `/health` still bounds the probe (gateway can never hang), still keeps the gateway/capability split, still leaks no topology.
- No new files. No state mechanism added — same three-step probe + bounded `wait_for`, just one more honest terminal state.

Preserves all the existing invariants from #3211/#3212: gateway/capability split, no topology leak, no Omni/Vintage promotion, no Super destabilization.

## Testing

- Updated `test_health_probe_is_bounded` in `spark/tests/test_mcp_capability_truth.py` to pin the new contract: timeout ⇒ `indeterminate` (not `fail-closed`), rollup mirrors per-capability state, gateway still `alive`.
- Ran `python3 spark/tests/test_mcp_capability_truth.py` — 13/13 pass, including the existing live / stale-fallback / honest-fail-closed / no-topology-leak cases.

## Files touched

- `spark/server.py` — `_probe_deep_search_capability`, `health_endpoint` rollup
- `spark/tests/test_mcp_capability_truth.py` — `test_health_probe_is_bounded` updated to the new contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)