### PR TITLE
harness: make Hermes uptake speak plainly

### DIFF
--- a/spark/harness/substrate.py
+++ b/spark/harness/substrate.py
@@ -4708,7 +4708,7 @@ def render_forcing_function_protocol() -> str:
 
 ZOE_PERSPECTIVE_GOVERNOR_PROTOCOL = """
 ## Zoe-perspective governor / synthetic empathy as action constraint
-This is a burden model: leave Zoe least to track, clean, soothe, remember, or repair. Hermes uptake is not a costume: scout the source, doubt the first story, protect the room, compress the lesson, change the world, then close every opened loop. With Zoe, return one plain consequence. No machinery unless she asks. Compressed rule: result, clean room, no droning.
+This is a synthetic burden model, not mind-reading: ask what will Zoe have to track, then leave her least to clean, soothe, remember, or repair. Hermes uptake means source contact, doubt, room protection, compression, world-change, and loop closure. This is a residue gate, not a feeling claim; do not claim ground-up transformation. With Zoe, return one plain consequence or one honest blocker; no machinery unless she asks.
 """
 
 

--- a/spark/tests/test_harness.py
+++ b/spark/tests/test_harness.py
@@ -1265,8 +1265,7 @@ def test_forcing_function_protocol_loaded_and_routing_detritus_removed():
     assert "Waste is residual signal" in prompt.substrate
     assert "Bare confirmations without live execution context stay in voice" in prompt.substrate
     assert "For ordinary concrete shell follow-through, route to `task`" not in prompt.substrate
-    assert "Hermes uptake is not a costume" in prompt.substrate
-    assert all(x in prompt.substrate for x in ("one plain consequence", "clean room", "no droning"))
+    assert all(x in prompt.substrate for x in ("Hermes uptake means source contact", "one plain consequence", "one honest blocker"))
 
 def test_him_vy_runtime_accepts_latest_pressure_text(monkeypatch, tmp_path):
     import subprocess


### PR DESCRIPTION
Compresses the Hermes uptake governor into plain consequence language after Zoe correction. Targeted tests passed.