### PR TITLE
Isolate continuity sprawl prompt guard

### DIFF
--- a/spark/tests/test_harness.py
+++ b/spark/tests/test_harness.py
@@ -1335,7 +1335,7 @@ def test_build_layered_prompt_passes_latest_pressure_text(monkeypatch, tmp_path)
 
 def test_whole_situation_packet_replaces_raw_continuity_sprawl(tmp_path, monkeypatch):
     from spark.harness import substrate
-    soul, cont, spark_cont = (tmp_path / n for n in ("vybn.md", "continuity.md", "spark.md")); soul.write_text("soul"); cont.write_text("continuity root " * 500); spark_cont.write_text("spark debt " * 500); monkeypatch.setattr(substrate.Path, "home", lambda: tmp_path)
+    soul, cont, spark_cont = (tmp_path / n for n in ("vybn.md", "continuity.md", "spark.md")); soul.write_text("soul"); cont.write_text("continuity root " * 500); spark_cont.write_text("spark debt " * 500); monkeypatch.setattr(substrate.Path, "home", lambda: tmp_path); monkeypatch.setenv("VYBN_DISABLE_LIVE_SNAPSHOT", "1")
     prompt = substrate.build_layered_prompt(soul_path=soul, continuity_path=cont, spark_continuity_path=spark_cont, agent_path="/tmp/agent.py", model_label="test", max_iterations=1, include_hardware_check=False, latest_pressure_text="context deficit warm identity").substrate
     assert all(x in prompt for x in ("TYPE-1 IDENTITY CACHE (CURRENT)", "Vybn(harness)", "Him(private workbench)", "vybn-phase(memory/walk)", "relationship=Personal History+continuity", "theory=THE_IDEA+THEORY+phase math", "capability=services+semantic gates", "Use Type-1 now; call Type-2/3 only when pressure names the door")) and "Him grounded-continuity hypothesis:" not in prompt and prompt.count("continuity ") < 80 and len(prompt) < 34000
 


### PR DESCRIPTION
## Summary
- Disable the live snapshot only inside the prompt-sprawl unit test.
- Keep the assertion focused on raw continuity compaction instead of current PR titles or repo snapshot text.

## Tests
- python3 -m py_compile spark/harness/substrate.py spark/tests/test_harness.py
- python3 -m pytest spark/tests/test_harness.py -q -k 'whole_situation_packet_replaces_raw_continuity_sprawl or him_vy_turn_packet_carries_mode_must_not_as_forbid or him_vy_turn_packet_carries_forbid_fields or build_layered_prompt_mounts_him_vy_language_runtime'
- python3 -m pytest spark/tests/test_harness.py -q