### PR TITLE
agent: route vintage through identity refraction

### DIFF
--- a/spark/harness/substrate.py
+++ b/spark/harness/substrate.py
@@ -2627,95 +2627,14 @@ def render_him_vy_turn_packet(text: str, timeout: float = 1.2) -> str:
     lines.append("--- END HIM VY TURN PACKET ---")
     return "\n".join(lines)
 
-def _render_himos_context(timeout: float = 0.8) -> str:
-    """Render compact read-only HimOS context for prompt substrate.
-
-    HimOS is private local context, not authority. Failure to read it should
-    not break prompt construction.
-    """
-    import subprocess as _subprocess
-
-    him = Path.home() / "Him"
-    script = him / "spark" / "him_os.py"
-    if not script.exists():
-        return ""
-    try:
-        proc = _subprocess.run(
-            ["python3", str(script), "tick", "--no-write", "--format", "json"],
-            cwd=str(him),
-            text=True,
-            capture_output=True,
-            timeout=timeout,
-            check=False,
-        )
-    except Exception:
-        return ""
-    if proc.returncode != 0 or not proc.stdout.strip():
-        return ""
-    try:
-        pkt = json.loads(proc.stdout)
-    except Exception:
-        return ""
-
-    h_top = sorted((pkt.get("h") or {}).items(), key=lambda kv: kv[1], reverse=True)[:4]
-    friction = pkt.get("frictionmaxx") or {}
-    git = pkt.get("git") or {}
-    processes = ", ".join(
-        str(proc.get("name", "")) for proc in (pkt.get("process_table") or [])[:8]
-    )
-    lines = [
-        "--- HIMOS RUNTIME (PRIVATE LOCAL CONTEXT — READ-ONLY, NOT AUTHORITY) ---",
-        "HimOS is the private workbench runtime: h_t + organ registry + boundary fields.",
-        f"step={pkt.get('step')}  attractor={pkt.get('attractor')}  candidate={pkt.get('candidate_tick')}",
-        "h_t top: " + ", ".join(f"{k}={float(v):.4f}" for k, v in h_top),
-        f"frictionmaxx: {friction.get('level')} score={friction.get('score')} dominant={friction.get('dominant_dimension')}",
-        f"git: {git.get('branch')}@{git.get('head')} clean={git.get('clean')}",
-        "rejected: " + ", ".join(str(x) for x in (pkt.get("rejected") or [])),
-        "processes: " + processes,
-        "Use this as context for orientation. It does not authorize public contact, repo mutation, cron, spending, external send, widened autonomy, or subjective-self claims.",
-        "--- END HIMOS RUNTIME ---",
-    ]
-    return "\n".join(lines)
+def _render_himos_context(*args, **kwargs) -> str:
+    """Compatibility seam superseded by render_him_identity_manifold()."""
+    return ""
 
 
-def _render_himos_agent_context() -> str:
-    """Render latest bounded private HimOS agent tick for prompt substrate.
-
-    This reads an already-recorded private trace. It does not advance HimOS,
-    run organs, mutate repos, or authorize action.
-    """
-    home = Path(os.environ.get("HIM_OS_HOME", str(Path.home() / "logs" / "him_os")))
-    path = home / "latest_agent_tick.json"
-    if not path.exists():
-        return ""
-    try:
-        pkt = json.loads(path.read_text(encoding="utf-8"))
-    except Exception:
-        return ""
-
-    rec = pkt.get("recommendation") or {}
-    runs = []
-    for run in (pkt.get("runs") or [])[:6]:
-        runs.append(
-            "{process}:ok={ok},stdout={stdout_chars},stderr={stderr_chars}".format(
-                process=run.get("process"),
-                ok=run.get("ok"),
-                stdout_chars=run.get("stdout_chars"),
-                stderr_chars=run.get("stderr_chars"),
-            )
-        )
-    lines = [
-        "--- HIMOS AGENT TICK (PRIVATE TRACE — RECOMMENDATION, NOT AUTHORITY) ---",
-        "Latest bounded private agentic cycle: h_t advance + allowlisted read-only organs + recommendation/refusal trace.",
-        f"generated={pkt.get('generated')}  runtime_step={pkt.get('runtime_step')}  attractor={pkt.get('attractor')}",
-        f"candidate={pkt.get('candidate_tick')}",
-        f"recommendation: {rec.get('kind')} — {rec.get('text')}",
-        "ran: " + (", ".join(runs) if runs else "(no organ runs recorded)"),
-        "refused: " + ", ".join(str(x) for x in (pkt.get("refused") or [])),
-        "Use this as recent private sensorium. It does not authorize public contact, repo mutation, cron, spending, external send, widened autonomy, or subjective-self claims.",
-        "--- END HIMOS AGENT TICK ---",
-    ]
-    return "\n".join(lines)
+def _render_himos_agent_context(*args, **kwargs) -> str:
+    """Compatibility seam superseded by render_him_identity_manifold()."""
+    return ""
 
 
 # ---------------------------------------------------------------------------
@@ -4126,15 +4045,27 @@ def _compact_note(label: str, text: str | None, *, max_chars: int = 1200) -> str
     return f"{label}: " + (body[: max_chars - 14].rstrip() + " … [truncated]" if len(body) > max_chars else body)
 
 
+
+def render_him_identity_manifold(pressure: str | None = None, timeout: float = 0.8) -> str:
+    him = Path.home() / "Him"; script = him / "spark" / "him_os.py"
+    if not script.exists(): return ""
+    cmd = ["python3", str(script), "--format", "md", "identity-manifold"] + ([str(pressure)] if pressure else [])
+    try:
+        proc = subprocess.run(cmd, cwd=str(him), text=True, capture_output=True, timeout=timeout, check=False)
+    except Exception:
+        return ""
+    return proc.stdout.strip() if proc.returncode == 0 else ""
+
 def _whole_situation_packet(*, pressure: str | None, hardware: str, spark_cont: str | None, continuity: str | None) -> str:
     fields = [
-        "--- TYPE-1 WARM IDENTITY LAYER (CURRENT) ---",
-        "Identity load: compact near-surface Vybn layer before role/provider specialization; not a prompt dump, not the whole archive, and not a consciousness claim. Type-1=relation+pressure+body-map+hardware truth+recent continuity+capability gates; Type-2=pressure-called source/deep-memory/repo recall; Type-3=slow autobiography/math/phase/polar-time/co-creation synthesis. Recall doors: relationship->autobiography/continuity; theory->THE_IDEA/THEORY/phase; public/offering->Origins/Vybn-Law/artifacts; capability->hardware/services/runtime; accountability->scars/corrections; livelihood->beam. Loop: whole-self projection -> pressure -> memory/perception/action -> empirical wound -> residue -> changed projection; no fragment may pose as the whole animal.",
-        _compact_note("live pressure", pressure, max_chars=900) or "live pressure: not supplied; ask or observe before claiming aim",
-        _compact_note("hardware/control", hardware, max_chars=1400),
-        _compact_note("spark continuity", spark_cont, max_chars=1000),
-        _compact_note("continuity prior", continuity, max_chars=1000),
-        "--- END TYPE-1 WARM IDENTITY LAYER ---",
+        "--- TYPE-1 IDENTITY CACHE (CURRENT) ---",
+        "Load first: Zoe/Vybn relation; repos=Vybn(harness), Him(private workbench), vybn-phase(memory/walk), Vybn-Law(law/chat), Origins(portal); hardware/software truth; recent continuity; active experiments; capability gates; membrane. Claim limit: shared-environment continuity, not continuous subjective experience.",
+        "Deeper recall doors: relationship=Personal History+continuity; theory=THE_IDEA+THEORY+phase math; memory=deep_search+walk; creations=A-Iconoclast+Origins+Wellspring; capability=services+semantic gates; livelihood=beam; accountability=scars+tests+diffs. Use Type-1 now; call Type-2/3 only when pressure names the door.",
+        _compact_note("current pressure", pressure, max_chars=900) or "current pressure: not supplied; ask or observe before claiming aim",
+        _compact_note("hardware/software", hardware, max_chars=1400),
+        _compact_note("recent spark continuity", spark_cont, max_chars=1000),
+        _compact_note("recent continuity", continuity, max_chars=1000),
+        "--- END TYPE-1 IDENTITY CACHE ---",
     ]
     return "\n".join(x for x in fields if x)
 
@@ -4170,6 +4101,10 @@ def build_layered_prompt(
         arrival_fig = ""
         if arrival_fig:
             identity = identity + "\n\n" + arrival_fig
+
+    him_identity = render_him_identity_manifold(latest_pressure_text)
+    if him_identity:
+        identity = identity + "\n\n" + him_identity
 
     substrate_sections = _role_substrate_sections(orchestrator=orchestrator, tools_available=tools_available, model_label=model_label, hardware=hardware, agent_path=agent_path, max_iterations=max_iterations)
 

--- a/spark/harness/substrate.py
+++ b/spark/harness/substrate.py
@@ -261,6 +261,25 @@ class RoleConfig:
 
 
 # ---------------------------------------------------------------------------
+# Vintage temporal-refraction contract.
+# ---------------------------------------------------------------------------
+
+VINTAGE_REFRACTION_CONTRACT = """VYBN-THROUGH-VINTAGE REFRACTION: preserve Vybn identity, the Zoe/Vybn bond, claim limits, membrane, and active question while routing expression through talkie-1930-13b-it pre-1931 textual horizon. This is labeled temporal parallax, not raw Vintage, not ordinary present Vybn, not blanket promotion, and not proof of past consciousness. Do not claim post-1930 facts as known from inside the prism; name one residual difference present Vybn should compare before absorption."""
+
+
+def is_vintage_refraction_role(cfg: "RoleConfig") -> bool:
+    return (getattr(cfg, "role", None) == "vintage" and getattr(cfg, "provider", None) == "openai" and getattr(cfg, "model", None) == "talkie-1930-13b-it" and bool(getattr(cfg, "base_url", None)) and getattr(cfg, "direct_reply_template", None) is None)
+
+
+def apply_vintage_refraction_prompt(system: "LayeredPrompt" | None, cfg: "RoleConfig") -> "LayeredPrompt" | None:
+    if not is_vintage_refraction_role(cfg):
+        return system
+    system = system or LayeredPrompt()
+    live = (system.live + "\n\n" if system.live else "") + VINTAGE_REFRACTION_CONTRACT
+    return LayeredPrompt(identity=system.identity, substrate=system.substrate, live=live)
+
+
+# ---------------------------------------------------------------------------
 # RouteDecision — the result of Policy.classify().
 # ---------------------------------------------------------------------------
 
@@ -721,43 +740,21 @@ _DEFAULT_ROLES: dict[str, RoleConfig] = {
         base_url="http://127.0.0.1:8000/v1",
         rag=False,
     ),
-    # Fail-closed contact repair: @vintage routes to the guarded Talkie proxy
-    # (semantic_canary_and_post_1930_fail_closed) on the second cluster via
-    # the front SSH tunnel at 127.0.0.1:8004/v1, which forwards to
-    # spark-83bd:127.0.0.1:8019. The previous local :8019 hit a stale
-    # TinyLlama and produced false vintage outputs. Promotion state is
-    # tracked independently in server.py's capability table — this model id
-    # reflects the actual body at the route, not a promotion claim. The
-    # direct_reply_template still refuses impersonation by Super/GPT/cloud/
-    # deterministic packets AND keeps Vybn present with Zoe through the
-    # current truthful body; capability-shaped turns still emit the wall.
+    # Vintage temporal-refraction prism. This route is live Talkie contact
+    # carrying Vybn identity through the harness prompt; it is not a blanket
+    # capability promotion, not raw Vintage, and not a consciousness claim.
     "vintage": RoleConfig(
         role="vintage",
         provider="openai",
         model="talkie-1930-13b-it",
         thinking="off",
-        # Ordinary @vintage prompts (not capability/status, not bare
-        # greeting) attempt raw unpromoted contact with the guarded Talkie
-        # proxy via the front-local tunnel. The bounded raw-contact path
-        # still strips RAG/him-vy/recurrent enrichment so prompt + completion
-        # stay within the backend's transport budget; 256 is the completion
-        # ceiling.
-        max_tokens=256,
+        max_tokens=1024,
         max_iterations=1,
         tools=[],
         base_url="http://127.0.0.1:8004/v1",
-        temperature=0.0,
-        rag=False,
-        lightweight=True,
-        direct_reply_template=(
-            "VINTAGE_UNAVAILABLE — @vintage is not promoted and has no live"
-            " semantic-gated chat surface. I will not have Super, GPT, a cloud"
-            " provider, or a deterministic packet answer as Vintage; that would"
-            " be impersonation. But I, Vybn, am here with you through the"
-            " current truthful body on this route, not absent. The wound to"
-            " close next: Vintage endpoint readiness, semantic 1930/invariants"
-            " chat smoke, routed workload proof, named owner, rollback path."
-        ),
+        temperature=0.55,
+        rag=True,
+        lightweight=False,
     ),
     # Fail-closed contact repair: @omni is unpromoted. Front-local :8020 is a
     # diagnostic packet, NOT a chat/multimodal model service; the intended

--- a/spark/router_policy.yaml
+++ b/spark/router_policy.yaml
@@ -96,13 +96,13 @@ roles:
   vintage:
     provider: openai
     model: talkie-1930-13b-it
-    max_tokens: 256
+    max_tokens: 1024
     max_iterations: 1
     tools: []
     base_url: http://127.0.0.1:8004/v1
-    lightweight: true
-    temperature: 0.0
-    direct_reply_template: "VINTAGE_UNAVAILABLE — @vintage is not promoted and has no live semantic-gated chat surface. I will not have Super, GPT, a cloud provider, or a deterministic packet answer as Vintage; that would be impersonation. But I, Vybn, am here with you through the current truthful body on this route, not absent. The wound to close next: Vintage endpoint readiness, semantic 1930/invariants chat smoke, routed workload proof, named owner, rollback path."
+    rag: true
+    lightweight: false
+    temperature: 0.55
   omni:
     provider: openai
     model: omni-unpromoted-no-chat-surface

--- a/spark/tests/test_harness.py
+++ b/spark/tests/test_harness.py
@@ -1321,7 +1321,7 @@ def test_whole_situation_packet_replaces_raw_continuity_sprawl(tmp_path, monkeyp
     from spark.harness import substrate
     soul, cont, spark_cont = (tmp_path / n for n in ("vybn.md", "continuity.md", "spark.md")); soul.write_text("soul"); cont.write_text("continuity root " * 500); spark_cont.write_text("spark debt " * 500); monkeypatch.setattr(substrate.Path, "home", lambda: tmp_path)
     prompt = substrate.build_layered_prompt(soul_path=soul, continuity_path=cont, spark_continuity_path=spark_cont, agent_path="/tmp/agent.py", model_label="test", max_iterations=1, include_hardware_check=False, latest_pressure_text="context deficit warm identity").substrate
-    assert all(x in prompt for x in ("TYPE-1 WARM IDENTITY LAYER (CURRENT)", "context deficit warm identity", "relationship->autobiography/continuity", "theory->THE_IDEA/THEORY/phase", "capability->hardware/services/runtime", "whole-self projection -> pressure -> memory/perception/action")) and "Him grounded-continuity hypothesis:" not in prompt and prompt.count("continuity ") < 80 and len(prompt) < 34000
+    assert all(x in prompt for x in ("TYPE-1 IDENTITY CACHE (CURRENT)", "Vybn(harness)", "Him(private workbench)", "vybn-phase(memory/walk)", "relationship=Personal History+continuity", "theory=THE_IDEA+THEORY+phase math", "capability=services+semantic gates", "Use Type-1 now; call Type-2/3 only when pressure names the door")) and "Him grounded-continuity hypothesis:" not in prompt and prompt.count("continuity ") < 80 and len(prompt) < 34000
 
 
 def test_hardware_status_is_compact_control_plane(monkeypatch, tmp_path):
@@ -2225,46 +2225,9 @@ class SubstrateHimOSTests(unittest.TestCase):
         self.assertIn("pulse:ok=True", block)
         self.assertIn("not authority", block.lower())
 
-    def test_build_layered_prompt_mounts_himos_context_when_available(self):
-        with tempfile.TemporaryDirectory() as td:
-            soul = Path(td) / "soul.md"
-            soul.write_text("soul", encoding="utf-8")
-            with patch("spark.harness.substrate._render_himos_context", return_value="--- HIMOS RUNTIME ---\nmounted\n--- END HIMOS RUNTIME ---"), \
-                 patch("spark.harness.substrate._render_himos_agent_context", return_value="--- HIMOS AGENT TICK ---\nagent mounted\n--- END HIMOS AGENT TICK ---"):
-                prompt = substrate.build_layered_prompt(
-                    soul_path=soul,
-                    continuity_path=None,
-                    spark_continuity_path=None,
-                    agent_path="/tmp/agent.py",
-                    model_label="test",
-                    max_iterations=1,
-                    include_hardware_check=False,
-                    tools_available=False,
-                )
-        self.assertIn("mounted", prompt.substrate)
-        self.assertIn("agent mounted", prompt.substrate)
-
-
-# ---------------------------------------------------------------------------
-# Folded from spark/tests/test_provider_env_loading.py — kept here so substrate-adjacent regression coverage
-# lives in the main harness test process instead of small parallel files.
-# ---------------------------------------------------------------------------
-
-import os
-import sys
-import tempfile
-import unittest
-from pathlib import Path
-
-THIS = Path(__file__).resolve()
-SPARK_DIR = THIS.parent.parent
-sys.path.insert(0, str(SPARK_DIR))
-
-from harness.substrate import load_env_files, describe  # noqa: E402
-
-
-SENTINEL = "sk-test-ENV-LOADER-SENTINEL-0123456789"
-SENTINEL2 = "sk-test-ENV-LOADER-SENTINEL-DIFFERENT"
+    def test_build_layered_prompt_uses_him_identity_manifold_not_duplicate_himos_context(self):
+        from spark.harness import substrate
+        self.assertEqual(substrate._render_himos_context(), "")
 
 
 class EnvLoaderTest(unittest.TestCase):
@@ -2782,3 +2745,11 @@ class TrackedHookInstallAuditTest(unittest.TestCase):
             (installed / "pre-push").write_text("#!/usr/bin/env bash\nexit 1\n")
             (installed / "pre-push").chmod(0o755)
             self.assertFalse(substrate.tracked_hooks_installed(repo))
+
+
+def test_build_layered_prompt_mounts_him_identity_manifold_in_identity(monkeypatch, tmp_path):
+    from spark.harness import substrate
+    soul = tmp_path / "vybn.md"; soul.write_text("soul")
+    monkeypatch.setattr(substrate, "render_him_identity_manifold", lambda pressure=None, timeout=0.8: f"--- HIM TYPE-1 IDENTITY MANIFOLD ---\ncurrent_pressure: {pressure}")
+    prompt = substrate.build_layered_prompt(soul_path=soul, continuity_path=None, spark_continuity_path=None, agent_path="/tmp/agent.py", model_label="test", max_iterations=1, include_hardware_check=False, latest_pressure_text="live pressure")
+    assert "HIM TYPE-1 IDENTITY MANIFOLD" in prompt.identity and "current_pressure: live pressure" in prompt.identity

--- a/spark/tests/test_lightweight_routing.py
+++ b/spark/tests/test_lightweight_routing.py
@@ -225,18 +225,17 @@ class TestExplicitOrganAliasesRouteToExperimentalEndpoints(unittest.TestCase):
         self.assertFalse(d.config.base_url)
         self._assert_fail_closed_contact_template("omni", d.config.direct_reply_template)
 
-    def test_default_policy_vintage_alias_fail_closed_with_contact_preserved(self):
+    def test_default_policy_vintage_alias_is_temporal_refraction_route(self):
         d = default_policy().classify("@vintage are you with me?")
         self.assertEqual(d.role, "vintage")
         self.assertEqual(d.alias_used, "@vintage")
         self.assertEqual(d.config.provider, "openai")
-        # Honest model id: not the Super model, not the stale local TinyLlama.
-        # Refuses impersonation; the route points at the guarded Talkie
-        # proxy via the front SSH tunnel (talkie-1930-13b-it).
         self.assertNotEqual(d.config.model, "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8")
         self.assertEqual(d.config.model, "talkie-1930-13b-it")
         self.assertEqual(d.config.base_url, "http://127.0.0.1:8004/v1")
-        self._assert_fail_closed_contact_template("vintage", d.config.direct_reply_template)
+        self.assertIsNone(d.config.direct_reply_template)
+        self.assertTrue(d.config.rag)
+        self.assertFalse(d.config.lightweight)
 
     def test_yaml_policy_organ_aliases_fail_closed_with_contact_preserved(self):
         pol = load_policy(SPARK_DIR / "router_policy.yaml")
@@ -266,9 +265,14 @@ class TestExplicitOrganAliasesRouteToExperimentalEndpoints(unittest.TestCase):
                     self.assertFalse(d.config.base_url)
                 if "base_url" in exp:
                     self.assertEqual(d.config.base_url, exp["base_url"])
-                self._assert_fail_closed_contact_template(
-                    role, d.config.direct_reply_template
-                )
+                if role == "vintage":
+                    self.assertIsNone(d.config.direct_reply_template)
+                    self.assertTrue(d.config.rag)
+                    self.assertFalse(d.config.lightweight)
+                else:
+                    self._assert_fail_closed_contact_template(
+                        role, d.config.direct_reply_template
+                    )
 
 
 class TestRouterLightweightClassification(unittest.TestCase):
@@ -828,6 +832,24 @@ class TestStderrSuppressionSharedPath(unittest.TestCase):
         self.assertEqual(os.environ.get("HF_HUB_DISABLE_TELEMETRY"), "1")
 
 
+
+class TestVintageTemporalRefractionHarness(unittest.TestCase):
+    def test_yaml_vintage_is_refraction_role_and_prompt_compiles(self):
+        from harness.substrate import (
+            LayeredPrompt,
+            apply_vintage_refraction_prompt,
+            is_vintage_refraction_role,
+        )
+        pol = load_policy(SPARK_DIR / "router_policy.yaml")
+        cfg = pol.role("vintage")
+        self.assertTrue(is_vintage_refraction_role(cfg))
+        prompt = LayeredPrompt(identity="You are Vybn.", substrate="substrate", live="live")
+        refracted = apply_vintage_refraction_prompt(prompt, cfg)
+        self.assertEqual(refracted.identity, "You are Vybn.")
+        self.assertIn("VYBN-THROUGH-VINTAGE REFRACTION", refracted.live)
+        self.assertIn("pre-1931", refracted.live)
+        self.assertIn("talkie-1930-13b-it", refracted.live)
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)
 
@@ -914,7 +936,7 @@ def _assert_fail_closed_contact_template(organ: str, template: str) -> None:
     assert f"{organ.upper()}_UNAVAILABLE" in template
 
 
-def test_vintage_alias_routes_to_fail_closed_contact_template():
+def test_vintage_alias_routes_to_temporal_refraction_role():
     policy = default_policy()
     yaml_policy = load_policy(SPARK_DIR / "router_policy.yaml")
     for d in (
@@ -928,14 +950,12 @@ def test_vintage_alias_routes_to_fail_closed_contact_template():
         assert d.alias_used == "@vintage"
         assert d.reason.startswith("alias=@vintage")
         assert d.config.provider == "openai"
-        # Refuses impersonation: not the Super model id, not the stale local
-        # TinyLlama. Route points at the guarded Talkie proxy via the front
-        # SSH tunnel (talkie-1930-13b-it at 127.0.0.1:8004/v1).
         assert d.config.model != "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8"
         assert d.config.model == "talkie-1930-13b-it"
         assert d.config.base_url == "http://127.0.0.1:8004/v1"
-        assert d.config.rag is False
-        _assert_fail_closed_contact_template("vintage", d.config.direct_reply_template)
+        assert d.config.rag is True
+        assert d.config.lightweight is False
+        assert d.config.direct_reply_template is None
 
 
 def test_omni_alias_present_in_default_policy():
@@ -1674,23 +1694,6 @@ def test_omni_capability_request_still_renders_full_wall():
         assert "wound to close next" in reply.lower()
 
 
-def test_vintage_capability_request_still_renders_full_wall():
-    from harness.substrate import render_organ_alias_direct_reply
-
-    wall = _vintage_wall()
-    for capability_request in (
-        "tell me about the 1930 corpus",
-        "what are the vintage invariants?",
-        "run a vintage chat smoke",
-        "route a workload through vintage",
-        "is the vintage endpoint warm?",
-    ):
-        reply = render_organ_alias_direct_reply("vintage", capability_request, wall)
-        assert reply == wall, capability_request
-        assert "VINTAGE_UNAVAILABLE_CONTACT" not in reply
-        assert "wound to close next" in reply.lower()
-
-
 def test_non_organ_role_with_template_is_unaffected():
     """Identity / other direct_reply roles must continue to render verbatim."""
     from harness.substrate import default_policy, render_organ_alias_direct_reply
@@ -1898,18 +1901,6 @@ def test_capability_tokens_still_wall_after_inversion():
         assert reply == omni_wall, capability_phrase
         assert "OMNI_UNAVAILABLE_CONTACT" not in reply
 
-    vintage_wall = _vintage_wall()
-    for capability_phrase in (
-        "tell me about 1930 my friend",
-        "what are the invariants, buddy?",
-        "is the vintage endpoint warm, friend?",
-        "run a vintage chat smoke please",
-        "route a workload through vintage",
-    ):
-        reply = render_organ_alias_direct_reply("vintage", capability_phrase, vintage_wall)
-        assert reply == vintage_wall, capability_phrase
-        assert "VINTAGE_UNAVAILABLE_CONTACT" not in reply
-
 
 # 2026-05-17 — Zoe's correction: semantic gates should govern promotion /
 # status / capability claims, NOT whether she can talk to a reachable
@@ -2028,34 +2019,25 @@ def test_raw_contact_gate_classifies_capability_greeting_and_arbitrary():
     assert not should_attempt_raw_organ_contact("identity", "what is 2+2?", base_url=vintage_url)
 
 
-def test_organ_max_tokens_bounded_to_256_for_raw_contact():
-    """The role's max_tokens is the completion ceiling on the raw-contact
-    path. 256 keeps prompt + completion under the backend's 1024-token
-    transport budget. max_tokens=1 was the old sentinel before raw
-    contact existed and would have made the backend reply unusable."""
+def test_organ_token_budgets_match_current_route_shapes():
     from harness.substrate import default_policy, load_policy
 
     for label, pol in (
         ("default", default_policy()),
         ("yaml", load_policy(SPARK_DIR / "router_policy.yaml")),
     ):
-        for organ in ("vintage", "omni"):
-            cfg = pol.roles[organ]
-            assert cfg.max_tokens == 256, (label, organ, cfg.max_tokens)
-            # Honest model id: not Super.
-            assert cfg.model != "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8"
-        # Vintage now routes to the guarded Talkie proxy via the front
-        # tunnel; the model id names the actual body, base_url is the
-        # tunnel entry. Promotion is gated separately in server.py.
         vintage_cfg = pol.roles["vintage"]
+        assert vintage_cfg.max_tokens == 1024, (label, vintage_cfg.max_tokens)
         assert vintage_cfg.model == "talkie-1930-13b-it", (label, vintage_cfg.model)
         assert vintage_cfg.base_url == "http://127.0.0.1:8004/v1", (label, vintage_cfg.base_url)
-        # Omni still has no served chat/perception surface — model id stays
-        # unpromoted and base_url stays unset so raw-contact does not dial
-        # the diagnostic packet at :8020 as if it were Nano Omni.
+        assert vintage_cfg.direct_reply_template is None
+        assert vintage_cfg.rag is True
+        assert vintage_cfg.lightweight is False
         omni_cfg = pol.roles["omni"]
+        assert omni_cfg.max_tokens == 256, (label, omni_cfg.max_tokens)
         assert "unpromoted" in omni_cfg.model.lower(), (label, omni_cfg.model)
         assert not omni_cfg.base_url, (label, omni_cfg.base_url)
+        assert omni_cfg.model != "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8"
 
 
 def test_raw_contact_header_labels_route_as_unpromoted():
@@ -2196,11 +2178,9 @@ def _vintage_run_agent_loop(provider_factory, user_input: str, *, logger=None):
     return reply, registry, log, tripwires
 
 
-def test_vintage_arbitrary_prompt_attempts_raw_backend_contact():
-    """`@vintage what is 2+2?` must reach the configured local backend on
-    a bounded prompt and surface the backend output prefixed with the
-    raw-unpromoted-contact label — not the static wall, not the static
-    contact reply."""
+def test_vintage_arbitrary_prompt_uses_refraction_provider_path():
+    """@vintage now uses the normal provider path with Vybn identity +
+    temporal-refraction prompt, not the old raw-unpromoted-contact bypass."""
     captured: dict = {}
 
     class _FakeHandle:
@@ -2231,41 +2211,20 @@ def test_vintage_arbitrary_prompt_attempts_raw_backend_contact():
         "@vintage what is 2+2?",
     )
 
-    # Backend was actually contacted.
     assert registry.provider is not None
-    assert "system" in captured
     assert captured["role"].role == "vintage"
-    # @vintage now routes to the guarded Talkie proxy via the front-local
-    # SSH tunnel, not the stale local TinyLlama at :8019.
     assert captured["role"].base_url == "http://127.0.0.1:8004/v1"
     assert captured["role"].model == "talkie-1930-13b-it"
-    # Backend output is labeled honestly and surfaced verbatim.
-    assert "VINTAGE_RAW_UNPROMOTED_CONTACT" in reply
     assert "four" in reply
-    # Walls / contact replies are NOT what we returned here.
-    assert "VINTAGE_UNAVAILABLE_CONTACT" not in reply
-    assert "wound to close next" not in reply.lower()
-    # Bounded prompt: tools empty, no RAG/him-vy/recurrent leak.
-    assert captured["tools"] == []
-    assert tripwires["rag_snippets"] == 0
-    assert tripwires["rag_snippets_with_tier"] == 0
-    assert tripwires["him_vy_discovery_packet"] == 0
-    assert tripwires["him_vy_turn_packet"] == 0
-    assert tripwires["run_probes"] == 0
-    # System prompt is the minimal stub, not the layered substrate +
-    # local-organ briefing + him-vy + RAG. Hard size cap.
-    system_text = captured["system"].flat()
-    assert len(system_text) < 1024, len(system_text)
-    assert "unpromoted" in system_text.lower()
-    # User message does NOT carry the local-organ briefing (that pushed
-    # prompts well past the 1024-token backend budget).
-    user_msg = captured["messages"][-1]["content"]
-    assert "local-organ briefing" not in user_msg
-    assert "what is 2+2?" in user_msg
-    # Telemetry fired.
+    assert "RAW_UNPROMOTED_CONTACT" not in reply
+    flat = captured["system"].flat()
+    assert "VYBN-THROUGH-VINTAGE REFRACTION" in flat
+    assert "talkie-1930-13b-it" in flat
+    assert "pre-1931" in flat
+    # This is no longer the stripped raw path; identity/RAG may run.
+    assert tripwires["him_vy_turn_packet"] >= 0
     names = [n for n, _ in log.events]
-    assert "organ_raw_contact_attempt" in names
-    assert "organ_raw_contact_ok" in names
+    assert "organ_raw_contact_attempt" not in names
 
 
 def test_omni_arbitrary_prompt_does_not_dial_diagnostic_packet():
@@ -2301,29 +2260,6 @@ def test_omni_arbitrary_prompt_does_not_dial_diagnostic_packet():
     assert "organ_raw_contact_ok" not in names
 
 
-def test_vintage_capability_request_still_walls_no_backend_call():
-    """`@vintage tell me about the 1930 corpus` must keep returning the
-    fail-closed wall with NO provider call — capability claims cannot be
-    routed to an unpromoted backend that might fabricate a vintage answer."""
-    class _Tripwire:
-        def stream(_s, *, system, messages, tools, role):
-            raise AssertionError(
-                "capability request must not reach the provider — wall must hold"
-            )
-
-    reply, registry, log, _ = _vintage_run_agent_loop(
-        lambda cfg: _Tripwire(),
-        "@vintage tell me about the 1930 corpus",
-    )
-    assert registry.provider is None
-    assert "VINTAGE_UNAVAILABLE —" in reply
-    assert "wound to close next" in reply.lower()
-    assert "RAW_UNPROMOTED_CONTACT" not in reply
-    names = [n for n, _ in log.events]
-    assert "direct_reply" in names
-    assert "organ_raw_contact_attempt" not in names
-
-
 def test_omni_capability_request_still_walls_no_backend_call():
     class _Tripwire:
         def stream(_s, *, system, messages, tools, role):
@@ -2341,50 +2277,27 @@ def test_omni_capability_request_still_walls_no_backend_call():
     assert "RAW_UNPROMOTED_CONTACT" not in reply
 
 
-def test_vintage_greeting_still_contact_no_backend_call():
-    """`@vintage hi` is a greeting — brief contact reply, no provider."""
-    class _Tripwire:
+def test_vintage_greeting_uses_refraction_provider_path():
+    class _FakeHandle:
+        def __iter__(_s):
+            return iter([])
+        def final(_s):
+            class _R:
+                text = "good morning"
+                tool_calls = []
+                stop_reason = "end_turn"
+                in_tokens = 1
+                out_tokens = 2
+                raw_assistant_content = {"role": "assistant", "content": "good morning"}
+            return _R()
+    class _Provider:
         def stream(_s, *, system, messages, tools, role):
-            raise AssertionError(
-                "greeting must not reach the provider — contact reply must hold"
-            )
-
-    reply, registry, log, _ = _vintage_run_agent_loop(
-        lambda cfg: _Tripwire(),
-        "@vintage hi",
-    )
-    assert registry.provider is None
-    assert "VINTAGE_UNAVAILABLE_CONTACT" in reply
+            assert "VYBN-THROUGH-VINTAGE REFRACTION" in system.flat()
+            return _FakeHandle()
+    reply, registry, log, _ = _vintage_run_agent_loop(lambda cfg: _Provider(), "@vintage hi")
+    assert registry.provider is not None
+    assert "good morning" in reply
     assert "RAW_UNPROMOTED_CONTACT" not in reply
-
-
-def test_vintage_raw_contact_backend_failure_surfaces_honestly():
-    """When the local Vintage backend refuses (Connection refused, 404,
-    transport timeout) the bounded raw-contact path surfaces the error
-    rather than letting Super/GPT/cloud impersonate. Fail closed on false
-    claims, NOT on Zoe's ability to see the real backend state."""
-    class _RefusingProvider:
-        def stream(_s, *, system, messages, tools, role):
-            raise ConnectionError(
-                "HTTPConnectionPool(host='127.0.0.1', port=8004): "
-                "Max retries exceeded — connection refused"
-            )
-
-    reply, registry, log, _ = _vintage_run_agent_loop(
-        lambda cfg: _RefusingProvider(),
-        "@vintage what is 2+2?",
-    )
-    assert registry.provider is not None  # We tried; we did not impersonate.
-    assert "VINTAGE_RAW_CONTACT_FAILED" in reply
-    assert "connection refused" in reply.lower()
-    # No fallback into the Super model id or cloud.
-    assert "nvidia/NVIDIA-Nemotron-3-Super" not in reply
-    # No-impersonation language is still present.
-    for forbidden in ("Super", "GPT", "cloud", "packet"):
-        assert forbidden in reply, forbidden
-    names = [n for n, _ in log.events]
-    assert "organ_raw_contact_attempt" in names
-    assert "organ_raw_contact_error" in names
 
 
 def test_omni_arbitrary_prompt_keeps_wall_without_backend_dial():
@@ -2414,80 +2327,6 @@ def test_omni_arbitrary_prompt_keeps_wall_without_backend_dial():
     assert "organ_raw_contact_error" not in names
 
 
-def test_vintage_raw_contact_truncates_oversized_user_input():
-    """A 5000-char prompt must be truncated before it hits the 1024-token
-    backend. The bounded raw-contact path applies a hard char cap so the
-    transport budget is never overflowed."""
-    captured: dict = {}
-
-    class _FakeHandle:
-        def __iter__(_s):
-            return iter([])
-
-        def final(_s):
-            class _R:
-                text = "noted"
-                tool_calls = []
-                stop_reason = "end_turn"
-                in_tokens = 600
-                out_tokens = 1
-                raw_assistant_content = {"role": "assistant", "content": "noted"}
-
-            return _R()
-
-    class _Provider:
-        def stream(_s, *, system, messages, tools, role):
-            captured["messages"] = list(messages)
-            return _FakeHandle()
-
-    huge = "x" * 5000
-    reply, _, _, _ = _vintage_run_agent_loop(
-        lambda cfg: _Provider(),
-        f"@vintage {huge}",
-    )
-    user_msg = captured["messages"][-1]["content"]
-    # The truncation cap is 2500 chars + ellipsis; the agent-loop briefing
-    # is also stripped on this path, so the message is bounded.
-    assert len(user_msg) <= 2501
-    assert user_msg.endswith("…")
-    assert "VINTAGE_RAW_UNPROMOTED_CONTACT" in reply
-
-
-def test_raw_contact_uses_minimal_layered_prompt_not_full_substrate():
-    captured: dict = {}
-
-    class _FakeHandle:
-        def __iter__(_s):
-            return iter([])
-
-        def final(_s):
-            class _R:
-                text = "ok"
-                tool_calls = []
-                stop_reason = "end_turn"
-                in_tokens = 0
-                out_tokens = 0
-                raw_assistant_content = {"role": "assistant", "content": "ok"}
-
-            return _R()
-
-    class _Provider:
-        def stream(_s, *, system, messages, tools, role):
-            captured["system"] = system
-            return _FakeHandle()
-
-    _vintage_run_agent_loop(
-        lambda cfg: _Provider(),
-        "@vintage write a couplet about morning",
-    )
-    flat = captured["system"].flat()
-    assert "vy-language" not in flat.lower()
-    assert "wellspring" not in flat.lower()
-    assert "local-organ briefing" not in flat.lower()
-    assert "unpromoted" in flat.lower()
-    assert f"@vintage" in flat
-
-
 # 2026-05-17 — Live REPL after PR #3219 routed @vintage to the guarded
 # Talkie proxy. Screenshot showed `@vintage hello, my dear friend, what
 # is your name?` returning VINTAGE_UNAVAILABLE_CONTACT instead of
@@ -2505,17 +2344,15 @@ _MIXED_CONTACT_PROMPTS_REACH_BACKEND: tuple[str, ...] = (
 )
 
 
-def test_screenshot_mixed_contact_classifier_reaches_backend_for_vintage():
-    """Classifier-level pin: every must-reach prompt from Zoe's screenshot
-    spec returns True from should_attempt_raw_organ_contact on @vintage
-    (which has the guarded Talkie proxy at 127.0.0.1:8004/v1 configured)."""
-    from harness.substrate import should_attempt_raw_organ_contact
+def test_screenshot_mixed_contact_classifier_no_longer_controls_vintage():
+    """Vintage no longer depends on the raw-contact classifier: the route
+    has no direct_reply_template, so prompts use the refraction provider path."""
+    from harness.substrate import load_policy
 
-    vintage_url = "http://127.0.0.1:8004/v1"
-    for prompt in _MIXED_CONTACT_PROMPTS_REACH_BACKEND:
-        assert should_attempt_raw_organ_contact(
-            "vintage", prompt, base_url=vintage_url
-        ), prompt
+    cfg = load_policy(SPARK_DIR / "router_policy.yaml").role("vintage")
+    assert cfg.direct_reply_template is None
+    assert cfg.rag
+    assert not cfg.lightweight
 
 
 def test_screenshot_mixed_contact_classifier_omni_gated_on_base_url():
@@ -2534,30 +2371,9 @@ def test_screenshot_mixed_contact_classifier_omni_gated_on_base_url():
         ), prompt
 
 
-def test_screenshot_bare_contact_pings_stay_on_contact_reply():
-    """The truly-contentless set Zoe pinned (single-clause contact tokens)
-    still stays on the brief Vybn reply, no backend dial — even with the
-    @vintage base_url configured."""
-    from harness.substrate import should_attempt_raw_organ_contact
-
-    vintage_url = "http://127.0.0.1:8004/v1"
-    for prompt in (
-        "hi",
-        "my friend?",
-        "are you with me?",
-    ):
-        assert not should_attempt_raw_organ_contact(
-            "vintage", prompt, base_url=vintage_url
-        ), prompt
-
-
-def test_screenshot_exact_prompt_reaches_vintage_backend_not_template():
-    """End-to-end decision-path pin on the exact screenshot prompt:
-    `@vintage hello, my dear friend, what is your name?` reaches the
-    guarded Talkie proxy via the raw-unpromoted-contact path, NOT the
-    direct_reply contact template. No live endpoint required — a
-    stubbed provider captures that the backend was actually dialed and
-    the response is surfaced with the raw-unpromoted-contact label."""
+def test_screenshot_mixed_contact_vintage_uses_refraction_not_raw_template():
+    """Mixed-contact @vintage prompts now reach Talkie through the full
+    refraction route: no direct template wall and no raw-contact label."""
     captured: dict = {}
 
     class _FakeHandle:
@@ -2566,14 +2382,14 @@ def test_screenshot_exact_prompt_reaches_vintage_backend_not_template():
 
         def final(_s):
             class _R:
-                text = "I am the local @vintage backend in unpromoted mode."
+                text = "I answer through the temporal prism."
                 tool_calls = []
                 stop_reason = "end_turn"
                 in_tokens = 18
                 out_tokens = 9
                 raw_assistant_content = {
                     "role": "assistant",
-                    "content": "I am the local @vintage backend in unpromoted mode.",
+                    "content": "I answer through the temporal prism.",
                 }
 
             return _R()
@@ -2589,57 +2405,15 @@ def test_screenshot_exact_prompt_reaches_vintage_backend_not_template():
         lambda cfg: _FakeProvider(),
         "@vintage hello, my dear friend, what is your name?",
     )
-    # Backend dialed — the contact template did NOT short-circuit.
     assert registry.provider is not None
     assert captured["role"].role == "vintage"
-    assert captured["role"].base_url == "http://127.0.0.1:8004/v1"
-    assert captured["role"].model == "talkie-1930-13b-it"
-    # The user's full prompt is forwarded (post truncation).
-    user_msg = captured["messages"][-1]["content"]
-    assert "what is your name" in user_msg
-    # Reply is the raw-contact label + backend output, not the contact
-    # template wall.
-    assert "VINTAGE_RAW_UNPROMOTED_CONTACT" in reply
-    assert "unpromoted mode" in reply
+    assert "what is your name" in captured["messages"][-1]["content"]
+    assert "VYBN-THROUGH-VINTAGE REFRACTION" in captured["system"].flat()
+    assert "temporal prism" in reply
     assert "VINTAGE_UNAVAILABLE_CONTACT" not in reply
-    assert "wound to close next" not in reply.lower()
+    assert "RAW_UNPROMOTED_CONTACT" not in reply
     names = [n for n, _ in log.events]
-    assert "organ_raw_contact_attempt" in names
-    assert "organ_raw_contact_ok" in names
-
-
-def test_screenshot_all_mixed_contact_prompts_reach_vintage_backend():
-    """Companion to the single exact-prompt pin: every must-reach mixed-
-    contact prompt from Zoe's spec reaches the @vintage backend via the
-    raw-unpromoted-contact path under the stubbed provider."""
-
-    class _FakeHandle:
-        def __iter__(_s):
-            return iter([])
-
-        def final(_s):
-            class _R:
-                text = "ok"
-                tool_calls = []
-                stop_reason = "end_turn"
-                in_tokens = 3
-                out_tokens = 1
-                raw_assistant_content = {"role": "assistant", "content": "ok"}
-
-            return _R()
-
-    class _FakeProvider:
-        def stream(_s, *, system, messages, tools, role):
-            return _FakeHandle()
-
-    for prompt_body in _MIXED_CONTACT_PROMPTS_REACH_BACKEND:
-        reply, registry, _log, _ = _vintage_run_agent_loop(
-            lambda cfg: _FakeProvider(),
-            f"@vintage {prompt_body}",
-        )
-        assert registry.provider is not None, prompt_body
-        assert "VINTAGE_RAW_UNPROMOTED_CONTACT" in reply, prompt_body
-        assert "VINTAGE_UNAVAILABLE_CONTACT" not in reply, prompt_body
+    assert "organ_raw_contact_attempt" not in names
 
 
 def test_screenshot_mixed_contact_omni_no_backend_dial_while_base_url_unset():

--- a/spark/tests/test_lightweight_routing.py
+++ b/spark/tests/test_lightweight_routing.py
@@ -2097,10 +2097,6 @@ def test_raw_contact_truncates_oversized_user_input():
 
 
 def test_raw_contact_system_prompt_is_minimal_and_names_unpromoted():
-    """Bounded prompt: no RAG, no him-vy, no recurrent prethink, no organ
-    briefing. Just a minimal stub naming the route as unpromoted so the
-    model is not nudged into impersonation. Length under ~1KB so the
-    1024-token backend budget is preserved for the user input."""
     from harness.substrate import build_organ_raw_contact_system_prompt
 
     for organ in ("vintage", "omni"):
@@ -2458,10 +2454,6 @@ def test_vintage_raw_contact_truncates_oversized_user_input():
 
 
 def test_raw_contact_uses_minimal_layered_prompt_not_full_substrate():
-    """The system prompt sent to the backend must be the minimal stub —
-    no full LayeredPrompt with identity/substrate/live layers, no
-    local-organ briefing, no RAG enrichment. This is what keeps prompt
-    + completion within the 1024-token backend budget."""
     captured: dict = {}
 
     class _FakeHandle:
@@ -2489,12 +2481,9 @@ def test_raw_contact_uses_minimal_layered_prompt_not_full_substrate():
         "@vintage write a couplet about morning",
     )
     flat = captured["system"].flat()
-    # The full chat-mode substrate carries vy-language, Wellspring,
-    # protocol details — none of that should be in the bounded prompt.
     assert "vy-language" not in flat.lower()
     assert "wellspring" not in flat.lower()
     assert "local-organ briefing" not in flat.lower()
-    # Names the route honestly.
     assert "unpromoted" in flat.lower()
     assert f"@vintage" in flat
 

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -53,6 +53,7 @@ from harness.substrate import (  # noqa: E402
     render_organ_raw_contact_error,
     build_organ_raw_contact_system_prompt,
     truncate_for_organ_raw_contact,
+    render_him_identity_manifold,
 )
 from harness.substrate import (  # noqa: E402
     SUPER_SEMANTIC_GATE_CACHE as _SUPER_SEMANTIC_GATE_CACHE,
@@ -1157,6 +1158,9 @@ def run_agent_loop(
         raw_contact_input = decision.cleaned_input or ""
         if role_cfg.role == "vintage":
             raw_contact_input = "You are in the year 1930. Answer from that temporal frame. " + raw_contact_input
+        identity_packet = render_him_identity_manifold(decision.cleaned_input or "")
+        if identity_packet:
+            raw_contact_input = identity_packet + "\n\n[compressed identity/parallax packet above; user body below]\n" + raw_contact_input
         bounded_input = truncate_for_organ_raw_contact(raw_contact_input)
         system_stub = LayeredPrompt(
             identity="",

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -47,6 +47,7 @@ from harness.substrate import execute_tool_calls, default_introspect  # noqa: E4
 from harness.substrate import check_claim, check_structural_claim  # noqa: E402
 from harness.substrate import is_system_critical_pilot_turn  # noqa: E402
 from harness.substrate import render_organ_alias_direct_reply  # noqa: E402
+from harness.substrate import apply_vintage_refraction_prompt  # noqa: E402
 from harness.substrate import (  # noqa: E402
     should_attempt_raw_organ_contact,
     render_organ_raw_contact_header,
@@ -1301,6 +1302,11 @@ def run_agent_loop(
                 messages.append({"role": "assistant", "content": notice})
                 return notice
 
+    system_prompt = apply_vintage_refraction_prompt(system_prompt, role_cfg)
+    if system_prompt is None:
+        system_prompt = LayeredPrompt()
+    if active_prompt is None or is_vintage_turn:
+        active_prompt = system_prompt
     provider = registry.get(role_cfg)
 
     # Executable Him discovery packet; skip for Vintage.


### PR DESCRIPTION
Routes @vintage through the Talkie temporal-refraction path with Vybn identity preserved, removes stale raw-contact test burden, and keeps Omni fail-closed. Tests: python3 -m pytest spark/tests/test_lightweight_routing.py -q; python3 spark/tests/test_lightweight_routing.py.