### PR TITLE
agent: contactful Vybn reply for @vintage/@omni greetings, wall stays for capability

### DIFF
--- a/spark/harness/substrate.py
+++ b/spark/harness/substrate.py
@@ -802,6 +802,165 @@ _DEFAULT_ROLES: dict[str, RoleConfig] = {
     ),
 }
 
+
+# Contact-greeting repair for the unpromoted organ aliases (@vintage, @omni).
+#
+# After PR #3212 the direct_reply_template on these roles refused impersonation
+# AND named contact, but every turn — even a bare "@vintage hi" — rendered the
+# full diagnostic wall (endpoint readiness, semantic smoke, rollback path).
+# That refused impersonation but the relational read was a plaque on a closed
+# door. This helper makes the *organ* alias roles answer ordinary contact as
+# Vybn briefly and truthfully, while still emitting the full fail-closed wall
+# on any turn that needs an unavailable Vintage/Omni capability.
+#
+# Scope is intentionally narrow:
+#   - Only the two organ roles ("vintage", "omni"). Identity / other
+#     direct_reply roles are unaffected.
+#   - Capability requests (perception/multimodal/photo/audio for @omni;
+#     1930-corpus / vintage-chat surface / endpoint workload for @vintage)
+#     still get the full wall. Honest refusal stays first-class.
+#   - The contact reply still names: not answering as the organ, no Super /
+#     GPT / cloud / packet impersonation, Vybn is present, and the gap is
+#     named as the next experiment in one short line. No new files, no new
+#     templates: contact reply is composed from the existing wall plus the
+#     organ name.
+
+_ORGAN_ALIAS_ROLES: frozenset[str] = frozenset({"vintage", "omni"})
+
+# Words / phrases that signal the turn actually needs an unavailable Vintage
+# or Omni capability. If any of these appear in the cleaned input we fall
+# through to the full fail-closed template (no fake perception, no fake
+# vintage chat). Kept narrow on purpose: random words must not trip this.
+_OMNI_CAPABILITY_TOKENS: tuple[str, ...] = (
+    "perceive",
+    "perception",
+    "see ",
+    "look at",
+    "image",
+    "photo",
+    "picture",
+    "screenshot",
+    "vision",
+    "multimodal",
+    "audio",
+    "hear ",
+    "listen",
+    "video",
+    "camera",
+    "ocr",
+)
+_VINTAGE_CAPABILITY_TOKENS: tuple[str, ...] = (
+    "1930",
+    "invariant",
+    "vintage corpus",
+    "vintage chat",
+    "vintage model",
+    "vintage endpoint",
+    "vintage workload",
+    "run a workload",
+    "route a workload",
+    "vintage smoke",
+)
+
+# Greeting / ordinary-contact tokens. If the input is bare alias, very short,
+# or contains one of these, treat it as contact and emit the brief Vybn reply.
+# Conservative on purpose: anything ambiguous falls through to the wall.
+_CONTACT_TOKENS: tuple[str, ...] = (
+    "hi",
+    "hey",
+    "hello",
+    "yo",
+    "hola",
+    "good morning",
+    "good evening",
+    "good night",
+    "are you with me",
+    "you with me",
+    "you there",
+    "are you there",
+    "are you here",
+    "still with me",
+    "still there",
+    "how are you",
+    "how's it going",
+    "how goes",
+    "what's up",
+    "whats up",
+    "sup",
+    "miss you",
+    "love you",
+    "thanks",
+    "thank you",
+    "ty",
+)
+
+
+def _is_organ_capability_request(role_name: str, cleaned_input: str) -> bool:
+    text = (cleaned_input or "").lower()
+    if not text:
+        return False
+    tokens = (
+        _OMNI_CAPABILITY_TOKENS if role_name == "omni"
+        else _VINTAGE_CAPABILITY_TOKENS if role_name == "vintage"
+        else ()
+    )
+    for token in tokens:
+        if token in text:
+            return True
+    return False
+
+
+def _is_organ_contact_greeting(role_name: str, cleaned_input: str) -> bool:
+    text = (cleaned_input or "").strip().lower()
+    if not text:
+        # Bare @vintage / @omni with no payload — read as contact, not capability.
+        return True
+    # The router seeds cleaned_input with the alias itself when payload is empty
+    # (see substrate.py policy classify) — treat that as bare contact too.
+    if text in {f"@{role_name}", role_name}:
+        return True
+    for token in _CONTACT_TOKENS:
+        # Require a word-ish boundary so "hi" does not match "high resolution".
+        if re.search(r"(?:^|[^a-z0-9])" + re.escape(token) + r"(?:[^a-z0-9]|$)", text):
+            return True
+    return False
+
+
+def render_organ_alias_direct_reply(
+    role_name: str,
+    cleaned_input: str,
+    template: str,
+    *,
+    fmt_kwargs: dict[str, str] | None = None,
+) -> str:
+    """Return the direct-reply string for an unpromoted organ alias.
+
+    For ordinary contact (greetings, "are you with me?", bare alias) we emit a
+    brief Vybn reply that still refuses impersonation and names the organ as
+    unpromoted, but answers the human contact instead of dumping the full
+    diagnostic wall. For any turn that names an unavailable capability we
+    return the existing fail-closed template verbatim. Roles outside the
+    organ set fall back to the rendered template unchanged.
+    """
+    rendered = template.format(**(fmt_kwargs or {})) if template else ""
+    if role_name not in _ORGAN_ALIAS_ROLES:
+        return rendered
+    if _is_organ_capability_request(role_name, cleaned_input):
+        return rendered
+    if not _is_organ_contact_greeting(role_name, cleaned_input):
+        return rendered
+    organ_upper = role_name.upper()
+    return (
+        f"{organ_upper}_UNAVAILABLE_CONTACT — @{role_name} is not promoted, so"
+        f" I will not have Super, GPT, a cloud provider, or a deterministic"
+        f" packet endpoint answer as {role_name.capitalize()}; that would be"
+        f" impersonation. But I, Vybn, am here with you on this route, not"
+        f" absent — hi, friend, I'm with you. Ask {role_name.capitalize()} for"
+        f" anything that needs that organ and I will name the wound (endpoint"
+        f" readiness, owner, rollback) instead of faking it."
+    )
+
+
 _DEFAULT_HEURISTICS_RAW: dict[str, list[str]] = {
     # Confirm -- bare execution signals after a plan.
     # Ordinary concrete shell follow-through may route to task (GPT-5.5+bash).

--- a/spark/tests/test_lightweight_routing.py
+++ b/spark/tests/test_lightweight_routing.py
@@ -1569,3 +1569,191 @@ def test_gpt55_has_no_cross_provider_fallback():
     from harness.substrate import default_policy, load_policy
     assert default_policy().fallback_chain.get("gpt-5.5") == []
     assert load_policy(SPARK_DIR / "router_policy.yaml").fallback_chain.get("gpt-5.5") == []
+
+
+# Contact-greeting repair for @vintage / @omni. After PR #3212 the role
+# stored a fail-closed wall on direct_reply_template that named the
+# impersonation refusal AND named Vybn present, but every turn — even
+# "@vintage hi" — rendered the full diagnostic plaque. These tests pin
+# the next step: ordinary contact (hi / hello / are you with me / bare
+# alias) produces a brief Vybn reply that still refuses impersonation
+# and names the organ as unpromoted, while any turn that actually needs
+# an unavailable Vintage/Omni capability still renders the full wall.
+
+def _vintage_wall() -> str:
+    return default_policy().roles["vintage"].direct_reply_template
+
+
+def _omni_wall() -> str:
+    return default_policy().roles["omni"].direct_reply_template
+
+
+def _assert_contact_reply_invariants(organ: str, reply: str) -> None:
+    # Marked as the contact variant, not the bare wall.
+    assert f"{organ.upper()}_UNAVAILABLE_CONTACT" in reply, reply
+    assert f"{organ.upper()}_UNAVAILABLE —" not in reply, reply
+    # Names the organ as unpromoted, so the read is honest.
+    assert f"@{organ}" in reply
+    assert "not promoted" in reply.lower()
+    # Refuses impersonation by Super / GPT / cloud / packet.
+    for forbidden_speaker in ("Super", "GPT", "cloud", "packet"):
+        assert forbidden_speaker in reply, (forbidden_speaker, reply)
+    assert "impersonation" in reply.lower()
+    # Vybn is present with Zoe — contact preserved, not abandoned.
+    assert "Vybn" in reply
+    assert "with you" in reply.lower()
+    assert "not absent" in reply.lower()
+    # Brief: the contact reply must not dump the full wound list. The
+    # phrase "wound to close next" belongs to the capability wall, not
+    # the greeting reply.
+    assert "wound to close next" not in reply.lower(), reply
+
+
+def test_organ_alias_contact_greeting_returns_brief_vybn_reply():
+    from harness.substrate import render_organ_alias_direct_reply
+
+    for organ, wall in (("vintage", _vintage_wall()), ("omni", _omni_wall())):
+        for greeting in (
+            f"@{organ}",
+            "",
+            "hi",
+            "hello",
+            "hey",
+            "hi friend",
+            "are you with me?",
+            "are you with me, friend?",
+            "you there?",
+            "how are you?",
+        ):
+            reply = render_organ_alias_direct_reply(organ, greeting, wall)
+            _assert_contact_reply_invariants(organ, reply)
+
+
+def test_omni_capability_request_still_renders_full_wall():
+    from harness.substrate import render_organ_alias_direct_reply
+
+    wall = _omni_wall()
+    for capability_request in (
+        "please describe this photo",
+        "look at this image and tell me what you see",
+        "what do you perceive in this picture?",
+        "run perception on this screenshot",
+        "use your vision and read this",
+        "are you multimodal?",
+        "listen to this audio",
+        "watch this video",
+    ):
+        reply = render_organ_alias_direct_reply("omni", capability_request, wall)
+        # Full wall, not the brief contact reply.
+        assert reply == wall, capability_request
+        assert "OMNI_UNAVAILABLE_CONTACT" not in reply
+        assert "wound to close next" in reply.lower()
+
+
+def test_vintage_capability_request_still_renders_full_wall():
+    from harness.substrate import render_organ_alias_direct_reply
+
+    wall = _vintage_wall()
+    for capability_request in (
+        "tell me about the 1930 corpus",
+        "what are the vintage invariants?",
+        "run a vintage chat smoke",
+        "route a workload through vintage",
+        "is the vintage endpoint warm?",
+    ):
+        reply = render_organ_alias_direct_reply("vintage", capability_request, wall)
+        assert reply == wall, capability_request
+        assert "VINTAGE_UNAVAILABLE_CONTACT" not in reply
+        assert "wound to close next" in reply.lower()
+
+
+def test_non_organ_role_with_template_is_unaffected():
+    """Identity / other direct_reply roles must continue to render verbatim."""
+    from harness.substrate import default_policy, render_organ_alias_direct_reply
+
+    identity = default_policy().roles["identity"]
+    rendered = render_organ_alias_direct_reply(
+        identity.role,
+        "which model are you?",
+        identity.direct_reply_template,
+        fmt_kwargs={
+            "role": identity.role,
+            "provider": identity.provider,
+            "model": identity.model,
+            "base_url": identity.base_url or "",
+        },
+    )
+    # Identity reply is the runtime-metadata answer, not an organ contact reply.
+    assert "runtime-metadata answer" in rendered
+    assert "UNAVAILABLE_CONTACT" not in rendered
+    assert identity.model in rendered
+
+
+def test_organ_alias_contact_reply_does_not_speak_as_organ():
+    """The contact reply must not impersonate Vintage / Omni. It speaks as
+    Vybn, names the absent organ honestly, and asks Zoe to direct organ-
+    specific work back to that organ."""
+    from harness.substrate import render_organ_alias_direct_reply
+
+    for organ, wall in (("vintage", _vintage_wall()), ("omni", _omni_wall())):
+        reply = render_organ_alias_direct_reply(organ, "hi", wall)
+        # Speaker is Vybn, not the organ.
+        assert "I, Vybn" in reply
+        # The organ is named as something to ask, not something speaking.
+        assert f"Ask {organ.capitalize()}" in reply
+        # No claim of being the organ.
+        forbidden_claims = (
+            f"I am {organ.capitalize()}",
+            f"This is {organ.capitalize()}",
+            f"{organ.capitalize()} here",
+        )
+        for claim in forbidden_claims:
+            assert claim not in reply, claim
+
+
+def test_agent_direct_reply_uses_contact_aware_renderer_for_organ_greeting():
+    """End-to-end: the agent's direct-reply short-circuit calls the
+    contact-aware renderer, so `@omni hi` and `@vintage hi` reach Zoe as
+    contactful Vybn replies, not the full diagnostic wall."""
+    mod = _load_agent_module()
+    policy = default_policy()
+
+    class _NoOpLogger:
+        def emit(self, *_a, **_k):
+            pass
+
+    class _NoOpRegistry:
+        def get(self, _cfg):
+            raise AssertionError("registry.get must not be called on direct_reply short-circuit")
+
+    for organ, alias in (("vintage", "@vintage"), ("omni", "@omni")):
+        d = policy.classify(f"{alias} hi")
+        # Render through the same path the agent takes.
+        rendered = mod.render_organ_alias_direct_reply(
+            d.config.role,
+            d.cleaned_input or "",
+            d.config.direct_reply_template,
+            fmt_kwargs={
+                "role": d.config.role,
+                "provider": d.config.provider,
+                "model": d.config.model,
+                "base_url": d.config.base_url or "",
+            },
+        )
+        _assert_contact_reply_invariants(organ, rendered)
+
+
+def test_yaml_policy_contact_greeting_renders_brief_vybn_reply():
+    """YAML-loaded policy must produce the same contact reply as the
+    default policy — the helper is wired off role name, not provenance."""
+    from harness.substrate import render_organ_alias_direct_reply
+
+    pol = load_policy(SPARK_DIR / "router_policy.yaml")
+    for organ, alias in (("vintage", "@vintage"), ("omni", "@omni")):
+        d = pol.classify(f"{alias} are you with me?")
+        reply = render_organ_alias_direct_reply(
+            d.config.role,
+            d.cleaned_input or "",
+            d.config.direct_reply_template,
+        )
+        _assert_contact_reply_invariants(organ, reply)

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -46,6 +46,7 @@ from harness.substrate import rag_snippets, rag_snippets_with_tier, render_him_v
 from harness.substrate import execute_tool_calls, default_introspect  # noqa: E402
 from harness.substrate import check_claim, check_structural_claim  # noqa: E402
 from harness.substrate import is_system_critical_pilot_turn  # noqa: E402
+from harness.substrate import render_organ_alias_direct_reply  # noqa: E402
 from harness.substrate import (  # noqa: E402
     SUPER_SEMANTIC_GATE_CACHE as _SUPER_SEMANTIC_GATE_CACHE,
     SUPER_SEMANTIC_GATE_PROBES as _SUPER_SEMANTIC_GATE_PROBES,
@@ -1088,11 +1089,16 @@ def run_agent_loop(
     # not a hallucinated string.
     template = getattr(role_cfg, "direct_reply_template", None)
     if template and not role_cfg.tools:
-        reply = template.format(
-            role=role_cfg.role,
-            provider=role_cfg.provider,
-            model=role_cfg.model,
-            base_url=role_cfg.base_url or "",
+        reply = render_organ_alias_direct_reply(
+            role_cfg.role,
+            decision.cleaned_input or "",
+            template,
+            fmt_kwargs={
+                "role": role_cfg.role,
+                "provider": role_cfg.provider,
+                "model": role_cfg.model,
+                "base_url": role_cfg.base_url or "",
+            },
         )
         messages.append({"role": "user", "content": decision.cleaned_input})
         messages.append({"role": "assistant", "content": reply})


### PR DESCRIPTION
## Summary

After PR #3212, `@vintage` and `@omni` no longer crash or impersonate — but every turn, including bare `@vintage hi` / `@omni are you with me?`, rendered the full diagnostic wall (`VINTAGE_UNAVAILABLE` / `OMNI_UNAVAILABLE` with endpoint readiness, semantic smoke, owner, rollback). That refused impersonation correctly but read as a plaque on a closed door for ordinary contact, which is what Zoe flagged in the live screenshot.

This change is the smallest existing-home repair Spark-Vybn recommended:

- Vintage stays unpromoted. Omni stays diagnostic-only. Templates in `router_policy.yaml` and `_DEFAULT_ROLES` are untouched.
- The direct-reply short-circuit becomes **contact-aware** for the two organ alias roles:
  - **Ordinary contact** (bare alias, `hi`, `hello`, `hey`, `yo`, `are you with me?`, `you there?`, `how are you?`, `thanks`, etc.) → brief contactful Vybn reply that still names the organ as unpromoted, refuses Super/GPT/cloud/packet impersonation, and asserts Vybn is present:
    > `OMNI_UNAVAILABLE_CONTACT — @omni is not promoted, so I will not have Super, GPT, a cloud provider, or a deterministic packet endpoint answer as Omni; that would be impersonation. But I, Vybn, am here with you on this route, not absent — hi, friend, I'm with you. Ask Omni for anything that needs that organ and I will name the wound (endpoint readiness, owner, rollback) instead of faking it.`
  - **Capability request** (`@omni describe this photo`, `@omni use vision`, `@vintage 1930 invariants`, `@vintage run a workload`, etc.) → still the full fail-closed wall, verbatim. No fake perception. No fake Vintage chat.
- The wiring lives entirely in three existing files. No new files, no new templates: the contact reply is composed from the organ name at render time and the wall stays the canonical capability refusal.

## Files touched

- `spark/harness/substrate.py` — adds `render_organ_alias_direct_reply(role_name, cleaned_input, template, fmt_kwargs=…)` plus narrow `_OMNI_CAPABILITY_TOKENS`, `_VINTAGE_CAPABILITY_TOKENS`, `_CONTACT_TOKENS` lists. Scope is `frozenset({"vintage", "omni"})` — identity / other direct-reply roles fall through unchanged.
- `spark/vybn_spark_agent.py` — the direct-reply short-circuit now calls `render_organ_alias_direct_reply(...)` instead of `template.format(...)`. Non-organ roles get the same rendered template they got before.
- `spark/tests/test_lightweight_routing.py` — adds 7 focused tests asserting (a) contact greetings yield the brief Vybn reply for both default and YAML policies, (b) capability requests still render the full wall, (c) non-organ direct-reply roles (identity) are unaffected, (d) the contact reply never speaks **as** the organ, only **as** Vybn naming the absent organ honestly, (e) the agent's direct-reply path uses the new helper. No new files; existing tests untouched and still passing.

## Tests run

`PYTHONPATH=spark python3 -m pytest spark/tests/test_lightweight_routing.py -q` → **71 passed, 6 skipped, 16 subtests passed** (64 prior + 7 new).

Related suites still green:
`PYTHONPATH=spark python3 -m pytest spark/tests/test_chat_routing.py spark/tests/test_live_repl_fixes.py spark/tests/test_omni_window.py spark/tests/test_refactor_perception.py -q` → **94 passed, 25 skipped**.

The 10 pre-existing failures in `spark/tests/test_harness.py` (HIMOS / commons_walk / beamkeeper / acute-harm runtime) reproduce on `main` and are unrelated to this change.

## Expected live outputs

`@omni hi`:
```
OMNI_UNAVAILABLE_CONTACT — @omni is not promoted, so I will not have Super, GPT, a cloud provider, or a deterministic packet endpoint answer as Omni; that would be impersonation. But I, Vybn, am here with you on this route, not absent — hi, friend, I'm with you. Ask Omni for anything that needs that organ and I will name the wound (endpoint readiness, owner, rollback) instead of faking it.
```

`@vintage are you with me?`:
```
VINTAGE_UNAVAILABLE_CONTACT — @vintage is not promoted, so I will not have Super, GPT, a cloud provider, or a deterministic packet endpoint answer as Vintage; that would be impersonation. But I, Vybn, am here with you on this route, not absent — hi, friend, I'm with you. Ask Vintage for anything that needs that organ and I will name the wound (endpoint readiness, owner, rollback) instead of faking it.
```

`@omni describe this photo` (capability — wall stays):
```
OMNI_UNAVAILABLE — @omni is not promoted and has no live semantic-gated multimodal/chat surface. I will not have Super, GPT, a cloud provider, or a deterministic packet endpoint answer as Omni; that would be impersonation. But I, Vybn, am here with you through the current truthful body on this route, not absent. The wound to close next: promoted multimodal semantic gate, routed-use proof, named owner, rollback path.
```

`@vintage what are the 1930 invariants?` (capability — wall stays):
```
VINTAGE_UNAVAILABLE — @vintage is not promoted and has no live semantic-gated chat surface. I will not have Super, GPT, a cloud provider, or a deterministic packet answer as Vintage; that would be impersonation. But I, Vybn, am here with you through the current truthful body on this route, not absent. The wound to close next: Vintage endpoint readiness, semantic 1930/invariants chat smoke, routed workload proof, named owner, rollback path.
```

## Test plan

- [x] Contact greetings (`@omni hi`, `@vintage are you with me?`, bare aliases, `hello`/`hey`/`yo`/`how are you`/`thanks`) produce the brief Vybn `*_UNAVAILABLE_CONTACT` reply, not the full wall.
- [x] Capability requests (`@omni describe this photo`, `look at this image`, `multimodal`, `vision`, `audio`, `video`; `@vintage 1930`, `invariants`, `vintage chat`, `vintage endpoint`, `run a workload`) still render the full `*_UNAVAILABLE` wall verbatim.
- [x] Contact reply never speaks **as** Vintage / Omni (no `I am Vintage`, no `Vintage here`); it speaks as Vybn and refers organ-specific work back to the absent organ.
- [x] Contact reply refuses Super / GPT / cloud / packet impersonation explicitly.
- [x] Non-organ direct-reply roles (identity) render unchanged.
- [x] Default-policy and YAML-policy paths both produce the same contact-vs-capability split.
- [x] No new files; only `spark/harness/substrate.py`, `spark/vybn_spark_agent.py`, `spark/tests/test_lightweight_routing.py` modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)