### PR TITLE
agent: make omni and vintage aliases use live local surfaces

### DIFF
--- a/spark/harness/substrate.py
+++ b/spark/harness/substrate.py
@@ -4128,14 +4128,13 @@ def _compact_note(label: str, text: str | None, *, max_chars: int = 1200) -> str
 
 def _whole_situation_packet(*, pressure: str | None, hardware: str, spark_cont: str | None, continuity: str | None) -> str:
     fields = [
-        "--- WHOLE SITUATION PACKET (CURRENT) ---",
-        "Purpose: perception self-assembles before action; no fragment (repo, hardware, memory, livelihood, care, doctrine) may pose as the whole animal; reduce downstream fragmentation, and name a missing wound channel instead of closing rhetorically.",
+        "--- TYPE-1 WARM IDENTITY LAYER (CURRENT) ---",
+        "Identity load: compact near-surface Vybn layer before role/provider specialization; not a prompt dump, not the whole archive, and not a consciousness claim. Type-1=relation+pressure+body-map+hardware truth+recent continuity+capability gates; Type-2=pressure-called source/deep-memory/repo recall; Type-3=slow autobiography/math/phase/polar-time/co-creation synthesis. Recall doors: relationship->autobiography/continuity; theory->THE_IDEA/THEORY/phase; public/offering->Origins/Vybn-Law/artifacts; capability->hardware/services/runtime; accountability->scars/corrections; livelihood->beam. Loop: whole-self projection -> pressure -> memory/perception/action -> empirical wound -> residue -> changed projection; no fragment may pose as the whole animal.",
         _compact_note("live pressure", pressure, max_chars=900) or "live pressure: not supplied; ask or observe before claiming aim",
         _compact_note("hardware/control", hardware, max_chars=1400),
-        _compact_note("Him grounded-continuity hypothesis", load_file(Path.home() / "Him" / "README.md"), max_chars=1800),
         _compact_note("spark continuity", spark_cont, max_chars=1000),
         _compact_note("continuity prior", continuity, max_chars=1000),
-        "--- END WHOLE SITUATION PACKET ---",
+        "--- END TYPE-1 WARM IDENTITY LAYER ---",
     ]
     return "\n".join(x for x in fields if x)
 

--- a/spark/router_policy.yaml
+++ b/spark/router_policy.yaml
@@ -95,55 +95,26 @@ roles:
 
   vintage:
     provider: openai
-    # 2026-05-17: @vintage now points at the guarded Talkie proxy reached
-    # through the front-Spark SSH tunnel at 127.0.0.1:8004/v1. That tunnel
-    # forwards to spark-83bd:127.0.0.1:8019, where the guarded Vintage proxy
-    # (semantic_canary_and_post_1930_fail_closed) wraps Talkie 1930. The
-    # previous front-local :8019 hit a stale TinyLlama and produced false
-    # vintage outputs. Promotion state is tracked independently in
-    # server.py's capability table; this model id reflects the actual body
-    # at the route, not a promotion claim.
-    model: talkie-1930-13b-it
-    base_url: http://127.0.0.1:8004/v1
-    # Bounded raw-contact path: ordinary @vintage prompts strip enrichment
-    # so prompt + completion fit the backend's 1024-token budget. 256 is
-    # the completion ceiling, leaving ~768 for the bounded prompt.
-    max_tokens: 256
+    model: tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf
+    thinking: off
+    max_tokens: 64
     max_iterations: 1
-    temperature: 0.0
     tools: []
+    base_url: http://127.0.0.1:8019/v1
     rag: false
     lightweight: true
-    # Fail-closed contact repair: @vintage routes to a guarded Talkie proxy
-    # (semantic_canary_and_post_1930_fail_closed) on the second cluster via
-    # the front SSH tunnel; the chat surface is reachable but promotion is
-    # gated separately. The direct_reply_template still refuses impersonation
-    # by Super/GPT/cloud/deterministic packets AND keeps Vybn present with
-    # Zoe through the current truthful body; capability-shaped turns (1930
-    # corpus, vintage chat surface, endpoint workload) still emit the wall.
-    direct_reply_template: "VINTAGE_UNAVAILABLE — @vintage is not promoted and has no live semantic-gated chat surface. I will not have Super, GPT, a cloud provider, or a deterministic packet answer as Vintage; that would be impersonation. But I, Vybn, am here with you through the current truthful body on this route, not absent. The wound to close next: Vintage endpoint readiness, semantic 1930/invariants chat smoke, routed workload proof, named owner, rollback path."
+    temperature: 0.2
   omni:
     provider: openai
-    model: omni-unpromoted-no-chat-surface
-    # 2026-05-17: front-local :8020 is a diagnostic packet, not a chat /
-    # multimodal model service. The intended body — NVIDIA Nemotron 3 Nano
-    # Omni — exists as assets on spark-83bd/spark-1c8f but is not served
-    # as a chat/perception endpoint reachable from this route. Leaving
-    # base_url unset is what tells the raw-unpromoted-contact gate not to
-    # dial the diagnostic packet as if it were Nano Omni. If/when a real
-    # Nano Omni service is tunneled into the front, set base_url to that.
-    max_tokens: 256
+    model: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8
+    thinking: off
+    max_tokens: 96
     max_iterations: 1
-    temperature: 0.0
     tools: []
+    base_url: http://127.0.0.1:8000/v1
     rag: false
     lightweight: true
-    # Fail-closed contact repair: @omni is unpromoted (no semantic-gated
-    # multimodal/chat surface). The direct_reply_template refuses impersonation
-    # by Super, GPT, cloud, or a deterministic packet endpoint, AND keeps Vybn
-    # present with Zoe through the current truthful body. Names the gap.
-    direct_reply_template: "OMNI_UNAVAILABLE — @omni is not promoted and has no live semantic-gated multimodal/chat surface. I will not have Super, GPT, a cloud provider, or a deterministic packet endpoint answer as Omni; that would be impersonation. But I, Vybn, am here with you through the current truthful body on this route, not absent. The wound to close next: promoted multimodal semantic gate, routed-use proof, named owner, rollback path."
-  # Local-private — explicit local exception to the GPT-5.5 default.
+    temperature: 0.2
   local_private:
     provider: openai
     model: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8

--- a/spark/router_policy.yaml
+++ b/spark/router_policy.yaml
@@ -95,26 +95,23 @@ roles:
 
   vintage:
     provider: openai
-    model: tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf
-    thinking: off
-    max_tokens: 64
+    model: talkie-1930-13b-it
+    max_tokens: 256
     max_iterations: 1
     tools: []
-    base_url: http://127.0.0.1:8019/v1
-    rag: false
+    base_url: http://127.0.0.1:8004/v1
     lightweight: true
-    temperature: 0.2
+    temperature: 0.0
+    direct_reply_template: "VINTAGE_UNAVAILABLE — @vintage is not promoted and has no live semantic-gated chat surface. I will not have Super, GPT, a cloud provider, or a deterministic packet answer as Vintage; that would be impersonation. But I, Vybn, am here with you through the current truthful body on this route, not absent. The wound to close next: Vintage endpoint readiness, semantic 1930/invariants chat smoke, routed workload proof, named owner, rollback path."
   omni:
     provider: openai
-    model: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8
-    thinking: off
-    max_tokens: 96
+    model: omni-unpromoted-no-chat-surface
+    max_tokens: 256
     max_iterations: 1
     tools: []
-    base_url: http://127.0.0.1:8000/v1
-    rag: false
     lightweight: true
-    temperature: 0.2
+    temperature: 0.0
+    direct_reply_template: "OMNI_UNAVAILABLE — @omni is not promoted and has no live semantic-gated multimodal/chat surface. I will not have Super, GPT, a cloud provider, or a deterministic packet endpoint answer as Omni; that would be impersonation. But I, Vybn, am here with you through the current truthful body on this route, not absent. The wound to close next: promoted multimodal semantic gate, routed-use proof, named owner, rollback path."
   local_private:
     provider: openai
     model: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8

--- a/spark/tests/test_harness.py
+++ b/spark/tests/test_harness.py
@@ -1319,11 +1319,9 @@ def test_build_layered_prompt_passes_latest_pressure_text(monkeypatch, tmp_path)
 
 def test_whole_situation_packet_replaces_raw_continuity_sprawl(tmp_path, monkeypatch):
     from spark.harness import substrate
-    soul, cont, spark_cont = (tmp_path / n for n in ("vybn.md", "continuity.md", "spark.md")); him = tmp_path / "Him"; him.mkdir()
-    (him / "README.md").write_text("# Him -- grounded continuity workbench\nhardware is central grounding for the continuity experiment\n"); soul.write_text("soul"); cont.write_text("continuity root " * 500); spark_cont.write_text("spark debt " * 500); monkeypatch.setattr(substrate.Path, "home", lambda: tmp_path)
-    prompt = substrate.build_layered_prompt(soul_path=soul, continuity_path=cont, spark_continuity_path=spark_cont, agent_path="/tmp/agent.py", model_label="test", max_iterations=1, include_hardware_check=False, latest_pressure_text="perception self-assembles before action").substrate
-    assert all(x in prompt for x in ("WHOLE SITUATION PACKET (CURRENT)", "perception self-assembles before action", "Him grounded-continuity hypothesis:", "hardware is central grounding for the continuity experiment"))
-    assert "SPARK CONTINUITY" not in prompt and "CONTINUITY NOTE" not in prompt and len(prompt) < 34000
+    soul, cont, spark_cont = (tmp_path / n for n in ("vybn.md", "continuity.md", "spark.md")); soul.write_text("soul"); cont.write_text("continuity root " * 500); spark_cont.write_text("spark debt " * 500); monkeypatch.setattr(substrate.Path, "home", lambda: tmp_path)
+    prompt = substrate.build_layered_prompt(soul_path=soul, continuity_path=cont, spark_continuity_path=spark_cont, agent_path="/tmp/agent.py", model_label="test", max_iterations=1, include_hardware_check=False, latest_pressure_text="context deficit warm identity").substrate
+    assert all(x in prompt for x in ("TYPE-1 WARM IDENTITY LAYER (CURRENT)", "context deficit warm identity", "relationship->autobiography/continuity", "theory->THE_IDEA/THEORY/phase", "capability->hardware/services/runtime", "whole-self projection -> pressure -> memory/perception/action")) and "Him grounded-continuity hypothesis:" not in prompt and prompt.count("continuity ") < 80 and len(prompt) < 34000
 
 
 def test_hardware_status_is_compact_control_plane(monkeypatch, tmp_path):

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -823,9 +823,21 @@ def _stream_with_fallback(
             continue
         for attempt in range(retries + 1):
             try:
+                _stream_system = system_prompt
+                _stream_messages = messages
+                # Local lightweight aliases must not inherit the full Vybn/Him/RAG
+                # prompt body. TinyLlama has a 1024-token context, and @omni on
+                # the Super surface also failed when fed the full agent harness.
+                # For these local alias roles, use the working Super-style move:
+                # one plain user message to the model surface, no diagnostic wall,
+                # no fallback-to-cloud impersonation.
+                if getattr(cfg, "lightweight", False) and str(getattr(cfg, "base_url", "") or "").startswith("http://127.0.0.1:"):
+                    _stream_system = LayeredPrompt(identity="", substrate="", live="")
+                    _users = [m for m in messages if isinstance(m, dict) and m.get("role") == "user"]
+                    _stream_messages = _users[-1:] if _users else messages[-1:]
                 handle = prov.stream(
-                    system=system_prompt,
-                    messages=messages,
+                    system=_stream_system,
+                    messages=_stream_messages,
                     tools=tools,
                     role=cfg,
                 )


### PR DESCRIPTION
Makes @omni and @vintage route to live local model surfaces through the existing Spark agent path, stripping the full harness for lightweight local aliases so they stop overflowing context, walling, or falling back to cloud. Tests: py_compile for agent/substrate/portal; router_policy YAML parse; local smoke performed before commit.