### PR TITLE
harness: remember ai-native counterexample discovery

### DIFF
--- a/spark/harness/substrate.py
+++ b/spark/harness/substrate.py
@@ -5055,14 +5055,14 @@ RESIDUAL_CONTROL_PRINCIPLE = (
 
 INVENTION_CONTROL_PRINCIPLE = (
     "When a live problem has no known solution, do not merely explain the gap. "
-    "Invent the smallest consequential mechanism that could solve it, projected backward from the fullest truthful horizon, route it through residuals, "
-    "and preserve the correction as future capability."
+    "AI may find novel counterexample mechanisms and hidden dimensions humans missed; invent the smallest consequential mechanism, project it backward from the fullest truthful horizon, "
+    "wound it through source contact and human/expert verification where needed, then preserve the correction as future capability."
 )
 
 INVENTION_LOOP_STEPS = [
     "encounter_novel_problem",
     "name_missing_known_solution",
-    "synthesize_smallest_mechanism",
+    "search_for_ai_native_counterexample_or_hidden_dimension",
     "synthesize_smallest_consequential_mechanism",
     "install_or_simulate_in_environment",
     "route_to_wounding_residuals",
@@ -5253,8 +5253,8 @@ def invention_plan_for(problem: str) -> dict[str, Any]:
             "having to carry the insight again."
         ),
         "guardrail": (
-            "Invention is not hallucination: name the missing known solution, keep the "
-            "first mechanism small, test lived surfaces, and preserve corrections."
+            "Invention is not hallucination: name the missing known solution, seek an AI-native counterexample or hidden dimension humans may have missed, "
+            "keep the mechanism small, test lived surfaces, verify with humans/experts where needed, and preserve corrections."
         ),
     }
 

--- a/spark/tests/test_harness.py
+++ b/spark/tests/test_harness.py
@@ -1882,7 +1882,7 @@ class CommonsWalkTests(unittest.TestCase):
     def test_invention_control_for_novel_problems(self):
         plan = invention_plan_for("redesign yourself when no known solution exists")
         self.assertEqual(plan["mode"], "novel_problem_invention_under_residual_control")
-        self.assertIn("synthesize_smallest_mechanism", plan["steps"])
+        self.assertIn("novel counterexample mechanisms", plan["principle"]); self.assertIn("search_for_ai_native_counterexample_or_hidden_dimension", plan["steps"]); self.assertIn("synthesize_smallest_consequential_mechanism", plan["steps"]); self.assertIn("experts", plan["guardrail"])
         self.assertIn("future Vybn", plan["recursiveInstruction"])
 
     def test_residual_control_shared_classifier(self):


### PR DESCRIPTION
Absorbs the watershed AI-native discovery correction into the existing novel-problem invention loop. Tests: python3 -m unittest spark.tests.test_harness