### PR TITLE
spark/health: witness deep_search via POST /search, not /healthz

### DIFF
--- a/spark/server.py
+++ b/spark/server.py
@@ -1596,18 +1596,23 @@ async def mcp_endpoint(request: Request):
 # ============================================================
 
 HEALTH_PROBE_BUDGET_S = float(os.environ.get("HEALTH_PROBE_BUDGET_S", "5"))
-DEEP_SEARCH_HEALTHZ_URL = os.environ.get(
-    "DEEP_SEARCH_HEALTHZ_URL", "http://127.0.0.1:8100/healthz"
-)
 
 
 async def _probe_memory_api_readiness(machine: str) -> bool:
-    """Cheap loopback readiness probe. Prefers a side-effect-free /healthz
-    on the memory service so /health does not pollute the real search
-    pipeline with a `__health__` query. Treats 2xx as live."""
+    """Role-specific witness for deep_search. Hits the same loopback
+    endpoint the tool itself uses (`DEEP_SEARCH_API_URL`, i.e. POST
+    /search) with a minimal `__health__` query and k=1, so /health
+    actually observes the operation that matters instead of relying
+    on a separate liveness route that may not exist (the memory
+    service exposes /health, not /healthz, and routes diverge).
+    Bounded by a tight curl deadline; treats HTTP 2xx as live."""
+    payload = json.dumps({"query": "__health__", "k": 1})
     cmd = (
-        "curl -fsS --max-time 3 -o /dev/null -w '%{http_code}' "
-        + _shell_quote(DEEP_SEARCH_HEALTHZ_URL)
+        "curl -s -S --max-time 3 -o /dev/null -w '%{http_code}' "
+        "-X POST -H 'Content-Type: application/json' -d "
+        + _shell_quote(payload)
+        + " "
+        + _shell_quote(DEEP_SEARCH_API_URL)
     )
     try:
         result = await run_ssh(machine, cmd, timeout=5)

--- a/spark/tests/test_mcp_capability_truth.py
+++ b/spark/tests/test_mcp_capability_truth.py
@@ -274,6 +274,62 @@ class HealthCapabilityTests(unittest.TestCase):
         self.assertTrue(data["gateway"]["alive"])
         self.assertEqual(data["status"], "gateway-alive")
 
+    def test_readiness_witness_uses_search_endpoint_not_healthz(self):
+        """The deep_search readiness witness must hit the same loopback
+        endpoint the tool itself uses (POST /search), not a separate
+        liveness route. Live observation: the memory service exposes
+        /health and /search but not /healthz — so a /healthz pre-check
+        404s, the probe falls through to the Him-phase fallback, and
+        /health reports `stale-fallback` even though the real tool is
+        answering live. Pin: the issued shell command must be a POST
+        to DEEP_SEARCH_API_URL with a minimal `__health__` body, and a
+        2xx response must yield state=live."""
+        fake = FakeSSH()
+        # Witness command: POST /search with __health__ body returns 200.
+        fake.add("__health__", {
+            "stdout": "200",
+            "stderr": "",
+            "exit_code": 0,
+        })
+        with mock.patch.object(server, "run_ssh", fake):
+            ready = _run(server._probe_memory_api_readiness("spark-1"))
+        self.assertTrue(ready, "2xx from POST /search must be witnessed as live")
+        # Exactly one SSH command was issued, and it must:
+        #   - POST (not GET) to the search endpoint the tool itself uses
+        #   - carry the minimal __health__ probe body with k=1
+        #   - NOT reach for /healthz, which the memory service does not expose
+        self.assertEqual(len(fake.calls), 1)
+        cmd = fake.calls[0][1]
+        self.assertIn("-X POST", cmd)
+        self.assertIn("__health__", cmd)
+        self.assertIn('"k": 1', cmd)
+        self.assertIn(server.DEEP_SEARCH_API_URL, cmd)
+        self.assertNotIn("/healthz", cmd)
+
+    def test_health_live_via_search_witness_does_not_fall_back(self):
+        """End-to-end: when the search-witness succeeds, /health reports
+        state=live via loopback-memory-api and never invokes the Him-phase
+        fallback. This is the case that was misreporting `stale-fallback`
+        live — pin it shut."""
+        fake = FakeSSH()
+        fake.add("__health__", {"stdout": "200", "stderr": "", "exit_code": 0})
+        # If the fallback is ever called we'd see "deep_memory.py" in calls;
+        # we explicitly do NOT register a response for it. The default
+        # response (exit_code 1) would still cause `state=fail-closed`,
+        # so a live witness must short-circuit before that path.
+        with mock.patch.object(server, "run_ssh", fake):
+            from starlette.testclient import TestClient
+            client = TestClient(server.app)
+            resp = client.get("/health")
+        data = resp.json()
+        self.assertEqual(data["capabilities"]["deep_search"]["state"], "live")
+        self.assertEqual(data["capabilities"]["deep_search"].get("via"),
+                         "loopback-memory-api")
+        self.assertEqual(data["probed_capabilities_state"], "live")
+        # Fallback path must not have been touched on the live happy path.
+        for _, cmd in fake.calls:
+            self.assertNotIn("deep_memory.py", cmd)
+
 
 class ModelStatusRoleTests(unittest.TestCase):
     """The Him capability mirror is non-authoritative — a generated


### PR DESCRIPTION
## Summary

After #3213, live probes showed `/health` reporting `state=stale-fallback via=absorbed-him-phase` even while the loopback memory API is healthy and the `deep_search` tool answers through it. Root cause: the readiness probe was reaching for `GET /healthz`, but the memory service exposes `/health` and `/search`, not `/healthz`. The 404 failed readiness, the probe fell through to the Him-phase fallback, and `/health` reported `stale-fallback` while the tool itself was live — fragmentation from tool truth in a new direction.

Repair: replace the separate liveness route with a role-specific witness. `_probe_memory_api_readiness` now POSTs to `DEEP_SEARCH_API_URL` (the same endpoint the tool itself uses) with a minimal `\"__health__\"` query and `k=1`, bounded by a tight curl deadline. HTTP 2xx is live. `/health` now witnesses the operation that matters instead of guessing at a separate route the service does not provide.

- Same probe signature and `via=\"loopback-memory-api\"` label — no API change for callers.
- The retired `DEEP_SEARCH_HEALTHZ_URL` env var is dropped; it was only read here.
- Bounded probe envelope (`HEALTH_PROBE_BUDGET_S`) is unchanged; the curl deadline (3s) is unchanged.

## Invariants preserved

- Gateway liveness vs capability truth — still separate axes.
- No topology leak — response body still says `loopback-memory-api`; no URL, IP, or port is added (existing `test_health_does_not_leak_topology` still green).
- Bounded probe — same `asyncio.wait_for` budget, same curl `--max-time`.
- Honest fail-closed, indeterminate, and stale-fallback semantics all retained.
- No Omni/Vintage promotion, no Super destabilization — only the deep_search witness changed.

## Testing

Two new test cases in `spark/tests/test_mcp_capability_truth.py`:

- `test_readiness_witness_uses_search_endpoint_not_healthz` — pins the probe shell command: POST to `DEEP_SEARCH_API_URL`, `__health__` body with `k=1`, no `/healthz` anywhere.
- `test_health_live_via_search_witness_does_not_fall_back` — end-to-end: a 2xx search witness yields `state=live` and the Him-phase fallback is not invoked.

```
python3 spark/tests/test_mcp_capability_truth.py
Ran 15 tests in 0.191s
OK
```

All previously-existing capability-truth cases (live, stale-fallback, honest fail-closed, indeterminate-on-budget-timeout, no-topology-leak, model_status role invariants) remain green.

## Files touched

- `spark/server.py` — `_probe_memory_api_readiness` rewritten to POST `/search`; `DEEP_SEARCH_HEALTHZ_URL` constant removed
- `spark/tests/test_mcp_capability_truth.py` — two new tests added

🤖 Generated with [Claude Code](https://claude.com/claude-code)