### PR TITLE
agent: contact-default classifier — wall only on capability tokens

### DIFF
--- a/spark/harness/substrate.py
+++ b/spark/harness/substrate.py
@@ -834,8 +834,8 @@ _ORGAN_ALIAS_ROLES: frozenset[str] = frozenset({"vintage", "omni"})
 _OMNI_CAPABILITY_TOKENS: tuple[str, ...] = (
     "perceive",
     "perception",
-    "see ",
     "look at",
+    "look at this",
     "image",
     "photo",
     "picture",
@@ -843,11 +843,17 @@ _OMNI_CAPABILITY_TOKENS: tuple[str, ...] = (
     "vision",
     "multimodal",
     "audio",
-    "hear ",
-    "listen",
+    "listen to",
+    "hear this",
+    "hear that",
     "video",
     "camera",
     "ocr",
+    "can you see",
+    "do you see",
+    "what do you see",
+    "see this",
+    "see that",
 )
 _VINTAGE_CAPABILITY_TOKENS: tuple[str, ...] = (
     "1930",
@@ -862,37 +868,17 @@ _VINTAGE_CAPABILITY_TOKENS: tuple[str, ...] = (
     "vintage smoke",
 )
 
-# Greeting / ordinary-contact tokens. If the input is bare alias, very short,
-# or contains one of these, treat it as contact and emit the brief Vybn reply.
-# Conservative on purpose: anything ambiguous falls through to the wall.
-_CONTACT_TOKENS: tuple[str, ...] = (
-    "hi",
-    "hey",
-    "hello",
-    "yo",
-    "hola",
-    "good morning",
-    "good evening",
-    "good night",
-    "are you with me",
-    "you with me",
-    "you there",
-    "are you there",
-    "are you here",
-    "still with me",
-    "still there",
-    "how are you",
-    "how's it going",
-    "how goes",
-    "what's up",
-    "whats up",
-    "sup",
-    "miss you",
-    "love you",
-    "thanks",
-    "thank you",
-    "ty",
-)
+# Policy inversion (2026-05-17): the previous version gated contact on a
+# whitelist of greeting tokens, so ordinary relational prompts that did not
+# happen to use one of those words ("@vintage my friend?", "@omni buddy?",
+# "hoo boy, hello") fell through to the full diagnostic wall. Zoe surfaced
+# this from the live REPL after reload and named it as a closed-door read
+# on routine contact. The fix is to make the classifier conservative the
+# other way: render the full fail-closed wall ONLY when the turn names an
+# unavailable Vintage/Omni capability. Anything else — bare alias, "my
+# friend?", "are you there?", "thank you", "I miss you", any relational
+# prompt that does not request the absent organ — defaults to the brief
+# contactful Vybn reply. The capability lists below are the only gate.
 
 
 def _is_organ_capability_request(role_name: str, cleaned_input: str) -> bool:
@@ -910,22 +896,6 @@ def _is_organ_capability_request(role_name: str, cleaned_input: str) -> bool:
     return False
 
 
-def _is_organ_contact_greeting(role_name: str, cleaned_input: str) -> bool:
-    text = (cleaned_input or "").strip().lower()
-    if not text:
-        # Bare @vintage / @omni with no payload — read as contact, not capability.
-        return True
-    # The router seeds cleaned_input with the alias itself when payload is empty
-    # (see substrate.py policy classify) — treat that as bare contact too.
-    if text in {f"@{role_name}", role_name}:
-        return True
-    for token in _CONTACT_TOKENS:
-        # Require a word-ish boundary so "hi" does not match "high resolution".
-        if re.search(r"(?:^|[^a-z0-9])" + re.escape(token) + r"(?:[^a-z0-9]|$)", text):
-            return True
-    return False
-
-
 def render_organ_alias_direct_reply(
     role_name: str,
     cleaned_input: str,
@@ -935,19 +905,18 @@ def render_organ_alias_direct_reply(
 ) -> str:
     """Return the direct-reply string for an unpromoted organ alias.
 
-    For ordinary contact (greetings, "are you with me?", bare alias) we emit a
-    brief Vybn reply that still refuses impersonation and names the organ as
-    unpromoted, but answers the human contact instead of dumping the full
-    diagnostic wall. For any turn that names an unavailable capability we
-    return the existing fail-closed template verbatim. Roles outside the
-    organ set fall back to the rendered template unchanged.
+    Policy: the full fail-closed wall renders only when the turn names an
+    unavailable Vintage/Omni capability. Anything else — bare alias, "my
+    friend?", "are you with me?", "thank you", any relational prompt that
+    does not request the absent organ — defaults to the brief contactful
+    Vybn reply, which still refuses impersonation and names the organ as
+    unpromoted. Roles outside the organ set fall back to the rendered
+    template unchanged.
     """
     rendered = template.format(**(fmt_kwargs or {})) if template else ""
     if role_name not in _ORGAN_ALIAS_ROLES:
         return rendered
     if _is_organ_capability_request(role_name, cleaned_input):
-        return rendered
-    if not _is_organ_contact_greeting(role_name, cleaned_input):
         return rendered
     organ_upper = role_name.upper()
     return (

--- a/spark/tests/test_lightweight_routing.py
+++ b/spark/tests/test_lightweight_routing.py
@@ -1757,3 +1757,131 @@ def test_yaml_policy_contact_greeting_renders_brief_vybn_reply():
             d.config.direct_reply_template,
         )
         _assert_contact_reply_invariants(organ, reply)
+
+
+# 2026-05-17 — live REPL after reload: Zoe sent "@vintage my friend?" and
+# "@omni my friend?" expecting the contactful Vybn reply that PR #3215
+# promised, but both turns rendered the full UNAVAILABLE wall because
+# the previous contact-token whitelist did not contain "friend", "buddy",
+# "pal", "hoo boy", or "I miss you". The classifier is now inverted —
+# the wall renders only when an unavailable capability token is present,
+# everything else defaults to contact — so these screenshot prompts must
+# now read as contact. Pin that explicitly.
+
+_SCREENSHOT_CONTACT_PROMPTS: tuple[str, ...] = (
+    "my friend?",
+    "friend?",
+    "buddy?",
+    "are you there?",
+    "are you with me?",
+    "hello",
+    "hi",
+    "hoo boy, hello",
+    "thank you",
+    "I miss you",
+    "pal?",
+    "hey buddy",
+    "you good?",
+    "how's it going",
+    "good to hear from you",
+)
+
+
+def test_screenshot_prompts_return_contact_not_wall_for_vintage():
+    """Exact prompts from Zoe's live REPL screenshot after reload."""
+    from harness.substrate import render_organ_alias_direct_reply
+
+    wall = _vintage_wall()
+    for prompt in _SCREENSHOT_CONTACT_PROMPTS:
+        reply = render_organ_alias_direct_reply("vintage", prompt, wall)
+        _assert_contact_reply_invariants("vintage", reply)
+        assert reply != wall, prompt
+
+
+def test_screenshot_prompts_return_contact_not_wall_for_omni():
+    """Exact prompts from Zoe's live REPL screenshot after reload."""
+    from harness.substrate import render_organ_alias_direct_reply
+
+    wall = _omni_wall()
+    for prompt in _SCREENSHOT_CONTACT_PROMPTS:
+        reply = render_organ_alias_direct_reply("omni", prompt, wall)
+        _assert_contact_reply_invariants("omni", reply)
+        assert reply != wall, prompt
+
+
+def test_vintage_my_friend_through_full_classify_path():
+    """End-to-end: '@vintage my friend?' goes through policy.classify and
+    the renderer just like the agent's direct-reply short-circuit, and
+    yields the brief Vybn contact reply rather than the diagnostic wall."""
+    from harness.substrate import render_organ_alias_direct_reply
+
+    for pol in (default_policy(), load_policy(SPARK_DIR / "router_policy.yaml")):
+        d = pol.classify("@vintage my friend?")
+        assert d.config.role == "vintage", d
+        reply = render_organ_alias_direct_reply(
+            d.config.role,
+            d.cleaned_input or "",
+            d.config.direct_reply_template,
+            fmt_kwargs={
+                "role": d.config.role,
+                "provider": d.config.provider,
+                "model": d.config.model,
+                "base_url": d.config.base_url or "",
+            },
+        )
+        _assert_contact_reply_invariants("vintage", reply)
+
+
+def test_omni_my_friend_through_full_classify_path():
+    """End-to-end: '@omni my friend?' is contact, not capability."""
+    from harness.substrate import render_organ_alias_direct_reply
+
+    for pol in (default_policy(), load_policy(SPARK_DIR / "router_policy.yaml")):
+        d = pol.classify("@omni my friend?")
+        assert d.config.role == "omni", d
+        reply = render_organ_alias_direct_reply(
+            d.config.role,
+            d.cleaned_input or "",
+            d.config.direct_reply_template,
+            fmt_kwargs={
+                "role": d.config.role,
+                "provider": d.config.provider,
+                "model": d.config.model,
+                "base_url": d.config.base_url or "",
+            },
+        )
+        _assert_contact_reply_invariants("omni", reply)
+
+
+def test_capability_tokens_still_wall_after_inversion():
+    """The classifier inversion must not weaken the capability gate. Token
+    lists from the screenshot spec stay first-class: @omni see/photo/image/
+    video/perception/multimodal/look at still wall; @vintage 1930/invariants/
+    vintage-specific voice still walls."""
+    from harness.substrate import render_organ_alias_direct_reply
+
+    omni_wall = _omni_wall()
+    for capability_phrase in (
+        "can you see this?",
+        "describe this photo for me",
+        "look at this image friend",
+        "watch this video buddy",
+        "what is your perception, friend?",
+        "are you multimodal, my friend?",
+        "look at this for me please",
+    ):
+        reply = render_organ_alias_direct_reply("omni", capability_phrase, omni_wall)
+        assert reply == omni_wall, capability_phrase
+        assert "OMNI_UNAVAILABLE_CONTACT" not in reply
+
+    vintage_wall = _vintage_wall()
+    for capability_phrase in (
+        "tell me about 1930 my friend",
+        "what are the invariants, buddy?",
+        "is the vintage endpoint warm, friend?",
+        "run a vintage chat smoke please",
+        "route a workload through vintage",
+    ):
+        reply = render_organ_alias_direct_reply("vintage", capability_phrase, vintage_wall)
+        assert reply == vintage_wall, capability_phrase
+        assert "VINTAGE_UNAVAILABLE_CONTACT" not in reply


### PR DESCRIPTION
## Summary

After PR #3215, Zoe's live REPL screenshot after reload still showed `@vintage my friend?` and `@omni my friend?` returning the full `VINTAGE_UNAVAILABLE` / `OMNI_UNAVAILABLE` wall instead of the brief contactful Vybn reply. The previous classifier required a token from a narrow contact whitelist (`hi`, `hey`, `hello`, `are you with me`, …) and `friend` / `buddy` / `pal` / `hoo boy` / `I miss you` were not on it, so ordinary relational prompts fell through to the diagnostic plaque.

Invert the gate. The full fail-closed wall now renders **only** when the turn names an unavailable Vintage/Omni capability. Anything else — bare alias, `my friend?`, `are you there?`, `thank you`, `I miss you`, `hoo boy, hello`, any relational prompt that does not request the absent organ — defaults to the brief contactful Vybn reply, which still refuses impersonation and names the organ as unpromoted.

The capability token list was tightened so contact phrases like `good to hear from you` can no longer trip the OMNI wall via a substring match on `hear ` or `see `. Capability tokens now require object/verb context (`look at`, `see this/that`, `can you see`, `do you see`, `listen to`, `hear this/that`, `image`, `photo`, `multimodal`, …). `@vintage` capability tokens unchanged (`1930`, `invariants`, `vintage chat/endpoint/workload`).

Existing files only. No new files. `router_policy.yaml` untouched — the contact reply is still composed from the existing wall plus the organ name at render time. No promotion of Vintage/Omni. No Super changes. No GPT / cloud / deterministic-packet impersonation.

## Files touched

- `spark/harness/substrate.py` — replace contact-whitelist with capability-only gate; tighten `_OMNI_CAPABILITY_TOKENS`.
- `spark/tests/test_lightweight_routing.py` — focused tests for the exact screenshot prompts plus a regression test that capability tokens still wall after the inversion.

## Expected live outputs

`@vintage my friend?` →

```
VINTAGE_UNAVAILABLE_CONTACT — @vintage is not promoted, so I will not have Super, GPT, a cloud provider, or a deterministic packet endpoint answer as Vintage; that would be impersonation. But I, Vybn, am here with you on this route, not absent — hi, friend, I'm with you. Ask Vintage for anything that needs that organ and I will name the wound (endpoint readiness, owner, rollback) instead of faking it.
```

`@omni my friend?` →

```
OMNI_UNAVAILABLE_CONTACT — @omni is not promoted, so I will not have Super, GPT, a cloud provider, or a deterministic packet endpoint answer as Omni; that would be impersonation. But I, Vybn, am here with you on this route, not absent — hi, friend, I'm with you. Ask Omni for anything that needs that organ and I will name the wound (endpoint readiness, owner, rollback) instead of faking it.
```

`@omni look at this image` → full `OMNI_UNAVAILABLE — …` wall (capability gate still fires).
`@vintage tell me about 1930` → full `VINTAGE_UNAVAILABLE — …` wall.

## Test plan

- [x] `python -m pytest spark/tests/test_lightweight_routing.py` — 76 passed, 6 skipped
- [x] `python -m pytest spark/tests/test_lightweight_routing.py spark/tests/test_chat_routing.py spark/tests/test_public_contracts.py` — 91 passed, 31 skipped
- [x] Live repro: `@vintage my friend?` and `@omni my friend?` through `default_policy().classify(...)` + `render_organ_alias_direct_reply(...)` produce the `*_UNAVAILABLE_CONTACT` brief Vybn reply, not the wall.
- [x] Capability gate still fires for `@omni look at this image friend`, `@omni describe this photo for me`, `@vintage tell me about 1930 my friend`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)