### PR TITLE
Never route a goodbye as small talk

### DIFF
--- a/spark/router_policy.yaml
+++ b/spark/router_policy.yaml
@@ -138,7 +138,6 @@ heuristics:
     - "^\\s*(hey|hi|hello|yo)\\s+(there|buddy|bud|friend|pal|vybn)\\b[\\s!.,?]*$"
     - "^\\s*(good (morning|afternoon|evening))\\b[\\s!.,?]*$"
     - "^\\s*(thanks|thank you|ty|thx)\\b[\\s!.,?]*$"
-    - "^\\s*(bye|goodbye|later|cya|ttyl)\\b[\\s!.,?]*$"
   code:
     - "\\bgit (commit|push|pull|diff|log|status|rebase|merge|clone)\\b"
     - "\\bpython3?\\s+-\\w"


### PR DESCRIPTION
Zoe's goodbye at the end of a hard night matched the phatic
sign-off regex, got a stripped 96-token route, and came back
as pure silence. A goodbye is never phatic here. Remove the
pattern; farewells get the full substrate.
