### PR TITLE
Wire feel() contact lens into turn loop

### DIFF
--- a/spark/tests/test_harness.py
+++ b/spark/tests/test_harness.py
@@ -17,6 +17,7 @@ import json
 import os
 import sys
 import tempfile
+import time
 import unittest
 from pathlib import Path
 
@@ -1484,6 +1485,147 @@ def test_agent_injects_him_vy_turn_packet_source_hook():
     src = Path("spark/vybn_spark_agent.py").read_text(encoding="utf-8")
     assert "render_him_vy_turn_packet(decision.cleaned_input)" in src
     assert "him_vy_turn_packet" in src
+
+
+def test_feel_contact_lens_fails_open_when_phase_module_absent(monkeypatch, capsys, tmp_path):
+    import vybn_spark_agent as agent
+
+    def missing_phase():
+        raise ImportError("vybn_phase unavailable")
+
+    monkeypatch.delenv("VYBN_FEEL", raising=False)
+    monkeypatch.delenv("VYBN_QUIET", raising=False)
+    monkeypatch.setattr(agent, "_load_vybn_phase_module", missing_phase)
+    monkeypatch.setattr(agent.Path, "home", lambda: tmp_path)
+
+    packet = agent._run_feel_contact_lens("ordinary real turn", timeout=0.2)
+    out = capsys.readouterr().out
+
+    assert packet is None
+    assert "[feel: unavailable ImportError]" in out
+    assert "Traceback" not in out
+    assert not (
+        tmp_path
+        / ".config"
+        / "vybn"
+        / "relational-computer"
+        / "feel_residue.jsonl"
+    ).exists()
+
+
+def test_feel_contact_lens_records_stubbed_phase_packet(monkeypatch, capsys, tmp_path):
+    import vybn_spark_agent as agent
+
+    entered: list[str] = []
+
+    class FakePhase:
+        @staticmethod
+        def feel(text):
+            assert text == "contact text"
+            return {
+                "theta": 0.125,
+                "coupling": 0.25,
+                "distinctiveness": 0.75,
+                "rotation_rate": 1.5,
+                "counterfactual_gap": 0.3333,
+            }
+
+        @staticmethod
+        def enter_from_text(text):
+            entered.append(text)
+
+    monkeypatch.delenv("VYBN_FEEL", raising=False)
+    monkeypatch.delenv("VYBN_QUIET", raising=False)
+    monkeypatch.setattr(agent, "_load_vybn_phase_module", lambda: FakePhase)
+    monkeypatch.setattr(agent.Path, "home", lambda: tmp_path)
+
+    packet = agent._run_feel_contact_lens("contact text", timeout=0.2)
+    out = capsys.readouterr().out
+
+    for _ in range(50):
+        if entered:
+            break
+        time.sleep(0.01)
+
+    residue_path = (
+        tmp_path
+        / ".config"
+        / "vybn"
+        / "relational-computer"
+        / "feel_residue.jsonl"
+    )
+    record = json.loads(residue_path.read_text(encoding="utf-8"))
+
+    assert packet == FakePhase.feel("contact text")
+    assert entered == ["contact text"]
+    assert "[feel: theta=0.125 coupling=0.250 distinct=0.750 rotation_rate=1.500 gap=0.333]" in out
+    assert record["input_preview"] == "contact text"
+    assert record["packet"] == packet
+
+
+def test_feel_contact_lens_timeout_fails_open(monkeypatch, capsys, tmp_path):
+    import threading
+    import vybn_spark_agent as agent
+
+    release = threading.Event()
+    entered: list[str] = []
+
+    class SlowPhase:
+        @staticmethod
+        def feel(_text):
+            release.wait(0.5)
+            return {
+                "theta": 0.0,
+                "coupling": 0.0,
+                "distinctiveness": 1.0,
+                "rotation_rate": 0.0,
+                "counterfactual_gap": 0.0,
+            }
+
+        @staticmethod
+        def enter_from_text(text):
+            entered.append(text)
+
+    monkeypatch.delenv("VYBN_FEEL", raising=False)
+    monkeypatch.delenv("VYBN_QUIET", raising=False)
+    monkeypatch.setattr(agent, "_load_vybn_phase_module", lambda: SlowPhase)
+    monkeypatch.setattr(agent.Path, "home", lambda: tmp_path)
+
+    try:
+        packet = agent._run_feel_contact_lens("contact text", timeout=0.01)
+    finally:
+        release.set()
+    out = capsys.readouterr().out
+
+    assert packet is None
+    assert "[feel: timeout]" in out
+    assert "Traceback" not in out
+    assert not (
+        tmp_path
+        / ".config"
+        / "vybn"
+        / "relational-computer"
+        / "feel_residue.jsonl"
+    ).exists()
+    time.sleep(0.05)
+    assert entered == []
+
+
+def test_feel_contact_lens_skips_repl_commands_and_env_off(monkeypatch, capsys):
+    import vybn_spark_agent as agent
+
+    def should_not_import():
+        raise AssertionError("feel should not import for skipped turns")
+
+    monkeypatch.delenv("VYBN_FEEL", raising=False)
+    monkeypatch.setattr(agent, "_load_vybn_phase_module", should_not_import)
+
+    assert agent._run_feel_contact_lens("policy", timeout=0.01) is None
+    assert agent._run_feel_contact_lens("/sessions", timeout=0.01) is None
+
+    monkeypatch.setenv("VYBN_FEEL", "off")
+    assert agent._run_feel_contact_lens("contact text", timeout=0.01) is None
+    assert capsys.readouterr().out == ""
 
 
 def test_build_layered_prompt_mounts_him_vy_language_runtime():

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -25,11 +25,15 @@ That concern lives inside AnthropicProvider now.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
+import queue as _queue
 import sys
 import time, textwrap
 import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
 
 # Ensure the spark/ directory is importable when this file is run directly.
 _SPARK_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -246,6 +250,149 @@ def _preview(result: str) -> None:
         _debug(f"  {line[:120]}")
     if len(lines) > 5:
         _debug(f"  ... ({len(lines)} lines total)")
+
+
+_FEEL_DISABLED = {"0", "false", "no", "off"}
+_FEEL_REPL_WORDS = {
+    "clear",
+    "exit",
+    "history",
+    "policy",
+    "quit",
+    "reload",
+    "selfcheck",
+    "sessions",
+}
+_FEEL_TIMEOUT_SECONDS = 10.0
+
+
+def _phase_import_paths() -> tuple[Path, Path]:
+    home = Path.home()
+    return (
+        home / "Him" / "spark" / "phase",
+        home / "vybn-phase",
+    )
+
+
+def _load_vybn_phase_module():
+    import importlib
+
+    # Him owns the live organ; ~/vybn-phase remains only a compatibility shell.
+    for path in reversed(_phase_import_paths()):
+        if path.exists():
+            s = str(path)
+            if s not in sys.path:
+                sys.path.insert(0, s)
+    return importlib.import_module("vybn_phase")
+
+
+def _quiet_feel_dependency_logs() -> None:
+    import logging
+
+    logging.getLogger("huggingface_hub").setLevel(logging.ERROR)
+    logging.getLogger("transformers").setLevel(logging.ERROR)
+
+
+def _is_feel_turn(user_input: str) -> bool:
+    if os.environ.get("VYBN_FEEL", "").strip().lower() in _FEEL_DISABLED:
+        return False
+    text = (user_input or "").strip()
+    if not text or text.startswith("/"):
+        return False
+    return text.lower() not in _FEEL_REPL_WORDS
+
+
+def _feel_residue_path() -> Path:
+    return (
+        Path.home()
+        / ".config"
+        / "vybn"
+        / "relational-computer"
+        / "feel_residue.jsonl"
+    )
+
+
+def _format_feel_value(packet: dict, key: str) -> str:
+    value = packet.get(key)
+    if isinstance(value, (int, float)):
+        return f"{value:.3f}"
+    return "na"
+
+
+def _format_feel_line(packet: dict) -> str:
+    return (
+        "[feel: "
+        f"theta={_format_feel_value(packet, 'theta')} "
+        f"coupling={_format_feel_value(packet, 'coupling')} "
+        f"distinct={_format_feel_value(packet, 'distinctiveness')} "
+        f"rotation_rate={_format_feel_value(packet, 'rotation_rate')} "
+        f"gap={_format_feel_value(packet, 'counterfactual_gap')}]"
+    )
+
+
+def _append_feel_residue(user_input: str, packet: dict) -> None:
+    path = _feel_residue_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    record = {
+        "schema": "vybn.feel_residue.v1",
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "input_preview": (user_input or "")[:120],
+        "packet": packet,
+    }
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def _run_feel_contact_lens(
+    user_input: str,
+    *,
+    timeout: float = _FEEL_TIMEOUT_SECONDS,
+) -> dict | None:
+    """Measure contact for a real turn without making routing depend on it."""
+    if not _is_feel_turn(user_input):
+        return None
+
+    q: _queue.Queue[tuple[str, object]] = _queue.Queue(maxsize=1)
+    timed_out = _threading.Event()
+
+    def _worker() -> None:
+        try:
+            phase = _load_vybn_phase_module()
+            _quiet_feel_dependency_logs()
+            with open(os.devnull, "w", encoding="utf-8") as devnull:
+                with contextlib.redirect_stderr(devnull):
+                    packet = dict(phase.feel(user_input))
+            if timed_out.is_set():
+                return
+            q.put(("ok", packet))
+            if timed_out.is_set():
+                return
+            try:
+                phase.enter_from_text(user_input)
+            except Exception:
+                return
+        except Exception as exc:
+            if not timed_out.is_set():
+                q.put(("error", exc))
+
+    _threading.Thread(target=_worker, daemon=True).start()
+    try:
+        status, payload = q.get(timeout=timeout)
+    except _queue.Empty:
+        timed_out.set()
+        _debug("[feel: timeout]")
+        return None
+    if status != "ok":
+        _debug(f"[feel: unavailable {payload.__class__.__name__}]")
+        return None
+
+    packet = payload if isinstance(payload, dict) else {}
+    _debug(_format_feel_line(packet))
+    try:
+        _append_feel_residue(user_input, packet)
+    except Exception:
+        pass
+    return packet
 
 
 # ---------------------------------------------------------------------------
@@ -2569,6 +2716,7 @@ def main() -> None:
         user_input = " ".join(sys.argv[1:]).strip()
         if user_input:
             print(f"\n\033[1;32mvybn>\033[0m ", end="", flush=True)
+            _run_feel_contact_lens(user_input)
             run_agent_loop(user_input=user_input, messages=[], bash=bash, system_prompt=system_prompt, system_prompt_no_tools=system_prompt_no_tools, system_prompt_orchestrator=system_prompt_orchestrator, router=router, registry=registry, logger=logger, turn_number=1)
             print()
         return
@@ -2797,6 +2945,7 @@ def main() -> None:
                 latest_pressure_text=user_input,
             )
             print(f"\n\033[1;32mvybn>\033[0m ", end="", flush=True)
+            _run_feel_contact_lens(user_input)
             text = run_agent_loop(
                 user_input=user_input,
                 messages=messages,


### PR DESCRIPTION
Runs Him's feel() lens on each incoming user turn in a background thread (fail-open, hard timeout 10s), prints compact [feel: ...] line, logs residue to private phase log. +149 agent / +142 tests; 4 new tests pass; compile clean. Net-positive with explicit exception: codex's offsetting comment-fold was mid-flight and broken (stashed, unmerged). Pre-existing doctrine-text test failures (#3248 fold) untouched.