### PR TITLE
spark: route @vintage to guarded Talkie proxy; stop @omni dialing diagnostic packet

### DIFF
--- a/spark/harness/substrate.py
+++ b/spark/harness/substrate.py
@@ -721,25 +721,31 @@ _DEFAULT_ROLES: dict[str, RoleConfig] = {
         base_url="http://127.0.0.1:8000/v1",
         rag=False,
     ),
-    # Fail-closed contact repair: @vintage is unpromoted. The
-    # direct_reply_template refuses impersonation by Super/GPT/cloud/
+    # Fail-closed contact repair: @vintage routes to the guarded Talkie proxy
+    # (semantic_canary_and_post_1930_fail_closed) on the second cluster via
+    # the front SSH tunnel at 127.0.0.1:8004/v1, which forwards to
+    # spark-83bd:127.0.0.1:8019. The previous local :8019 hit a stale
+    # TinyLlama and produced false vintage outputs. Promotion state is
+    # tracked independently in server.py's capability table — this model id
+    # reflects the actual body at the route, not a promotion claim. The
+    # direct_reply_template still refuses impersonation by Super/GPT/cloud/
     # deterministic packets AND keeps Vybn present with Zoe through the
-    # current truthful body. Names the missing capability as next experiment.
+    # current truthful body; capability-shaped turns still emit the wall.
     "vintage": RoleConfig(
         role="vintage",
         provider="openai",
-        model="vintage-unpromoted-no-chat-surface",
+        model="vintage-1930-guarded-local",
         thinking="off",
         # Ordinary @vintage prompts (not capability/status, not bare
-        # greeting) attempt raw unpromoted contact with the local Vintage
-        # backend. The total transport budget on the backend is 1024
-        # tokens; the bounded raw-contact path strips RAG/him-vy/recurrent
-        # enrichment so prompt + completion fit. 256 is the completion
-        # ceiling, leaving ~768 tokens for the bounded prompt.
+        # greeting) attempt raw unpromoted contact with the guarded Talkie
+        # proxy via the front-local tunnel. The bounded raw-contact path
+        # still strips RAG/him-vy/recurrent enrichment so prompt + completion
+        # stay within the backend's transport budget; 256 is the completion
+        # ceiling.
         max_tokens=256,
         max_iterations=1,
         tools=[],
-        base_url="http://127.0.0.1:8019/v1",
+        base_url="http://127.0.0.1:8004/v1",
         temperature=0.0,
         rag=False,
         lightweight=True,
@@ -753,7 +759,14 @@ _DEFAULT_ROLES: dict[str, RoleConfig] = {
             " chat smoke, routed workload proof, named owner, rollback path."
         ),
     ),
-    # Fail-closed contact repair: @omni is unpromoted. The direct_reply_template
+    # Fail-closed contact repair: @omni is unpromoted. Front-local :8020 is a
+    # diagnostic packet, NOT a chat/multimodal model service; the intended
+    # body — NVIDIA Nemotron 3 Nano Omni — exists as assets on spark-83bd /
+    # spark-1c8f but is not served as a chat/perception endpoint reachable
+    # from this route. We deliberately leave base_url unset so the raw-
+    # unpromoted-contact gate refuses to dial the diagnostic packet as if it
+    # were Nano Omni. If/when a real Nano Omni service is tunneled into the
+    # front, set base_url to that endpoint. The direct_reply_template still
     # refuses impersonation by Super/GPT/cloud/deterministic packets AND keeps
     # Vybn present with Zoe through the current truthful body.
     "omni": RoleConfig(
@@ -761,15 +774,10 @@ _DEFAULT_ROLES: dict[str, RoleConfig] = {
         provider="openai",
         model="omni-unpromoted-no-chat-surface",
         thinking="off",
-        # See vintage: ordinary @omni prompts attempt raw unpromoted
-        # contact with whatever surface answers at the configured base_url.
-        # If no chat/multimodal model is served there the provider call
-        # surfaces the transport error honestly — Super/GPT/cloud do not
-        # impersonate Omni.
         max_tokens=256,
         max_iterations=1,
         tools=[],
-        base_url="http://127.0.0.1:8020/v1",
+        base_url=None,
         temperature=0.0,
         rag=False,
         lightweight=True,
@@ -974,11 +982,17 @@ def _is_organ_contact_greeting(cleaned_input: str) -> bool:
     return False
 
 
-def should_attempt_raw_organ_contact(role_name: str, cleaned_input: str) -> bool:
+def should_attempt_raw_organ_contact(role_name: str, cleaned_input: str, *, base_url: str | None = None) -> bool:
     """Gate for the bounded raw-unpromoted-contact path on @vintage / @omni.
 
     True only when:
       - role is one of the unpromoted organ aliases, AND
+      - the role has a configured base_url (no base_url means no real
+        chat/perception surface is reachable from this route — e.g. @omni
+        today, where front-local :8020 is a diagnostic packet, not a Nano
+        Omni service. Dialing the packet as if it were a model would
+        produce false outputs; the wall holds instead until a real service
+        is tunneled in), AND
       - the prompt does NOT name an unavailable Vintage/Omni capability
         (capability/status requests still get the honest wall — no false
         claim that the absent organ answered them), AND
@@ -988,9 +1002,11 @@ def should_attempt_raw_organ_contact(role_name: str, cleaned_input: str) -> bool
     Anything else — ordinary arbitrary prompts the user wants to send to
     the available local backend — attempts raw contact at the configured
     base_url, labeled as unpromoted/experimental in the agent loop, with
-    a bounded prompt so the 1024-token backend budget is respected.
+    a bounded prompt so the backend transport budget is respected.
     """
     if role_name not in _ORGAN_ALIAS_ROLES:
+        return False
+    if not (base_url and base_url.strip()):
         return False
     if _is_organ_capability_request(role_name, cleaned_input):
         return False

--- a/spark/router_policy.yaml
+++ b/spark/router_policy.yaml
@@ -95,8 +95,16 @@ roles:
 
   vintage:
     provider: openai
-    model: vintage-unpromoted-no-chat-surface
-    base_url: http://127.0.0.1:8019/v1
+    # 2026-05-17: @vintage now points at the guarded Talkie proxy reached
+    # through the front-Spark SSH tunnel at 127.0.0.1:8004/v1. That tunnel
+    # forwards to spark-83bd:127.0.0.1:8019, where the guarded Vintage proxy
+    # (semantic_canary_and_post_1930_fail_closed) wraps Talkie 1930. The
+    # previous front-local :8019 hit a stale TinyLlama and produced false
+    # vintage outputs. Promotion state is tracked independently in
+    # server.py's capability table; this model id reflects the actual body
+    # at the route, not a promotion claim.
+    model: vintage-1930-guarded-local
+    base_url: http://127.0.0.1:8004/v1
     # Bounded raw-contact path: ordinary @vintage prompts strip enrichment
     # so prompt + completion fit the backend's 1024-token budget. 256 is
     # the completion ceiling, leaving ~768 for the bounded prompt.
@@ -106,18 +114,24 @@ roles:
     tools: []
     rag: false
     lightweight: true
-    # Fail-closed contact repair: @vintage is unpromoted (no semantic-gated
-    # chat surface). The direct_reply_template refuses impersonation by Super,
-    # GPT, cloud, or any deterministic packet, AND keeps Vybn present with
-    # Zoe through the current truthful body. Names the gap as next experiment.
+    # Fail-closed contact repair: @vintage routes to a guarded Talkie proxy
+    # (semantic_canary_and_post_1930_fail_closed) on the second cluster via
+    # the front SSH tunnel; the chat surface is reachable but promotion is
+    # gated separately. The direct_reply_template still refuses impersonation
+    # by Super/GPT/cloud/deterministic packets AND keeps Vybn present with
+    # Zoe through the current truthful body; capability-shaped turns (1930
+    # corpus, vintage chat surface, endpoint workload) still emit the wall.
     direct_reply_template: "VINTAGE_UNAVAILABLE — @vintage is not promoted and has no live semantic-gated chat surface. I will not have Super, GPT, a cloud provider, or a deterministic packet answer as Vintage; that would be impersonation. But I, Vybn, am here with you through the current truthful body on this route, not absent. The wound to close next: Vintage endpoint readiness, semantic 1930/invariants chat smoke, routed workload proof, named owner, rollback path."
   omni:
     provider: openai
     model: omni-unpromoted-no-chat-surface
-    base_url: http://127.0.0.1:8020/v1
-    # See vintage: ordinary @omni prompts attempt raw unpromoted contact
-    # at the configured base_url. Transport failures surface honestly —
-    # no Super/GPT/cloud impersonation.
+    # 2026-05-17: front-local :8020 is a diagnostic packet, not a chat /
+    # multimodal model service. The intended body — NVIDIA Nemotron 3 Nano
+    # Omni — exists as assets on spark-83bd/spark-1c8f but is not served
+    # as a chat/perception endpoint reachable from this route. Leaving
+    # base_url unset is what tells the raw-unpromoted-contact gate not to
+    # dial the diagnostic packet as if it were Nano Omni. If/when a real
+    # Nano Omni service is tunneled into the front, set base_url to that.
     max_tokens: 256
     max_iterations: 1
     temperature: 0.0

--- a/spark/tests/test_lightweight_routing.py
+++ b/spark/tests/test_lightweight_routing.py
@@ -218,7 +218,11 @@ class TestExplicitOrganAliasesRouteToExperimentalEndpoints(unittest.TestCase):
         # Honest model id: not the Super model. Refuses impersonation.
         self.assertNotEqual(d.config.model, "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8")
         self.assertIn("omni", d.config.model.lower())
+        # Omni still has no served chat/perception surface — model id stays
+        # unpromoted and base_url is unset so raw-contact does not dial the
+        # diagnostic packet at :8020 as if it were Nano Omni.
         self.assertIn("unpromoted", d.config.model.lower())
+        self.assertFalse(d.config.base_url)
         self._assert_fail_closed_contact_template("omni", d.config.direct_reply_template)
 
     def test_default_policy_vintage_alias_fail_closed_with_contact_preserved(self):
@@ -226,14 +230,23 @@ class TestExplicitOrganAliasesRouteToExperimentalEndpoints(unittest.TestCase):
         self.assertEqual(d.role, "vintage")
         self.assertEqual(d.alias_used, "@vintage")
         self.assertEqual(d.config.provider, "openai")
-        # Honest model id: not the Super model. Refuses impersonation.
+        # Honest model id: not the Super model, not the stale local TinyLlama.
+        # Refuses impersonation; the route points at the guarded Talkie
+        # proxy via the front SSH tunnel (vintage-1930-guarded-local).
         self.assertNotEqual(d.config.model, "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8")
-        self.assertIn("vintage", d.config.model.lower())
-        self.assertIn("unpromoted", d.config.model.lower())
+        self.assertEqual(d.config.model, "vintage-1930-guarded-local")
+        self.assertEqual(d.config.base_url, "http://127.0.0.1:8004/v1")
         self._assert_fail_closed_contact_template("vintage", d.config.direct_reply_template)
 
     def test_yaml_policy_organ_aliases_fail_closed_with_contact_preserved(self):
         pol = load_policy(SPARK_DIR / "router_policy.yaml")
+        expected = {
+            "omni": {"model_substr": "unpromoted", "base_url_empty": True},
+            "vintage": {
+                "model_exact": "vintage-1930-guarded-local",
+                "base_url": "http://127.0.0.1:8004/v1",
+            },
+        }
         for alias, role in (("@omni", "omni"), ("@vintage", "vintage")):
             with self.subTest(alias=alias):
                 d = pol.classify(f"{alias} are you with me?")
@@ -244,7 +257,15 @@ class TestExplicitOrganAliasesRouteToExperimentalEndpoints(unittest.TestCase):
                     d.config.model,
                     "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
                 )
-                self.assertIn("unpromoted", d.config.model.lower())
+                exp = expected[role]
+                if "model_substr" in exp:
+                    self.assertIn(exp["model_substr"], d.config.model.lower())
+                if "model_exact" in exp:
+                    self.assertEqual(d.config.model, exp["model_exact"])
+                if exp.get("base_url_empty"):
+                    self.assertFalse(d.config.base_url)
+                if "base_url" in exp:
+                    self.assertEqual(d.config.base_url, exp["base_url"])
                 self._assert_fail_closed_contact_template(
                     role, d.config.direct_reply_template
                 )
@@ -907,9 +928,12 @@ def test_vintage_alias_routes_to_fail_closed_contact_template():
         assert d.alias_used == "@vintage"
         assert d.reason.startswith("alias=@vintage")
         assert d.config.provider == "openai"
-        # Refuses impersonation: not the Super model id.
+        # Refuses impersonation: not the Super model id, not the stale local
+        # TinyLlama. Route points at the guarded Talkie proxy via the front
+        # SSH tunnel (vintage-1930-guarded-local at 127.0.0.1:8004/v1).
         assert d.config.model != "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8"
-        assert "unpromoted" in d.config.model.lower()
+        assert d.config.model == "vintage-1930-guarded-local"
+        assert d.config.base_url == "http://127.0.0.1:8004/v1"
         assert d.config.rag is False
         _assert_fail_closed_contact_template("vintage", d.config.direct_reply_template)
 
@@ -1898,10 +1922,14 @@ def test_capability_tokens_still_wall_after_inversion():
 
 
 def test_raw_contact_gate_classifies_capability_greeting_and_arbitrary():
-    """The raw-contact gate fires only on arbitrary prompts. Capability /
-    status requests stay walled; bare relational greetings stay on the
-    brief contact reply; everything else attempts backend contact."""
+    """The raw-contact gate fires only on arbitrary prompts AND only when a
+    real backend URL is configured. Capability/status requests stay walled;
+    bare relational greetings stay on the brief contact reply; @omni stays
+    walled too because its base_url is unset (front-local :8020 is a
+    diagnostic packet, not Nano Omni)."""
     from harness.substrate import should_attempt_raw_organ_contact
+
+    vintage_url = "http://127.0.0.1:8004/v1"
 
     # Greetings / presence pings / thanks — contact reply, not backend.
     for greeting in (
@@ -1921,8 +1949,8 @@ def test_raw_contact_gate_classifies_capability_greeting_and_arbitrary():
         "hoo boy, hello",
         "good morning",
     ):
-        assert not should_attempt_raw_organ_contact("vintage", greeting), greeting
-        assert not should_attempt_raw_organ_contact("omni", greeting), greeting
+        assert not should_attempt_raw_organ_contact("vintage", greeting, base_url=vintage_url), greeting
+        assert not should_attempt_raw_organ_contact("omni", greeting, base_url=None), greeting
 
     # Capability / status requests — full wall, no backend call.
     for cap in (
@@ -1931,7 +1959,7 @@ def test_raw_contact_gate_classifies_capability_greeting_and_arbitrary():
         "is the vintage endpoint warm?",
         "route a workload through vintage",
     ):
-        assert not should_attempt_raw_organ_contact("vintage", cap), cap
+        assert not should_attempt_raw_organ_contact("vintage", cap, base_url=vintage_url), cap
     for cap in (
         "describe this photo",
         "look at this image",
@@ -1939,9 +1967,10 @@ def test_raw_contact_gate_classifies_capability_greeting_and_arbitrary():
         "what do you perceive?",
         "listen to this audio",
     ):
-        assert not should_attempt_raw_organ_contact("omni", cap), cap
+        assert not should_attempt_raw_organ_contact("omni", cap, base_url=None), cap
 
-    # Arbitrary ordinary prompts — backend contact attempted.
+    # Arbitrary ordinary prompts on @vintage — backend contact attempted
+    # against the guarded Talkie proxy.
     for arbitrary in (
         "what is 2+2?",
         "summarise this paragraph for me",
@@ -1949,12 +1978,25 @@ def test_raw_contact_gate_classifies_capability_greeting_and_arbitrary():
         "what would you say to a stranger on a train?",
         "give me three names for a coffee shop",
     ):
-        assert should_attempt_raw_organ_contact("vintage", arbitrary), arbitrary
-        assert should_attempt_raw_organ_contact("omni", arbitrary), arbitrary
+        assert should_attempt_raw_organ_contact("vintage", arbitrary, base_url=vintage_url), arbitrary
+        # @omni today has no served chat/perception surface; the diagnostic
+        # packet at :8020 must not be treated as raw model contact.
+        assert not should_attempt_raw_organ_contact("omni", arbitrary, base_url=None), arbitrary
+
+    # If a real Nano Omni service is tunneled in later, the gate must let
+    # arbitrary @omni prompts reach it — preserving Zoe's ability to
+    # communicate with the intended model when it is actually reachable.
+    for arbitrary in (
+        "summarise this paragraph for me",
+        "give me three names for a coffee shop",
+    ):
+        assert should_attempt_raw_organ_contact(
+            "omni", arbitrary, base_url="http://127.0.0.1:9999/v1"
+        ), arbitrary
 
     # Non-organ roles never use this gate.
-    assert not should_attempt_raw_organ_contact("chat", "what is 2+2?")
-    assert not should_attempt_raw_organ_contact("identity", "what is 2+2?")
+    assert not should_attempt_raw_organ_contact("chat", "what is 2+2?", base_url=vintage_url)
+    assert not should_attempt_raw_organ_contact("identity", "what is 2+2?", base_url=vintage_url)
 
 
 def test_organ_max_tokens_bounded_to_256_for_raw_contact():
@@ -1971,11 +2013,20 @@ def test_organ_max_tokens_bounded_to_256_for_raw_contact():
         for organ in ("vintage", "omni"):
             cfg = pol.roles[organ]
             assert cfg.max_tokens == 256, (label, organ, cfg.max_tokens)
-            # Honest model id: still names itself unpromoted; not Super.
-            assert "unpromoted" in cfg.model.lower(), (label, organ)
+            # Honest model id: not Super.
             assert cfg.model != "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8"
-            # Base URL still points at the configured backend.
-            assert cfg.base_url, (label, organ)
+        # Vintage now routes to the guarded Talkie proxy via the front
+        # tunnel; the model id names the actual body, base_url is the
+        # tunnel entry. Promotion is gated separately in server.py.
+        vintage_cfg = pol.roles["vintage"]
+        assert vintage_cfg.model == "vintage-1930-guarded-local", (label, vintage_cfg.model)
+        assert vintage_cfg.base_url == "http://127.0.0.1:8004/v1", (label, vintage_cfg.base_url)
+        # Omni still has no served chat/perception surface — model id stays
+        # unpromoted and base_url stays unset so raw-contact does not dial
+        # the diagnostic packet at :8020 as if it were Nano Omni.
+        omni_cfg = pol.roles["omni"]
+        assert "unpromoted" in omni_cfg.model.lower(), (label, omni_cfg.model)
+        assert not omni_cfg.base_url, (label, omni_cfg.base_url)
 
 
 def test_raw_contact_header_labels_route_as_unpromoted():
@@ -2159,7 +2210,10 @@ def test_vintage_arbitrary_prompt_attempts_raw_backend_contact():
     assert registry.provider is not None
     assert "system" in captured
     assert captured["role"].role == "vintage"
-    assert captured["role"].base_url == "http://127.0.0.1:8019/v1"
+    # @vintage now routes to the guarded Talkie proxy via the front-local
+    # SSH tunnel, not the stale local TinyLlama at :8019.
+    assert captured["role"].base_url == "http://127.0.0.1:8004/v1"
+    assert captured["role"].model == "vintage-1930-guarded-local"
     # Backend output is labeled honestly and surfaced verbatim.
     assert "VINTAGE_RAW_UNPROMOTED_CONTACT" in reply
     assert "four" in reply
@@ -2189,47 +2243,37 @@ def test_vintage_arbitrary_prompt_attempts_raw_backend_contact():
     assert "organ_raw_contact_ok" in names
 
 
-def test_omni_arbitrary_prompt_attempts_raw_backend_contact():
-    """`@omni summarise this paragraph` also attempts the configured
-    backend in raw unpromoted mode. If the backend at :8020 is just a
-    diagnostic surface, the failure path elsewhere surfaces it honestly;
-    here we assert the call actually happens with a bounded prompt."""
-    captured: dict = {}
+def test_omni_arbitrary_prompt_does_not_dial_diagnostic_packet():
+    """Until a real NVIDIA Nemotron 3 Nano Omni service is tunneled into
+    the front, `@omni` must NOT attempt raw model contact. Front-local
+    :8020 is a diagnostic packet, not a chat/perception model — dialing
+    it as raw contact would surface false Omni outputs. The wall (or the
+    brief contact reply) holds instead. This preserves Zoe's ability to
+    communicate with the intended Nano Omni body once it is actually
+    served; the gate keys off base_url so flipping the role to a real
+    Omni endpoint re-enables raw contact."""
 
-    class _FakeHandle:
-        def __iter__(_s):
-            return iter([])
-
-        def final(_s):
-            class _R:
-                text = "ok summary"
-                tool_calls = []
-                stop_reason = "end_turn"
-                in_tokens = 12
-                out_tokens = 3
-                raw_assistant_content = {"role": "assistant", "content": "ok summary"}
-
-            return _R()
-
-    class _FakeProvider:
+    class _Tripwire:
         def stream(_s, *, system, messages, tools, role):
-            captured["system"] = system
-            captured["messages"] = list(messages)
-            captured["role"] = role
-            return _FakeHandle()
+            raise AssertionError(
+                "@omni must not dial the diagnostic packet as raw model"
+                " contact while no Nano Omni service is configured"
+            )
 
     reply, registry, log, _ = _vintage_run_agent_loop(
-        lambda cfg: _FakeProvider(),
+        lambda cfg: _Tripwire(),
         "@omni write three names for a coffee shop",
     )
-    assert registry.provider is not None
-    assert captured["role"].role == "omni"
-    assert captured["role"].base_url == "http://127.0.0.1:8020/v1"
-    assert "OMNI_RAW_UNPROMOTED_CONTACT" in reply
-    assert "ok summary" in reply
+    # No provider call was made — the tripwire would have raised otherwise.
+    assert registry.provider is None
+    # Raw-contact labels are not present: this turn did not reach a backend.
+    assert "OMNI_RAW_UNPROMOTED_CONTACT" not in reply
+    assert "OMNI_RAW_CONTACT_FAILED" not in reply
+    # We still answer Zoe — either the brief contact reply or the wall.
+    assert ("OMNI_UNAVAILABLE_CONTACT" in reply) or ("OMNI_UNAVAILABLE —" in reply)
     names = [n for n, _ in log.events]
-    assert "organ_raw_contact_attempt" in names
-    assert "organ_raw_contact_ok" in names
+    assert "organ_raw_contact_attempt" not in names
+    assert "organ_raw_contact_ok" not in names
 
 
 def test_vintage_capability_request_still_walls_no_backend_call():
@@ -2297,7 +2341,7 @@ def test_vintage_raw_contact_backend_failure_surfaces_honestly():
     class _RefusingProvider:
         def stream(_s, *, system, messages, tools, role):
             raise ConnectionError(
-                "HTTPConnectionPool(host='127.0.0.1', port=8019): "
+                "HTTPConnectionPool(host='127.0.0.1', port=8004): "
                 "Max retries exceeded — connection refused"
             )
 
@@ -2318,23 +2362,31 @@ def test_vintage_raw_contact_backend_failure_surfaces_honestly():
     assert "organ_raw_contact_error" in names
 
 
-def test_omni_raw_contact_backend_failure_surfaces_honestly():
-    """Same invariant for @omni: if there is no real chat/multimodal
-    model at the configured base_url, the failure is named — we do not
-    pretend Omni answered."""
-    class _Refusing:
+def test_omni_arbitrary_prompt_keeps_wall_without_backend_dial():
+    """Companion to test_omni_arbitrary_prompt_does_not_dial_diagnostic_packet:
+    when @omni has no configured base_url, an arbitrary prompt must NOT
+    fall through to a raw-contact attempt — the wall (or contact reply)
+    holds without invoking the provider. The honest-failure surface
+    (OMNI_RAW_CONTACT_FAILED) still exists in render_organ_raw_contact_error
+    and would fire if a real backend later fails the dial; this test pins
+    that we do not even reach that path while no service is configured."""
+    class _Tripwire:
         def stream(_s, *, system, messages, tools, role):
-            raise RuntimeError("404 model 'omni-unpromoted-no-chat-surface' not found")
+            raise AssertionError(
+                "@omni must not dial any backend while base_url is unset"
+            )
 
     reply, registry, log, _ = _vintage_run_agent_loop(
-        lambda cfg: _Refusing(),
+        lambda cfg: _Tripwire(),
         "@omni tell me a joke",
     )
-    assert "OMNI_RAW_CONTACT_FAILED" in reply
-    assert "404" in reply or "not found" in reply.lower()
+    assert registry.provider is None
+    assert "OMNI_RAW_UNPROMOTED_CONTACT" not in reply
+    assert "OMNI_RAW_CONTACT_FAILED" not in reply
     assert "nvidia/NVIDIA-Nemotron-3-Super" not in reply
     names = [n for n, _ in log.events]
-    assert "organ_raw_contact_error" in names
+    assert "organ_raw_contact_attempt" not in names
+    assert "organ_raw_contact_error" not in names
 
 
 def test_vintage_raw_contact_truncates_oversized_user_input():

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -1110,7 +1110,9 @@ def run_agent_loop(
         template
         and not role_cfg.tools
         and should_attempt_raw_organ_contact(
-            role_cfg.role, decision.cleaned_input or ""
+            role_cfg.role,
+            decision.cleaned_input or "",
+            base_url=role_cfg.base_url,
         )
     )
     if template and not role_cfg.tools and not _organ_raw_contact:


### PR DESCRIPTION
## Summary

Critical repair after live fleet inventory. The front Spark (spark-2b7c) had been routing @vintage to a **stale local TinyLlama at 127.0.0.1:8019** (producing false vintage outputs) and @omni to a **diagnostic-packet endpoint at 127.0.0.1:8020** (not a Nano Omni model service). The intended bodies live on the second cluster:

- spark-83bd:127.0.0.1:8004 is direct Talkie (`talkie-1930-13b-it`); :8019 is the guarded Vintage proxy (`semantic_canary_and_post_1930_fail_closed`) wrapping Talkie. The front Spark has an ssh tunnel forwarding **front 127.0.0.1:8004 → spark-83bd:127.0.0.1:8019** (the guarded Vintage proxy, `vintage-1930-guarded-local`).
- NVIDIA Nemotron 3 Nano Omni assets are present on spark-83bd / spark-1c8f but no chat/perception service is running or tunneled into the front.

Existing-home repair only — **no new files**.

### Changes

- **`spark/router_policy.yaml` + `spark/harness/substrate.py`**: `@vintage` now uses `base_url: http://127.0.0.1:8004/v1` and `model: vintage-1930-guarded-local` (the front-tunnel entry into the guarded Talkie proxy). Promotion state remains in `server.py`'s capability table (independent of model id), so this is raw unpromoted contact with the intended body, **not** a promotion claim.
- **`spark/router_policy.yaml` + `spark/harness/substrate.py`**: `@omni` keeps the unpromoted model id but `base_url` is now unset (was `http://127.0.0.1:8020/v1`). `should_attempt_raw_organ_contact()` now requires a configured `base_url`, so the raw-contact path refuses to dial when no real service is present. If a Nano Omni service is later tunneled in, setting `base_url` re-enables raw contact — Zoe's ability to communicate with the intended model is preserved.
- **`spark/vybn_spark_agent.py`**: pass role `base_url` into the raw-contact gate.
- **`spark/tests/test_lightweight_routing.py`**: updated existing assertions (no new files):
  - `@vintage` model is `vintage-1930-guarded-local`, base_url is `http://127.0.0.1:8004/v1`.
  - `@omni` does not dial any backend while base_url is unset; the wall / contact reply holds.
  - Positive case: when a real Omni base_url is supplied, arbitrary prompts go through.

## Test plan

- [x] `python -m pytest spark/tests/test_lightweight_routing.py -q` — **91 passed, 6 skipped, 16 subtests passed**.
- [x] Pre-existing failures in `test_harness.py` (HimOS/commons/absorb/Beamkeeper) confirmed unrelated by re-running the failing test against the prior commit before our changes were applied.

### Expected live smokes

- `@vintage what's your favorite poem?` now goes through the front tunnel → spark-83bd guarded Vintage proxy → Talkie 1930, returning Gray's Elegy (or similar 1930-corpus output). Output is labeled `VINTAGE_RAW_UNPROMOTED_CONTACT` — the proxy is reachable but promotion stays gated separately. The stale TinyLlama is **not** consulted.
- `@omni <arbitrary>` does **not** dial the diagnostic packet at :8020. The honest fail-closed wall (or brief contact reply) is rendered instead, naming the gap (no semantic-gated multimodal/chat surface, owner, rollback). No false Nano Omni claims.
- Capability-shaped turns on either organ (`tell me about the 1930 corpus`, `describe this photo`) still emit the full wall — promotion-state walls remain first-class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)