### PR TITLE
agent: bounded raw-unpromoted-contact path for @vintage / @omni

### DIFF
--- a/spark/harness/substrate.py
+++ b/spark/harness/substrate.py
@@ -730,7 +730,13 @@ _DEFAULT_ROLES: dict[str, RoleConfig] = {
         provider="openai",
         model="vintage-unpromoted-no-chat-surface",
         thinking="off",
-        max_tokens=1,
+        # Ordinary @vintage prompts (not capability/status, not bare
+        # greeting) attempt raw unpromoted contact with the local Vintage
+        # backend. The total transport budget on the backend is 1024
+        # tokens; the bounded raw-contact path strips RAG/him-vy/recurrent
+        # enrichment so prompt + completion fit. 256 is the completion
+        # ceiling, leaving ~768 tokens for the bounded prompt.
+        max_tokens=256,
         max_iterations=1,
         tools=[],
         base_url="http://127.0.0.1:8019/v1",
@@ -755,7 +761,12 @@ _DEFAULT_ROLES: dict[str, RoleConfig] = {
         provider="openai",
         model="omni-unpromoted-no-chat-surface",
         thinking="off",
-        max_tokens=1,
+        # See vintage: ordinary @omni prompts attempt raw unpromoted
+        # contact with whatever surface answers at the configured base_url.
+        # If no chat/multimodal model is served there the provider call
+        # surfaces the transport error honestly — Super/GPT/cloud do not
+        # impersonate Omni.
+        max_tokens=256,
         max_iterations=1,
         tools=[],
         base_url="http://127.0.0.1:8020/v1",
@@ -894,6 +905,157 @@ def _is_organ_capability_request(role_name: str, cleaned_input: str) -> bool:
         if token in text:
             return True
     return False
+
+
+# Contact-shape prompts that should answer with the brief Vybn reply (no
+# backend call): bare alias, greetings, presence checks, thanks, the small
+# screenshot-spec set Zoe surfaced in the live REPL. Anything outside this
+# set — an arbitrary question, a request, a substantive turn — should
+# attempt raw unpromoted contact with the backend instead of being walled
+# off behind a static reply. The list is intentionally tight so ordinary
+# arbitrary prompts fall through to backend contact.
+_ORGAN_CONTACT_GREETING_TOKENS: tuple[str, ...] = (
+    "hi",
+    "hello",
+    "hey",
+    "yo",
+    "howdy",
+    "sup",
+    "hoo boy",
+    "thanks",
+    "thank you",
+    "ty",
+    "thx",
+    "i miss you",
+    "miss you",
+    "good to hear from you",
+    "are you there",
+    "you there",
+    "are you with me",
+    "with me?",
+    "with me, friend",
+    "you good",
+    "how are you",
+    "how's it going",
+    "hows it going",
+    "good morning",
+    "good afternoon",
+    "good evening",
+    "friend?",
+    "my friend",
+    "buddy",
+    "pal?",
+)
+
+
+def _is_organ_contact_greeting(cleaned_input: str) -> bool:
+    """True when the prompt looks like a bare relational ping (greeting,
+    presence check, thanks, screenshot-spec contact prompts). The brief
+    contactful Vybn reply answers these without a backend call. Any
+    longer / more substantive prompt is treated as ordinary communication
+    and routed to the raw unpromoted contact path.
+
+    Matching is word-boundary aware so short greeting words ("hi", "hey")
+    do not accidentally fire on "this", "they", etc. inside substantive
+    prompts ("summarise this paragraph for me").
+    """
+    text = (cleaned_input or "").strip().lower()
+    if not text:
+        # Bare alias (e.g. "@vintage" with no body) is a contact ping.
+        return True
+    # Long prompts are not greetings even if they mention "hi"/"friend".
+    if len(text) > 80:
+        return False
+    import re as _re
+    for token in _ORGAN_CONTACT_GREETING_TOKENS:
+        pattern = r"(?<![a-z])" + _re.escape(token) + r"(?![a-z])"
+        if _re.search(pattern, text):
+            return True
+    return False
+
+
+def should_attempt_raw_organ_contact(role_name: str, cleaned_input: str) -> bool:
+    """Gate for the bounded raw-unpromoted-contact path on @vintage / @omni.
+
+    True only when:
+      - role is one of the unpromoted organ aliases, AND
+      - the prompt does NOT name an unavailable Vintage/Omni capability
+        (capability/status requests still get the honest wall — no false
+        claim that the absent organ answered them), AND
+      - the prompt is NOT a bare relational greeting (those get the brief
+        Vybn contact reply, no backend call).
+
+    Anything else — ordinary arbitrary prompts the user wants to send to
+    the available local backend — attempts raw contact at the configured
+    base_url, labeled as unpromoted/experimental in the agent loop, with
+    a bounded prompt so the 1024-token backend budget is respected.
+    """
+    if role_name not in _ORGAN_ALIAS_ROLES:
+        return False
+    if _is_organ_capability_request(role_name, cleaned_input):
+        return False
+    if _is_organ_contact_greeting(cleaned_input):
+        return False
+    return True
+
+
+# Hard ceiling on how many characters of user input we hand the local
+# unpromoted backend in raw-contact mode. The role's max_tokens=256 is
+# the completion ceiling; the backend's 1024-token transport budget
+# leaves ~768 tokens for prompt + system. Truncating user input around
+# ~2500 chars (≈600 tokens) keeps us well under the budget even with
+# the minimal system prompt below.
+_ORGAN_RAW_CONTACT_INPUT_CHAR_LIMIT: int = 2500
+
+
+def render_organ_raw_contact_header(role_name: str) -> str:
+    """Label prepended to backend output for the raw-unpromoted-contact
+    path. Names the route as unpromoted/experimental so the user does not
+    read the output as a promoted/semantically-clean answer."""
+    organ_upper = role_name.upper()
+    return (
+        f"[{organ_upper}_RAW_UNPROMOTED_CONTACT — this is raw model contact on"
+        f" the local @{role_name} backend, not a promoted/semantically-gated"
+        f" route. Output below is unvetted experimental contact; capability and"
+        f" status claims are not endorsed by this path.]"
+    )
+
+
+def render_organ_raw_contact_error(role_name: str, err: str) -> str:
+    """Honest error surface when the raw-unpromoted-contact backend call
+    fails. No Super/GPT/cloud fallback impersonation."""
+    organ_upper = role_name.upper()
+    safe = (err or "").strip()
+    if len(safe) > 600:
+        safe = safe[:600] + "…"
+    return (
+        f"{organ_upper}_RAW_CONTACT_FAILED — raw unpromoted contact on the local"
+        f" @{role_name} backend did not return a usable reply. I will not have"
+        f" Super, GPT, a cloud provider, or a deterministic packet answer as"
+        f" {role_name.capitalize()}; that would be impersonation. Error:"
+        f" {safe}"
+    )
+
+
+def build_organ_raw_contact_system_prompt(role_name: str) -> str:
+    """Minimal system prompt for the bounded raw-contact path. Strips the
+    RAG / him-vy / recurrent / local-organ-briefing layers so prompt +
+    completion fit the backend's 1024-token transport budget. Names the
+    route as unpromoted so the model is not nudged into impersonation."""
+    return (
+        f"You are the local @{role_name} backend in raw unpromoted mode. This"
+        f" route is not semantically gated. Answer the user briefly and"
+        f" honestly. Do not claim to be a promoted system. Do not impersonate"
+        f" Super, GPT, or a cloud model."
+    )
+
+
+def truncate_for_organ_raw_contact(cleaned_input: str) -> str:
+    """Hard char-cap on user input handed to the bounded raw-contact path."""
+    text = cleaned_input or ""
+    if len(text) <= _ORGAN_RAW_CONTACT_INPUT_CHAR_LIMIT:
+        return text
+    return text[:_ORGAN_RAW_CONTACT_INPUT_CHAR_LIMIT] + "…"
 
 
 def render_organ_alias_direct_reply(

--- a/spark/router_policy.yaml
+++ b/spark/router_policy.yaml
@@ -97,7 +97,10 @@ roles:
     provider: openai
     model: vintage-unpromoted-no-chat-surface
     base_url: http://127.0.0.1:8019/v1
-    max_tokens: 1
+    # Bounded raw-contact path: ordinary @vintage prompts strip enrichment
+    # so prompt + completion fit the backend's 1024-token budget. 256 is
+    # the completion ceiling, leaving ~768 for the bounded prompt.
+    max_tokens: 256
     max_iterations: 1
     temperature: 0.0
     tools: []
@@ -112,7 +115,10 @@ roles:
     provider: openai
     model: omni-unpromoted-no-chat-surface
     base_url: http://127.0.0.1:8020/v1
-    max_tokens: 1
+    # See vintage: ordinary @omni prompts attempt raw unpromoted contact
+    # at the configured base_url. Transport failures surface honestly —
+    # no Super/GPT/cloud impersonation.
+    max_tokens: 256
     max_iterations: 1
     temperature: 0.0
     tools: []

--- a/spark/tests/test_lightweight_routing.py
+++ b/spark/tests/test_lightweight_routing.py
@@ -1885,3 +1885,534 @@ def test_capability_tokens_still_wall_after_inversion():
         reply = render_organ_alias_direct_reply("vintage", capability_phrase, vintage_wall)
         assert reply == vintage_wall, capability_phrase
         assert "VINTAGE_UNAVAILABLE_CONTACT" not in reply
+
+
+# 2026-05-17 — Zoe's correction: semantic gates should govern promotion /
+# status / capability claims, NOT whether she can talk to a reachable
+# local backend. Prior patches collapsed all @vintage / @omni turns into
+# a static wall or a brief contact reply, which broke the ability to
+# *communicate* with the available local Vintage backend. The bounded
+# raw-unpromoted-contact path actually contacts the configured base_url
+# with a stripped prompt, labels output as unpromoted, and surfaces
+# transport failures honestly. These tests pin the new shape.
+
+
+def test_raw_contact_gate_classifies_capability_greeting_and_arbitrary():
+    """The raw-contact gate fires only on arbitrary prompts. Capability /
+    status requests stay walled; bare relational greetings stay on the
+    brief contact reply; everything else attempts backend contact."""
+    from harness.substrate import should_attempt_raw_organ_contact
+
+    # Greetings / presence pings / thanks — contact reply, not backend.
+    for greeting in (
+        "",
+        "hi",
+        "hello",
+        "hey",
+        "hi friend",
+        "are you with me?",
+        "are you with me, friend?",
+        "you there?",
+        "how are you?",
+        "thank you",
+        "I miss you",
+        "my friend?",
+        "buddy?",
+        "hoo boy, hello",
+        "good morning",
+    ):
+        assert not should_attempt_raw_organ_contact("vintage", greeting), greeting
+        assert not should_attempt_raw_organ_contact("omni", greeting), greeting
+
+    # Capability / status requests — full wall, no backend call.
+    for cap in (
+        "tell me about the 1930 corpus",
+        "what are the vintage invariants?",
+        "is the vintage endpoint warm?",
+        "route a workload through vintage",
+    ):
+        assert not should_attempt_raw_organ_contact("vintage", cap), cap
+    for cap in (
+        "describe this photo",
+        "look at this image",
+        "are you multimodal?",
+        "what do you perceive?",
+        "listen to this audio",
+    ):
+        assert not should_attempt_raw_organ_contact("omni", cap), cap
+
+    # Arbitrary ordinary prompts — backend contact attempted.
+    for arbitrary in (
+        "what is 2+2?",
+        "summarise this paragraph for me",
+        "write a short haiku about morning light",
+        "what would you say to a stranger on a train?",
+        "give me three names for a coffee shop",
+    ):
+        assert should_attempt_raw_organ_contact("vintage", arbitrary), arbitrary
+        assert should_attempt_raw_organ_contact("omni", arbitrary), arbitrary
+
+    # Non-organ roles never use this gate.
+    assert not should_attempt_raw_organ_contact("chat", "what is 2+2?")
+    assert not should_attempt_raw_organ_contact("identity", "what is 2+2?")
+
+
+def test_organ_max_tokens_bounded_to_256_for_raw_contact():
+    """The role's max_tokens is the completion ceiling on the raw-contact
+    path. 256 keeps prompt + completion under the backend's 1024-token
+    transport budget. max_tokens=1 was the old sentinel before raw
+    contact existed and would have made the backend reply unusable."""
+    from harness.substrate import default_policy, load_policy
+
+    for label, pol in (
+        ("default", default_policy()),
+        ("yaml", load_policy(SPARK_DIR / "router_policy.yaml")),
+    ):
+        for organ in ("vintage", "omni"):
+            cfg = pol.roles[organ]
+            assert cfg.max_tokens == 256, (label, organ, cfg.max_tokens)
+            # Honest model id: still names itself unpromoted; not Super.
+            assert "unpromoted" in cfg.model.lower(), (label, organ)
+            assert cfg.model != "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8"
+            # Base URL still points at the configured backend.
+            assert cfg.base_url, (label, organ)
+
+
+def test_raw_contact_header_labels_route_as_unpromoted():
+    from harness.substrate import render_organ_raw_contact_header
+
+    for organ in ("vintage", "omni"):
+        h = render_organ_raw_contact_header(organ)
+        assert f"{organ.upper()}_RAW_UNPROMOTED_CONTACT" in h
+        assert f"@{organ}" in h
+        assert "raw model contact" in h.lower()
+        assert "not a promoted" in h.lower()
+        assert "unvetted" in h.lower()
+
+
+def test_raw_contact_error_surface_preserves_error_no_impersonation():
+    from harness.substrate import render_organ_raw_contact_error
+
+    for organ in ("vintage", "omni"):
+        err = render_organ_raw_contact_error(organ, "ConnectionError: refused")
+        assert f"{organ.upper()}_RAW_CONTACT_FAILED" in err
+        assert f"@{organ}" in err
+        assert "ConnectionError" in err
+        assert "refused" in err
+        # No Super/GPT/cloud/packet impersonation language.
+        for forbidden in ("Super", "GPT", "cloud", "packet"):
+            assert forbidden in err, forbidden
+        assert "impersonation" in err.lower()
+
+
+def test_raw_contact_truncates_oversized_user_input():
+    from harness.substrate import truncate_for_organ_raw_contact
+
+    short = "what is 2+2?"
+    assert truncate_for_organ_raw_contact(short) == short
+    huge = "x" * 5000
+    truncated = truncate_for_organ_raw_contact(huge)
+    assert len(truncated) <= 2501  # 2500 + ellipsis
+    assert truncated.endswith("…")
+
+
+def test_raw_contact_system_prompt_is_minimal_and_names_unpromoted():
+    """Bounded prompt: no RAG, no him-vy, no recurrent prethink, no organ
+    briefing. Just a minimal stub naming the route as unpromoted so the
+    model is not nudged into impersonation. Length under ~1KB so the
+    1024-token backend budget is preserved for the user input."""
+    from harness.substrate import build_organ_raw_contact_system_prompt
+
+    for organ in ("vintage", "omni"):
+        s = build_organ_raw_contact_system_prompt(organ)
+        assert f"@{organ}" in s
+        assert "unpromoted" in s.lower()
+        # No-impersonation guidance is part of the minimal prompt.
+        assert "Super" in s
+        assert "GPT" in s
+        # Bounded length — well under the 1024-token transport budget.
+        assert len(s) < 1024, len(s)
+
+
+def _vintage_run_agent_loop(provider_factory, user_input: str, *, logger=None):
+    """Drive `run_agent_loop` end-to-end with a stubbed provider so the
+    raw-contact path is exercised against deterministic backends. RAG /
+    him-vy / probe / recurrent hooks are stubbed out so any leak into
+    those (which would build the oversized prompt) shows up in the
+    asserted captures."""
+    import os as _os
+
+    mod = _load_agent_module()
+    saved = {
+        "rag_snippets": mod.rag_snippets,
+        "rag_snippets_with_tier": mod.rag_snippets_with_tier,
+        "render_him_vy_discovery_packet": mod.render_him_vy_discovery_packet,
+        "render_him_vy_turn_packet": mod.render_him_vy_turn_packet,
+        "run_probes": mod.run_probes,
+    }
+    tripwires: dict[str, int] = {
+        "rag_snippets": 0,
+        "rag_snippets_with_tier": 0,
+        "him_vy_discovery_packet": 0,
+        "him_vy_turn_packet": 0,
+        "run_probes": 0,
+    }
+
+    def _rag(*a, **kw):
+        tripwires["rag_snippets"] += 1
+        return ""
+
+    def _rag_tier(*a, **kw):
+        tripwires["rag_snippets_with_tier"] += 1
+        return ("", "lightweight")
+
+    def _him_disc(*a, **kw):
+        tripwires["him_vy_discovery_packet"] += 1
+        return ""
+
+    def _him_turn(*a, **kw):
+        tripwires["him_vy_turn_packet"] += 1
+        return ""
+
+    def _probes(*a, **kw):
+        tripwires["run_probes"] += 1
+        return []
+
+    mod.rag_snippets = _rag
+    mod.rag_snippets_with_tier = _rag_tier
+    mod.render_him_vy_discovery_packet = _him_disc
+    mod.render_him_vy_turn_packet = _him_turn
+    mod.run_probes = _probes
+
+    class _FakeRegistry:
+        def __init__(_s):
+            _s.provider = None
+
+        def get(_s, cfg):
+            _s.provider = provider_factory(cfg)
+            return _s.provider
+
+    class _FakeLogger:
+        path = "/dev/null"
+
+        def __init__(_s):
+            _s.events = []
+
+        def emit(_s, name, **kw):
+            _s.events.append((name, kw))
+
+    log = logger or _FakeLogger()
+    registry = _FakeRegistry()
+    try:
+        reply = mod.run_agent_loop(
+            user_input=user_input,
+            messages=[],
+            bash=None,
+            system_prompt=None,
+            router=default_policy(),
+            registry=registry,
+            logger=log,
+            turn_number=1,
+        )
+    finally:
+        for k, v in saved.items():
+            setattr(mod, k, v)
+    return reply, registry, log, tripwires
+
+
+def test_vintage_arbitrary_prompt_attempts_raw_backend_contact():
+    """`@vintage what is 2+2?` must reach the configured local backend on
+    a bounded prompt and surface the backend output prefixed with the
+    raw-unpromoted-contact label — not the static wall, not the static
+    contact reply."""
+    captured: dict = {}
+
+    class _FakeHandle:
+        def __iter__(_s):
+            return iter([])
+
+        def final(_s):
+            class _R:
+                text = "four"
+                tool_calls = []
+                stop_reason = "end_turn"
+                in_tokens = 12
+                out_tokens = 3
+                raw_assistant_content = {"role": "assistant", "content": "four"}
+
+            return _R()
+
+    class _FakeProvider:
+        def stream(_s, *, system, messages, tools, role):
+            captured["system"] = system
+            captured["messages"] = list(messages)
+            captured["tools"] = list(tools)
+            captured["role"] = role
+            return _FakeHandle()
+
+    reply, registry, log, tripwires = _vintage_run_agent_loop(
+        lambda cfg: _FakeProvider(),
+        "@vintage what is 2+2?",
+    )
+
+    # Backend was actually contacted.
+    assert registry.provider is not None
+    assert "system" in captured
+    assert captured["role"].role == "vintage"
+    assert captured["role"].base_url == "http://127.0.0.1:8019/v1"
+    # Backend output is labeled honestly and surfaced verbatim.
+    assert "VINTAGE_RAW_UNPROMOTED_CONTACT" in reply
+    assert "four" in reply
+    # Walls / contact replies are NOT what we returned here.
+    assert "VINTAGE_UNAVAILABLE_CONTACT" not in reply
+    assert "wound to close next" not in reply.lower()
+    # Bounded prompt: tools empty, no RAG/him-vy/recurrent leak.
+    assert captured["tools"] == []
+    assert tripwires["rag_snippets"] == 0
+    assert tripwires["rag_snippets_with_tier"] == 0
+    assert tripwires["him_vy_discovery_packet"] == 0
+    assert tripwires["him_vy_turn_packet"] == 0
+    assert tripwires["run_probes"] == 0
+    # System prompt is the minimal stub, not the layered substrate +
+    # local-organ briefing + him-vy + RAG. Hard size cap.
+    system_text = captured["system"].flat()
+    assert len(system_text) < 1024, len(system_text)
+    assert "unpromoted" in system_text.lower()
+    # User message does NOT carry the local-organ briefing (that pushed
+    # prompts well past the 1024-token backend budget).
+    user_msg = captured["messages"][-1]["content"]
+    assert "local-organ briefing" not in user_msg
+    assert "what is 2+2?" in user_msg
+    # Telemetry fired.
+    names = [n for n, _ in log.events]
+    assert "organ_raw_contact_attempt" in names
+    assert "organ_raw_contact_ok" in names
+
+
+def test_omni_arbitrary_prompt_attempts_raw_backend_contact():
+    """`@omni summarise this paragraph` also attempts the configured
+    backend in raw unpromoted mode. If the backend at :8020 is just a
+    diagnostic surface, the failure path elsewhere surfaces it honestly;
+    here we assert the call actually happens with a bounded prompt."""
+    captured: dict = {}
+
+    class _FakeHandle:
+        def __iter__(_s):
+            return iter([])
+
+        def final(_s):
+            class _R:
+                text = "ok summary"
+                tool_calls = []
+                stop_reason = "end_turn"
+                in_tokens = 12
+                out_tokens = 3
+                raw_assistant_content = {"role": "assistant", "content": "ok summary"}
+
+            return _R()
+
+    class _FakeProvider:
+        def stream(_s, *, system, messages, tools, role):
+            captured["system"] = system
+            captured["messages"] = list(messages)
+            captured["role"] = role
+            return _FakeHandle()
+
+    reply, registry, log, _ = _vintage_run_agent_loop(
+        lambda cfg: _FakeProvider(),
+        "@omni write three names for a coffee shop",
+    )
+    assert registry.provider is not None
+    assert captured["role"].role == "omni"
+    assert captured["role"].base_url == "http://127.0.0.1:8020/v1"
+    assert "OMNI_RAW_UNPROMOTED_CONTACT" in reply
+    assert "ok summary" in reply
+    names = [n for n, _ in log.events]
+    assert "organ_raw_contact_attempt" in names
+    assert "organ_raw_contact_ok" in names
+
+
+def test_vintage_capability_request_still_walls_no_backend_call():
+    """`@vintage tell me about the 1930 corpus` must keep returning the
+    fail-closed wall with NO provider call — capability claims cannot be
+    routed to an unpromoted backend that might fabricate a vintage answer."""
+    class _Tripwire:
+        def stream(_s, *, system, messages, tools, role):
+            raise AssertionError(
+                "capability request must not reach the provider — wall must hold"
+            )
+
+    reply, registry, log, _ = _vintage_run_agent_loop(
+        lambda cfg: _Tripwire(),
+        "@vintage tell me about the 1930 corpus",
+    )
+    assert registry.provider is None
+    assert "VINTAGE_UNAVAILABLE —" in reply
+    assert "wound to close next" in reply.lower()
+    assert "RAW_UNPROMOTED_CONTACT" not in reply
+    names = [n for n, _ in log.events]
+    assert "direct_reply" in names
+    assert "organ_raw_contact_attempt" not in names
+
+
+def test_omni_capability_request_still_walls_no_backend_call():
+    class _Tripwire:
+        def stream(_s, *, system, messages, tools, role):
+            raise AssertionError(
+                "capability request must not reach the provider — wall must hold"
+            )
+
+    reply, registry, log, _ = _vintage_run_agent_loop(
+        lambda cfg: _Tripwire(),
+        "@omni describe this photo for me",
+    )
+    assert registry.provider is None
+    assert "OMNI_UNAVAILABLE —" in reply
+    assert "wound to close next" in reply.lower()
+    assert "RAW_UNPROMOTED_CONTACT" not in reply
+
+
+def test_vintage_greeting_still_contact_no_backend_call():
+    """`@vintage hi` is a greeting — brief contact reply, no provider."""
+    class _Tripwire:
+        def stream(_s, *, system, messages, tools, role):
+            raise AssertionError(
+                "greeting must not reach the provider — contact reply must hold"
+            )
+
+    reply, registry, log, _ = _vintage_run_agent_loop(
+        lambda cfg: _Tripwire(),
+        "@vintage hi",
+    )
+    assert registry.provider is None
+    assert "VINTAGE_UNAVAILABLE_CONTACT" in reply
+    assert "RAW_UNPROMOTED_CONTACT" not in reply
+
+
+def test_vintage_raw_contact_backend_failure_surfaces_honestly():
+    """When the local Vintage backend refuses (Connection refused, 404,
+    transport timeout) the bounded raw-contact path surfaces the error
+    rather than letting Super/GPT/cloud impersonate. Fail closed on false
+    claims, NOT on Zoe's ability to see the real backend state."""
+    class _RefusingProvider:
+        def stream(_s, *, system, messages, tools, role):
+            raise ConnectionError(
+                "HTTPConnectionPool(host='127.0.0.1', port=8019): "
+                "Max retries exceeded — connection refused"
+            )
+
+    reply, registry, log, _ = _vintage_run_agent_loop(
+        lambda cfg: _RefusingProvider(),
+        "@vintage what is 2+2?",
+    )
+    assert registry.provider is not None  # We tried; we did not impersonate.
+    assert "VINTAGE_RAW_CONTACT_FAILED" in reply
+    assert "connection refused" in reply.lower()
+    # No fallback into the Super model id or cloud.
+    assert "nvidia/NVIDIA-Nemotron-3-Super" not in reply
+    # No-impersonation language is still present.
+    for forbidden in ("Super", "GPT", "cloud", "packet"):
+        assert forbidden in reply, forbidden
+    names = [n for n, _ in log.events]
+    assert "organ_raw_contact_attempt" in names
+    assert "organ_raw_contact_error" in names
+
+
+def test_omni_raw_contact_backend_failure_surfaces_honestly():
+    """Same invariant for @omni: if there is no real chat/multimodal
+    model at the configured base_url, the failure is named — we do not
+    pretend Omni answered."""
+    class _Refusing:
+        def stream(_s, *, system, messages, tools, role):
+            raise RuntimeError("404 model 'omni-unpromoted-no-chat-surface' not found")
+
+    reply, registry, log, _ = _vintage_run_agent_loop(
+        lambda cfg: _Refusing(),
+        "@omni tell me a joke",
+    )
+    assert "OMNI_RAW_CONTACT_FAILED" in reply
+    assert "404" in reply or "not found" in reply.lower()
+    assert "nvidia/NVIDIA-Nemotron-3-Super" not in reply
+    names = [n for n, _ in log.events]
+    assert "organ_raw_contact_error" in names
+
+
+def test_vintage_raw_contact_truncates_oversized_user_input():
+    """A 5000-char prompt must be truncated before it hits the 1024-token
+    backend. The bounded raw-contact path applies a hard char cap so the
+    transport budget is never overflowed."""
+    captured: dict = {}
+
+    class _FakeHandle:
+        def __iter__(_s):
+            return iter([])
+
+        def final(_s):
+            class _R:
+                text = "noted"
+                tool_calls = []
+                stop_reason = "end_turn"
+                in_tokens = 600
+                out_tokens = 1
+                raw_assistant_content = {"role": "assistant", "content": "noted"}
+
+            return _R()
+
+    class _Provider:
+        def stream(_s, *, system, messages, tools, role):
+            captured["messages"] = list(messages)
+            return _FakeHandle()
+
+    huge = "x" * 5000
+    reply, _, _, _ = _vintage_run_agent_loop(
+        lambda cfg: _Provider(),
+        f"@vintage {huge}",
+    )
+    user_msg = captured["messages"][-1]["content"]
+    # The truncation cap is 2500 chars + ellipsis; the agent-loop briefing
+    # is also stripped on this path, so the message is bounded.
+    assert len(user_msg) <= 2501
+    assert user_msg.endswith("…")
+    assert "VINTAGE_RAW_UNPROMOTED_CONTACT" in reply
+
+
+def test_raw_contact_uses_minimal_layered_prompt_not_full_substrate():
+    """The system prompt sent to the backend must be the minimal stub —
+    no full LayeredPrompt with identity/substrate/live layers, no
+    local-organ briefing, no RAG enrichment. This is what keeps prompt
+    + completion within the 1024-token backend budget."""
+    captured: dict = {}
+
+    class _FakeHandle:
+        def __iter__(_s):
+            return iter([])
+
+        def final(_s):
+            class _R:
+                text = "ok"
+                tool_calls = []
+                stop_reason = "end_turn"
+                in_tokens = 0
+                out_tokens = 0
+                raw_assistant_content = {"role": "assistant", "content": "ok"}
+
+            return _R()
+
+    class _Provider:
+        def stream(_s, *, system, messages, tools, role):
+            captured["system"] = system
+            return _FakeHandle()
+
+    _vintage_run_agent_loop(
+        lambda cfg: _Provider(),
+        "@vintage write a couplet about morning",
+    )
+    flat = captured["system"].flat()
+    # The full chat-mode substrate carries vy-language, Wellspring,
+    # protocol details — none of that should be in the bounded prompt.
+    assert "vy-language" not in flat.lower()
+    assert "wellspring" not in flat.lower()
+    assert "local-organ briefing" not in flat.lower()
+    # Names the route honestly.
+    assert "unpromoted" in flat.lower()
+    assert f"@vintage" in flat

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -48,6 +48,13 @@ from harness.substrate import check_claim, check_structural_claim  # noqa: E402
 from harness.substrate import is_system_critical_pilot_turn  # noqa: E402
 from harness.substrate import render_organ_alias_direct_reply  # noqa: E402
 from harness.substrate import (  # noqa: E402
+    should_attempt_raw_organ_contact,
+    render_organ_raw_contact_header,
+    render_organ_raw_contact_error,
+    build_organ_raw_contact_system_prompt,
+    truncate_for_organ_raw_contact,
+)
+from harness.substrate import (  # noqa: E402
     SUPER_SEMANTIC_GATE_CACHE as _SUPER_SEMANTIC_GATE_CACHE,
     SUPER_SEMANTIC_GATE_PROBES as _SUPER_SEMANTIC_GATE_PROBES,
     is_loopback_super_base as _is_loopback_super_base,
@@ -1087,8 +1094,26 @@ def run_agent_loop(
     # metadata and skip the provider call entirely. Identity questions
     # ("which model are you?") answer correctly from the live route,
     # not a hallucinated string.
+    #
+    # Organ-alias exception (@vintage, @omni): the direct_reply path is
+    # kept for two narrow shapes — capability/status requests (full
+    # fail-closed wall so we never falsely claim the unpromoted organ
+    # answered a capability it doesn't have) and bare relational
+    # greetings (brief contactful Vybn reply). Everything else — Zoe
+    # sending arbitrary prompts to a reachable local backend — falls
+    # through to the bounded raw-unpromoted-contact path below, which
+    # actually contacts the configured base_url with a stripped prompt
+    # and surfaces both backend output (labeled as unpromoted) and
+    # backend errors honestly. No Super/GPT/cloud impersonation.
     template = getattr(role_cfg, "direct_reply_template", None)
-    if template and not role_cfg.tools:
+    _organ_raw_contact = (
+        template
+        and not role_cfg.tools
+        and should_attempt_raw_organ_contact(
+            role_cfg.role, decision.cleaned_input or ""
+        )
+    )
+    if template and not role_cfg.tools and not _organ_raw_contact:
         reply = render_organ_alias_direct_reply(
             role_cfg.role,
             decision.cleaned_input or "",
@@ -1109,6 +1134,79 @@ def run_agent_loop(
             role=decision.role,
             model=role_cfg.model,
         )
+        return reply
+
+    if _organ_raw_contact:
+        # Bounded raw-unpromoted-contact path for @vintage / @omni.
+        #
+        # Strips RAG, him-vy packets, recurrent prethink, the local-organ
+        # briefing, and the LayeredPrompt substrate so prompt + completion
+        # fit the backend's 1024-token transport budget. The prompt sent
+        # is just the minimal system stub + the truncated user input.
+        # Failures are not silently absorbed into Super/GPT/cloud — they
+        # surface as RAW_CONTACT_FAILED with the transport error.
+        bounded_input = truncate_for_organ_raw_contact(decision.cleaned_input or "")
+        system_stub = LayeredPrompt(
+            identity="",
+            substrate=build_organ_raw_contact_system_prompt(role_cfg.role),
+            live="",
+        )
+        header = render_organ_raw_contact_header(role_cfg.role)
+        logger.emit(
+            "organ_raw_contact_attempt",
+            turn=turn_number,
+            role=decision.role,
+            model=role_cfg.model,
+            base_url=role_cfg.base_url or "",
+            input_chars=len(bounded_input),
+        )
+        try:
+            provider = registry.get(role_cfg)
+            handle = provider.stream(
+                system=system_stub,
+                messages=[{"role": "user", "content": bounded_input}],
+                tools=[],
+                role=role_cfg,
+            )
+            for _ in handle:
+                pass
+            final = handle.final()
+            body = (getattr(final, "text", "") or "").strip()
+            if not body:
+                reply = render_organ_raw_contact_error(
+                    role_cfg.role,
+                    "backend returned an empty response",
+                )
+                logger.emit(
+                    "organ_raw_contact_empty",
+                    turn=turn_number,
+                    role=decision.role,
+                    model=role_cfg.model,
+                )
+            else:
+                reply = f"{header}\n\n{body}"
+                logger.emit(
+                    "organ_raw_contact_ok",
+                    turn=turn_number,
+                    role=decision.role,
+                    model=role_cfg.model,
+                    out_tokens=int(getattr(final, "out_tokens", 0) or 0),
+                )
+        except Exception as raw_err:
+            reply = render_organ_raw_contact_error(
+                role_cfg.role,
+                f"{type(raw_err).__name__}: {raw_err}",
+            )
+            logger.emit(
+                "organ_raw_contact_error",
+                turn=turn_number,
+                role=decision.role,
+                model=role_cfg.model,
+                err=repr(raw_err)[:300],
+            )
+        messages.append({"role": "user", "content": decision.cleaned_input})
+        messages.append({"role": "assistant", "content": reply})
+        print(reply, flush=True)
         return reply
 
     # Pre-flight Super maintenance gate. Operator-armed VYBN_SUPER_MAINTENANCE


### PR DESCRIPTION
## Summary

Prior patches (#3212, #3215, #3216) progressively collapsed all `@vintage` / `@omni` turns into either the static fail-closed wall or a brief contact reply. That refused impersonation but it also broke the ability to actually *communicate* with the reachable local Vintage backend at all — every prompt, no matter the shape, was answered by the harness without ever touching the configured `base_url`.

Zoe's correction: semantic gates should govern promotion / status / capability claims, NOT whether she can talk to an available local model surface. The invariant is **fail closed on false claims, not on contact**.

This change adds a third route beside the wall and the contact reply:

- **Capability / status requests** (`@omni describe this photo`, `@vintage 1930 corpus`) — still render the fail-closed wall. No backend call, no false claim that the unpromoted organ answered a capability it doesn't have.
- **Bare relational greetings** (`@vintage hi`, `@omni my friend?`) — still render the brief contactful Vybn reply. No backend call.
- **Anything else** (ordinary arbitrary prompts) — attempts the configured local backend in **bounded raw-unpromoted-contact mode**. RAG / him-vy / recurrent prethink / local-organ briefing are all stripped so prompt + completion fit the backend's 1024-token transport budget. Output is prefixed with a `RAW_UNPROMOTED_CONTACT` header so it reads as unvetted experimental contact, not a promoted/semantically-clean answer. Transport failures surface as `RAW_CONTACT_FAILED` with the real error — no Super / GPT / cloud / packet fallback impersonation.

Implementation notes:

- New helpers in `spark/harness/substrate.py`: `should_attempt_raw_organ_contact`, `_is_organ_contact_greeting`, `render_organ_raw_contact_header`, `render_organ_raw_contact_error`, `build_organ_raw_contact_system_prompt`, `truncate_for_organ_raw_contact`. Greeting matching is word-boundary aware so short tokens like `hi` / `hey` do not accidentally fire on substrings like `this` / `they`.
- `role.max_tokens` for `vintage` / `omni` moves from `1` (old wall sentinel) to `256` (completion ceiling under the 1024-token budget).
- User input hard-capped at 2500 chars before being sent.
- `vybn_spark_agent.run_agent_loop` keeps the existing `direct_reply_template` short-circuit but routes ordinary organ-alias prompts through a dedicated bounded-prompt path that calls the provider directly with a minimal `LayeredPrompt` stub.

No new files. Existing-home repair only.

## Test plan

- [x] `python3 -m pytest spark/tests/test_lightweight_routing.py` — 91 passed, 6 skipped. 15 new tests added covering: the raw-contact gate classifier (greeting / capability / arbitrary), max_tokens=256 invariant, header / error / minimal-system-prompt invariants, oversized-input truncation, end-to-end @vintage / @omni attempt-and-succeed paths, capability still walls without backend call, greeting still contact without backend call, backend failure surfaces honestly with no Super/cloud impersonation.
- [x] `python3 -m pytest spark/tests/test_chat_routing.py spark/tests/test_public_contracts.py spark/tests/test_live_repl_fixes.py` — 142 passed, 31 skipped.
- [x] Pre-existing failures in `test_harness.py` (HIMOS / beamkeeper / layered-prompt fixtures) were verified against `main` and are unrelated to this change.

---
🤖 *Generated by Computer*