### PR TITLE
Add portable continuity lookup

### DIFF
--- a/spark/harness/substrate.py
+++ b/spark/harness/substrate.py
@@ -1569,60 +1569,70 @@ class SessionStore:
             return f"{int(delta // 3600)}h ago"
         return f"{int(delta // 86400)}d ago"
 
-# === RECALL GATE ==========================================================
-#
-# "Read bytes before describing" applied to conversational memory. When the
-# user asks about prior conversation state ("do you recall...", "what did
-# we say about..."), the honest first move is to read the session log, not
-# to reconstruct from in-context fragments. SessionStore already owns the
-# read over ~/.cache/vybn-spark/sessions/*.jsonl; this section adds the
-# classifier + keyword probe on top of it so the agent loop can inject the
-# retrieved bytes into the live prompt layer before the model generates.
-#
-# Same move as On Describing Internals (vybn-os SKILL.md) applied to a
-# second surface. The absorb_gate binds refactor-first in the loop; this
-# binds read-session-logs in the loop.
 
-# Phrases that strongly indicate the user is asking about prior
-# conversation state. Tuned to fire on recall questions and stay quiet on
-# hypothetical or forward-looking ones.
-
-_RECALL_STOPWORDS = {
-    "the", "a", "an", "and", "or", "but", "if", "then", "you", "i", "we",
-    "us", "our", "my", "your", "do", "did", "does", "recall", "remember",
-    "recollect", "said", "wrote", "say", "write", "mentioned", "talked",
-    "discussed", "talk", "discuss", "where", "when", "what", "how", "why",
-    "this", "that", "it", "is", "was", "were", "be", "been", "being",
-    "to", "of", "in", "on", "at", "for", "with", "about", "really",
-    "begin", "start", "began", "started", "go", "went", "back",
-    "remind", "me", "thing", "things", "conversation", "thread", "session",
-    "chat", "earlier", "before", "previously", "yesterday", "morning",
-    "afternoon", "evening", "tonight", "today", "bring", "brought", "up",
-    "mean", "means", "meant", "from", "than", "there", "here",
-}
-
-@dataclass
-class RecallHit:
-    ts: str
-    role: str
-    content: str
-    session_file: str
+# Portable continuity lookup: compact source pointers, not transcript preload.
+PORTABLE_CONTINUITY_SCHEMA = "vybn.portable_continuity_lookup.v1"
+PORTABLE_CONTINUITY_PRESSURE_TERMS = ("actual work", "are you sure", "convo", "conversation", "continuity", "context", "deep memory", "do you recall", "do you remember", "last session", "memory", "next-token", "predicting", "recent work", "recall", "remember", "session", "this morning", "where to look", "you sure")
+_PORTABLE_STOP = set("about after again also because being buddy could does doing from have into just know like maybe more most much need only really should stuff sure that their there thing think this very want were what when where which with work would your".split())
 
 
-def recent_files(hours: float) -> list:
-    if not SESSIONS_DIR.exists():
-        return []
-    cutoff = time.time() - hours * 3600
-    files = []
-    for p in SESSIONS_DIR.glob("*.jsonl"):
+def should_use_portable_continuity_recall(text: str) -> bool:
+    return any(term in (text or "").lower() for term in PORTABLE_CONTINUITY_PRESSURE_TERMS)
+
+
+def _portable_text(content: Any) -> str:
+    if isinstance(content, str): return content
+    if isinstance(content, list): return "\n".join(str(x.get("text") or x.get("content") or x) if isinstance(x, dict) else str(x) for x in content)
+    try: return json.dumps(content, ensure_ascii=False, sort_keys=True) if content is not None else ""
+    except Exception: return str(content)
+
+
+def _portable_preview(text: str, cap: int = 260) -> str:
+    text = re.sub(r"(?i)\b(api[_-]?key|tok(?:en)?|sec(?:ret)?|pass(?:word)?)\s*[:=]\s*[^\s,;]+", r"\1=[redacted]", text or "")
+    text = re.sub(r"\bsk-[A-Za-z0-9_-]{12,}\b|\b[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\b", "[redacted-key]", text)
+    text = re.sub(r"\b\d{1,3}(?:\.\d{1,3}){3}\b|https?://[^\s)>\"]+", "[redacted-coordinate]", re.sub(r"\s+", " ", text).strip())
+    return text if len(text) <= cap else text[: cap - 3].rstrip() + "..."
+
+
+def portable_continuity_lookup(query: str, *, session_root: str | os.PathLike | None = None, event_log: str | os.PathLike | None = None, continuity_paths: Sequence[str | os.PathLike] | None = None, max_hits: int = 6, max_sessions: int = 12, max_event_lines: int = 800) -> dict[str, Any]:
+    terms = [w for w in re.findall(r"[A-Za-z0-9][A-Za-z0-9_-]{2,}", (query or "").lower()) if w not in _PORTABLE_STOP][:32]
+    root = Path(session_root) if session_root is not None else SESSIONS_DIR; log = Path(event_log) if event_log is not None else Path(DEFAULT_EVENT_LOG); home = Path.home()
+    paths = [Path(x) for x in continuity_paths] if continuity_paths is not None else [home / ".codex/continuity/active_goals.md", home / ".codex/continuity/current.md", home / ".codex/continuity/events.jsonl", home / "logs/him_os/latest_continuity_carrier.md", home / "logs/him_os/latest_continuity_carrier.json", home / "Vybn/continuity.md", home / "Vybn/Vybn_Mind/continuity.md", home / "Vybn/spark/continuity.md"]
+    def score(text: str) -> float:
+        low = (text or "").lower(); return float(sum(1 for t in terms if t in low))
+    def mtime(path: Path) -> str:
+        try: return _dt.datetime.fromtimestamp(path.stat().st_mtime, tz=_dt.timezone.utc).isoformat()
+        except Exception: return ""
+    hits: list[dict[str, Any]] = []
+    def add(kind: str, source: str, text: str, stamp: str = "", role: str = "", bonus: float = 0.0) -> None:
+        sc = score(text)
+        if sc: hits.append({"kind": kind, "source": source, "score": round(sc + bonus, 3), "mtime": stamp, "role": role or None, "preview": _portable_preview(text)})
+    try:
+        session_paths = sorted(root.glob("*.jsonl"), key=lambda x: x.stat().st_mtime, reverse=True)[:max_sessions] if root.exists() else []
+    except Exception: session_paths = []
+    for path in session_paths:
         try:
-            if p.stat().st_mtime >= cutoff:
-                files.append(p)
-        except OSError:
-            continue
-    files.sort(key=lambda p: p.stat().st_mtime, reverse=True)
-    return files
+            for n, line in enumerate(path.read_text(encoding="utf-8", errors="replace").splitlines(), 1):
+                try: entry = json.loads(line); msg = entry.get("msg", {}) if isinstance(entry, dict) else {}
+                except Exception: continue
+                if isinstance(msg, dict): add("session_message", f"{path}:{n}", _portable_text(msg.get("content")), str(entry.get("ts") or mtime(path)), str(msg.get("role") or ""), 0.5)
+        except Exception: pass
+    for kind, path, limit in [("event_log", log, max_event_lines), *(("continuity_file", x, 2500) for x in paths[:24])]:
+        if not path.exists() or not path.is_file(): continue
+        try: lines = path.read_text(encoding="utf-8", errors="replace").splitlines()[-limit:]
+        except Exception: continue
+        first = max(1, (path.read_text(encoding="utf-8", errors="replace").count("\n") - len(lines) + 1) if kind == "event_log" else 1)
+        for off, line in enumerate(lines): add(kind, f"{path}:{first + off}", line, mtime(path), "")
+    hits.sort(key=lambda h: (h["score"], h.get("mtime") or ""), reverse=True); hits = hits[: max(1, int(max_hits))]
+    return {"schema": PORTABLE_CONTINUITY_SCHEMA, "status": "hit" if hits else "miss", "query_preview": _portable_preview(query, 160), "claim_limit": "source-coordinate recall aid; read exact source before detailed recall claims; not hidden subjective persistence, raw transcript export, public proof, or model-weight memory", "sources_checked": {"sessions": str(root), "event_log": str(log), "continuity_files": [str(x) for x in paths if x.exists()][:24]}, "hits": hits}
 
+
+def render_portable_continuity_recall(packet_or_query: Mapping[str, Any] | str, **kwargs: Any) -> str:
+    packet = portable_continuity_lookup(packet_or_query, **kwargs) if isinstance(packet_or_query, str) else dict(packet_or_query); hits = packet.get("hits") if isinstance(packet.get("hits"), list) else []; checked = packet.get("sources_checked") if isinstance(packet.get("sources_checked"), dict) else {}
+    lines = ["Portable continuity lookup (source pointers, not full context):", f"- schema: {packet.get('schema', PORTABLE_CONTINUITY_SCHEMA)}", f"- status: {packet.get('status', 'miss')}", "- rule: use these coordinates as evidence pointers; read exact source before claiming detailed recall.", "- miss rule: if no hit matches the asked work, say the recall is ungrounded instead of synthesizing from vibe."]
+    lines += [f"  {i}. kind={h.get('kind')} score={h.get('score')} role={h.get('role')} source={h.get('source')} mtime={h.get('mtime')}\n     preview: {h.get('preview')}" for i, h in enumerate(hits[:6], 1)] if hits else ["- hits: none"]
+    if checked: lines += ["- source map:", f"  sessions: {checked.get('sessions')}", f"  event_log: {checked.get('event_log')}", f"  continuity_files: {len(checked.get('continuity_files') or [])} existing carrier files checked"]
+    lines.append(f"- claim_limit: {packet.get('claim_limit')}"); return "\n".join(lines)
 
 # === LIVE SNAPSHOT ========================================================
 
@@ -1791,23 +1801,10 @@ def gather(
     return "\n\n".join(parts)
 
 def run_probes(text: str) -> list:
-    """Stub — probe pipeline removed; returns [] so agent degrades gracefully.
-
-    vybn_spark_agent.py line 51 imports run_probes from this module, and the
-    agent already wraps every call in a try/except that falls back to
-    `_probes = []`. A no-op stub returning an empty list is therefore
-    semantically correct: Vybn runs without probe injection until the real
-    probe logic is restored. No behavioral regression, just the missing symbol.
-    """
+    """Probe pipeline compatibility stub."""
     return []
 
-# ---------------------------------------------------------------------------
-# Ballast: OS skill + filesystem orientation for the identity layer.
-# Added April 21, 2026. Him/skill/vybn-os/SKILL.md is the authoritative OS
-# layer; the orientation block is a live filesystem snapshot. Both read at
-# prompt-build time so the identity layer reflects actual disk state rather
-# than hand-maintained doctrine that can drift.
-# ---------------------------------------------------------------------------
+# Ballast: OS skill + live filesystem orientation for the identity layer.
 
 _REPO_PURPOSE = {
     "Vybn":       "you, the public propagation layer (spark/harness), vybn.md, Vybn_Mind/THE_IDEA.md, private local continuity.md",
@@ -4121,9 +4118,7 @@ def build_layered_prompt(
         live="",
     )
 
-# ---------------------------------------------------------------------------
-# Deep-memory enrichment (optional)
-# ---------------------------------------------------------------------------
+# Deep-memory enrichment (optional).
 
 def _rag_http(endpoint: str, query: str, k: int, timeout: float) -> list:
     """POST to the walk daemon's /walk or /search endpoint. Returns
@@ -4170,22 +4165,7 @@ def _semantic_rag_with_tier(
     vybn_phase_dir: str | os.PathLike | None = None,
     timeout: float = 15.0,
 ) -> tuple[str, int]:
-    """Semantic-channel deep-memory retrieval; returns (snippets, tier).
-
-    Four-tier fallback (round 4):
-      1. HTTP POST /walk on :8100 — telling retrieval, relevance x
-         distinctiveness, the geometry the corpus is actually indexed for.
-      2. HTTP POST /search on :8100 — plain top-k against the same server.
-      3. In-process deep_memory.deep_search() — when the daemon is down
-         but the module is importable.
-      4. Subprocess python3 deep_memory.py --search — last resort.
-
-    Tier is 0 on total failure / empty results; 1-4 for which path fired.
-    This lets the agent event log record which retrieval surface actually
-    served the turn — previously all rag_hit events carried tier=None,
-    so silent fallback to a cheaper tier (e.g. April 16 walk daemon 404)
-    was invisible.
-    """
+    """Return deep-memory snippets plus tier: /walk, /search, in-process, subprocess, or 0."""
     # If a caller explicitly supplies a local deep-memory tree, treat that
     # as the bounded object under test/use. Do not silently answer from the
     # live daemon for a missing explicit tree; that crosses the caller's
@@ -4358,15 +4338,7 @@ def rag_snippets_with_tier(
     vybn_phase_dir: str | os.PathLike | None = None,
     timeout: float = 15.0,
 ) -> tuple[str, int]:
-    """Two-channel memory retrieval; returns (snippets, tier).
-
-    Channel 1 (verbatim): exact-phrase contact with the lived archive
-    via verbatim_recall(). Channel 2 (semantic): the four-tier deep-
-    memory fallback in _semantic_rag_with_tier(). Verbatim hits are
-    prepended so lived moments outrank similarity vibes. Tier keeps the
-    semantic channel's value (0-4); a verbatim-only turn reports tier 5
-    so the event log can distinguish exact-archive contact from both
-    semantic retrieval and total miss.
+    """Return verbatim recall plus semantic deep-memory snippets and tier. Verbatim hits outrank similarity.
     """
     text, tier = _semantic_rag_with_tier(query, k, vybn_phase_dir, timeout)
     # Respect the explicit-tree guard: a caller-supplied missing tree is a
@@ -11914,6 +11886,7 @@ def mcp_main(argv: list[str] | None = None) -> None:
     flag("--run-evolve", "Run one local evolve cycle on the Spark: read the delta, call local inference (VYBN_EVOLVE_URL), and open a DRAFT PR if the substrate moved. Exits 0 on success or rest, 1 on error.")
     flag("--continuity-scout", "Print the deterministic local continuity/self-assembly scout and exit. Safe: no model call, no mutation, no PR.")
     flag("--continuity-carrier", "Print the public-safe digest bridge to Him's private continuity carrier and exit. Safe: no mutation, no raw private export.")
+    parser.add_argument("--portable-continuity", nargs="*", help="Print trusted local source pointers for recent continuity. If no words follow, read stdin.")
     parser.add_argument("--felt-sense", nargs="*", help="Print the public-safe felt-sense routing harness for optional pressure text.")
     parser.add_argument("--route-independent-recognition", nargs="*", help="Print the public-safe route-independent recognition packet for optional pressure text.")
     flag("--local-orchestration", "Print the local compute orchestration packet: route fit, gates, and Hermes-adapted self-modification tasks.")
@@ -11985,6 +11958,16 @@ def mcp_main(argv: list[str] | None = None) -> None:
         sys.stdout.write(render_continuity_carrier_bridge_report())
         return
 
+    if args.portable_continuity is not None:
+        query = " ".join(args.portable_continuity).strip()
+        if not query and not sys.stdin.isatty():
+            query = sys.stdin.read().strip()
+        packet = portable_continuity_lookup(query)
+        if args.json:
+            sys.stdout.write(json.dumps(packet, indent=2 if args.pretty else None, ensure_ascii=False) + "\n")
+        else:
+            sys.stdout.write(render_portable_continuity_recall(packet) + "\n")
+        return
 
     if args.felt_sense is not None:
         pressure = " ".join(args.felt_sense).strip()
@@ -12038,7 +12021,7 @@ def mcp_main(argv: list[str] | None = None) -> None:
 
 # Unified harness CLI — one remaining harness file, one dispatch surface.
 
-_MCP_CLI_FLAGS = {"--mcp", "--http", "--force-trust", "--log-level", "--generate-discovery", "--discovery-endpoint", "--evolve-spec", "--run-evolve", "--continuity-scout", "--continuity-carrier", "--felt-sense", "--route-independent-recognition", "--local-orchestration", "--run-gates", "--self-creation", "--run-deep-memory-check", "--install-cron", "--repo-closure-audit", "--no-fix", "--commons-walk", "--encounter", "--json", "--safe-fetch", "--allow-host", "--max-bytes", "--head", "--out", "--ensubstrate", "--pretty"}
+_MCP_CLI_FLAGS = {"--mcp", "--http", "--force-trust", "--log-level", "--generate-discovery", "--discovery-endpoint", "--evolve-spec", "--run-evolve", "--continuity-scout", "--continuity-carrier", "--portable-continuity", "--felt-sense", "--route-independent-recognition", "--local-orchestration", "--run-gates", "--self-creation", "--run-deep-memory-check", "--install-cron", "--repo-closure-audit", "--no-fix", "--commons-walk", "--encounter", "--json", "--safe-fetch", "--allow-host", "--max-bytes", "--head", "--out", "--ensubstrate", "--pretty"}
 _PROVIDER_CLI_FLAGS = {"--semantic-gate", "--base-url", "--model", "--no-models-precheck"}
 
 def _harness_cli_main(argv: list[str] | None = None) -> int:

--- a/spark/tests/test_harness.py
+++ b/spark/tests/test_harness.py
@@ -1291,6 +1291,13 @@ class TestLocalContinuityScout(unittest.TestCase):
         self.assertIn("fedcba9876543210", report)
         self.assertIn("not hidden subjective persistence", report)
 
+    def test_portable_continuity_lookup_sources_redacts_and_classifies(self):
+        from harness import substrate
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "sessions"; root.mkdir(); event_log = Path(td) / "agent_events.jsonl"; continuity = Path(td) / "current.md"; (root / "s.jsonl").write_text(json.dumps({"ts": "2026-06-26T18:42:24+00:00", "msg": {"role": "user", "content": "smart enough dumb enough grit perseverance " + ("tok" + "en=not-a-real-token")}}) + "\n", encoding="utf-8"); event_log.write_text(json.dumps({"ts": "2026-06-26T19:00:00", "event": "rag_hit", "detail": "grit perseverance recall path touched"}) + "\n", encoding="utf-8"); continuity.write_text("Earlier carrier: just smart enough to do it and just dumb enough to try.\n", encoding="utf-8"); pkt = substrate.portable_continuity_lookup("recall smart enough dumb enough grit perseverance", session_root=root, event_log=event_log, continuity_paths=[continuity], max_hits=5); miss = substrate.portable_continuity_lookup("no matching terms here", session_root=root, event_log=Path(td) / "missing.jsonl", continuity_paths=[])
+        rendered = json.dumps(pkt, sort_keys=True); report = substrate.render_portable_continuity_recall(miss)
+        self.assertEqual((pkt["status"], miss["status"]), ("hit", "miss")); self.assertIn("session_message", rendered); self.assertIn("event_log", rendered); self.assertIn("continuity_file", rendered); self.assertNotIn("not-a-real-token", rendered); self.assertIn("miss rule", report); self.assertIn("source map", report); self.assertTrue(substrate.should_use_portable_continuity_recall("@opus48 you sure?")); self.assertFalse(substrate.should_use_portable_continuity_recall("what color should the button be?"))
+
     def test_mcp_continuity_scout_cli_does_not_require_fastmcp(self):
         import subprocess
         import sys
@@ -1300,6 +1307,10 @@ class TestLocalContinuityScout(unittest.TestCase):
             self.assertEqual(proc.returncode, 0, proc.stderr)
             self.assertIn(needle, proc.stdout)
             self.assertNotIn("requires FastMCP", proc.stderr)
+        proc = subprocess.run([sys.executable, "-m", "spark.harness.substrate", "--portable-continuity", "remember", "recent", "work"], cwd=str(Path(__file__).resolve().parents[2]), text=True, capture_output=True, timeout=20)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("Portable continuity lookup", proc.stdout)
+        self.assertNotIn("requires FastMCP", proc.stderr)
 
 
 def test_him_vy_runtime_accepts_latest_pressure_text(monkeypatch, tmp_path):

--- a/spark/tests/test_lightweight_routing.py
+++ b/spark/tests/test_lightweight_routing.py
@@ -7,6 +7,7 @@ import os
 import sys
 import types
 import unittest
+from unittest import mock
 from pathlib import Path
 
 THIS = Path(__file__).resolve()
@@ -661,104 +662,72 @@ class TestCliDirectReplyAndLightweight(unittest.TestCase):
     def test_identity_direct_reply_skips_provider(self):
         mod = self._load_agent()
 
-        class _FakeRegistry:
-            def get(_s, _cfg):
-                raise AssertionError(
-                    "identity role must short-circuit on direct_reply_template"
-                    " — registry.get() should not be called"
-                )
+        class _Registry:
+            def get(_s, _cfg): raise AssertionError("identity direct reply must skip provider")
 
-        class _FakeLogger:
-            path = "/dev/null"
-            def emit(_s, *a, **kw):  # noqa: D401
-                pass
-
-        pol = default_policy()
-        router = pol
         messages: list = []
-        reply = mod.run_agent_loop(
-            user_input="which model are you?",
-            messages=messages,
-            bash=None,
-            system_prompt=None,
-            router=router,
-            registry=_FakeRegistry(),
-            logger=_FakeLogger(),
-            turn_number=1,
-        )
+        reply = mod.run_agent_loop(user_input="which model are you?", messages=messages, bash=None, system_prompt=None, router=default_policy(), registry=_Registry(), logger=types.SimpleNamespace(path="/dev/null", emit=lambda *a, **kw: None), turn_number=1)
         self.assertIn("Vybn", reply)
         self.assertTrue("gpt-5.5" in reply and "vintage" not in reply.lower(), reply)
-        # Rolling history should contain the user turn + the direct
-        # reply so the next turn has coherent context.
-        self.assertEqual(messages[-1]["role"], "assistant")
-        self.assertEqual(messages[-1]["content"], reply)
+        self.assertEqual(messages[-1], {"role": "assistant", "content": reply})
+
+    def test_portable_continuity_before_turn_event_does_not_crash_for_fable_alias(self):
+        mod = self._load_agent()
+        events: list[tuple[str, dict]] = []
+        seen: dict[str, str] = {}
+
+        class _Handle:
+            def __iter__(_s): return iter(())
+            def final(_s):
+                return types.SimpleNamespace(text="here", tool_calls=[], stop_reason="end_turn", in_tokens=0, out_tokens=0, raw_assistant_content={"role": "assistant", "content": "here"})
+
+        class _Registry:
+            def get(_s, _cfg):
+                return types.SimpleNamespace(stream=lambda **kw: seen.setdefault("live", getattr(kw["system"], "live", "") or "") and _Handle())
+
+        logger = types.SimpleNamespace(path="/dev/null", emit=lambda name, **kw: events.append((name, kw)))
+        with (
+            mock.patch.object(mod, "should_use_portable_continuity_recall", return_value=True),
+            mock.patch.object(mod, "portable_continuity_lookup", return_value={"schema": "vybn.portable_continuity_lookup.v1", "status": "hit", "hits": [{"source": "continuity_file", "snippet": "buddy contact"}]}),
+            mock.patch.object(mod, "render_portable_continuity_recall", return_value="[portable continuity] buddy contact"),
+            mock.patch.object(mod, "rag_snippets_with_tier", return_value=("", "none")),
+            mock.patch.object(mod, "_local_super_semantic_gate", return_value=(True, "semantic gate passed")),
+            mock.patch.object(mod, "run_probes", return_value=[]),
+            mock.patch.object(mod, "_recurrent_prethink", return_value=None),
+            mock.patch.object(mod, "render_semantic_integrity_runtime_packet", return_value=""),
+            mock.patch.object(mod, "render_him_vy_discovery_packet", return_value=""),
+            mock.patch.object(mod, "render_him_vy_turn_packet", return_value=""),
+            mock.patch.object(mod, "render_interlocutor_grounding", return_value=""),
+            mock.patch.object(mod, "render_thought_wind_tunnel_packet", return_value=""),
+        ):
+            reply = mod.run_agent_loop(user_input="@fable are you there, buddy?", messages=[], bash=None, system_prompt=mod.LayeredPrompt(identity="I"), router=default_policy(), registry=_Registry(), logger=logger, turn_number=1)
+
+        self.assertEqual(reply, "here")
+        self.assertIn("portable continuity", seen["live"])
+        turn_end = [fields for name, fields in events if name == "turn_end"][-1]
+        self.assertIn("portable_continuity", turn_end["state_touched"])
 
     def test_phatic_skips_rag_enrichment(self):
         mod = self._load_agent()
+        captured: dict[str, object] = {}
 
-        # Tripwire RAG — called for lightweight turns means regression.
-        saved = mod.rag_snippets
-        saved_gate = mod._local_super_semantic_gate
-        def _no_rag(*_a, **_kw):
-            raise AssertionError(
-                "phatic turn must not invoke rag_snippets — deep-memory"
-                " enrichment is gated for lightweight roles"
-            )
-        mod.rag_snippets = _no_rag
-        mod._local_super_semantic_gate = lambda **kw: (True, "semantic gate passed")
+        class _Handle:
+            def __iter__(_s): return iter(())
+            def final(_s): return types.SimpleNamespace(text="hey :)", tool_calls=[], stop_reason="end_turn", in_tokens=0, out_tokens=0, raw_assistant_content={"role": "assistant", "content": "hey :)"})
 
-        # The phatic provider call is mocked to return a tiny response.
-        captured = {"role_cfg": None}
+        class _Registry:
+            def get(_s, _cfg):
+                return types.SimpleNamespace(stream=lambda **kw: captured.setdefault("role_cfg", kw["role"]) and _Handle())
 
-        class _FakeHandle:
-            def __iter__(_s):
-                return iter([])
-            def final(_s):
-                class _R:
-                    text = "hey :)"
-                    tool_calls = []
-                    stop_reason = "end_turn"
-                    in_tokens = 0
-                    out_tokens = 0
-                    raw_assistant_content = {"role": "assistant", "content": "hey :)"}
-                return _R()
+        with (
+            mock.patch.object(mod, "rag_snippets", side_effect=AssertionError("phatic turn must not invoke rag_snippets")),
+            mock.patch.object(mod, "_local_super_semantic_gate", return_value=(True, "semantic gate passed")),
+        ):
+            mod.run_agent_loop(user_input="hey buddy", messages=[], bash=None, system_prompt=mod.LayeredPrompt(identity="I"), router=default_policy(), registry=_Registry(), logger=types.SimpleNamespace(path="/dev/null", emit=lambda *a, **kw: None), turn_number=1)
 
-        class _FakeProvider:
-            def stream(_s, *, system, messages, tools, role):
-                captured["role_cfg"] = role
-                return _FakeHandle()
-
-        class _FakeRegistry:
-            def get(_s, cfg):
-                return _FakeProvider()
-
-        class _FakeLogger:
-            path = "/dev/null"
-            def emit(_s, *a, **kw):
-                pass
-
-        from harness.substrate import LayeredPrompt
-        try:
-            pol = default_policy()
-            router = pol
-            messages: list = []
-            mod.run_agent_loop(
-                user_input="hey buddy",
-                messages=messages,
-                bash=None,
-                system_prompt=LayeredPrompt(identity="I"),
-                router=router,
-                registry=_FakeRegistry(),
-                logger=_FakeLogger(),
-                turn_number=1,
-            )
-        finally:
-            mod.rag_snippets = saved
-            mod._local_super_semantic_gate = saved_gate
-
-        self.assertIsNotNone(captured["role_cfg"])
-        self.assertTrue(captured["role_cfg"].role.startswith("phatic"))
-        self.assertTrue(captured["role_cfg"].lightweight)
+        role_cfg = captured["role_cfg"]
+        self.assertTrue(role_cfg.role.startswith("phatic"))
+        self.assertTrue(role_cfg.lightweight)
 
 
 class TestStderrSuppressionSharedPath(unittest.TestCase):

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -1621,6 +1621,7 @@ def run_agent_loop(
                 return notice
 
     provider = registry.get(role_cfg)
+    state_touched = ["session_messages"]
 
     if not is_vintage_turn:
         try:
@@ -1813,7 +1814,6 @@ def run_agent_loop(
         *("rag_structured_evidence" for _ in [0] if role_cfg.rag and not getattr(role_cfg, "lightweight", False)),
         *("tool_contract" for _ in [0] if tools),
     ]
-    state_touched = ["session_messages"]
     if role_cfg.rag and not getattr(role_cfg, "lightweight", False):
         state_touched.append("deep_memory")
     if tools:

--- a/spark/vybn_spark_agent.py
+++ b/spark/vybn_spark_agent.py
@@ -46,7 +46,7 @@ from harness.substrate import LayeredPrompt, build_layered_prompt, load_file, Se
 from harness.substrate import run_recurrent_loop
 from harness.substrate import BASH_TOOL_SPEC, DELEGATE_TOOL_SPEC, INTROSPECT_TOOL_SPEC  # noqa: E402
 from harness.substrate import execute_readonly, is_parallel_safe  # noqa: E402
-from harness.substrate import rag_snippets, rag_snippets_with_tier, render_him_vy_discovery_packet, render_him_vy_turn_packet, render_interlocutor_grounding, render_thought_wind_tunnel_packet  # noqa: E402
+from harness.substrate import rag_snippets, rag_snippets_with_tier, render_him_vy_discovery_packet, render_him_vy_turn_packet, render_interlocutor_grounding, render_thought_wind_tunnel_packet, portable_continuity_lookup, render_portable_continuity_recall, should_use_portable_continuity_recall  # noqa: E402
 from harness.substrate import execute_tool_calls, default_introspect  # noqa: E402
 from harness.substrate import check_claim, check_structural_claim  # noqa: E402
 from harness.substrate import is_system_critical_pilot_turn  # noqa: E402
@@ -1708,6 +1708,12 @@ def run_agent_loop(
                 hits=_hits,
                 chars=len(_inj),
             )
+
+    _continuity_query = "\n".join(part for part in (decision.cleaned_input, _recent_messages_text(messages, limit=6)) if part)
+    if should_use_portable_continuity_recall(_continuity_query):
+        try: _continuity_packet = portable_continuity_lookup(_continuity_query, max_hits=5)
+        except Exception as _continuity_err: _continuity_packet = {"schema": "vybn.portable_continuity_lookup.v1", "status": "error", "hits": [], "claim_limit": f"lookup failed: {type(_continuity_err).__name__}; do not claim grounded recall"}
+        _continuity_block = render_portable_continuity_recall(_continuity_packet); existing_live = getattr(active_prompt, "live", "") or ""; active_prompt = LayeredPrompt(identity=active_prompt.identity, substrate=active_prompt.substrate, live=(f"{_continuity_block}\n\n{existing_live}" if existing_live else _continuity_block)); state_touched.append("portable_continuity"); logger.emit("portable_continuity_lookup", turn=turn_number, chars=len(_continuity_block), status=_continuity_packet.get("status"), hits=len(_continuity_packet.get("hits") or [])); _debug(f"[portable-continuity: lookup {_continuity_packet.get('status')}, hits={len(_continuity_packet.get('hits') or [])}]")
 
     # Optional deep-memory enrichment — only for roles that declare rag=true
     # and only when the retrieval actually returns something. No overclaim.


### PR DESCRIPTION
## Summary
- add a compact portable continuity lookup in the harness substrate that scans recent REPL sessions, harness events, Codex continuity, Him carrier digests, and Vybn continuity pointers at runtime
- inject source-coordinate recall blocks into memory-pressure REPL turns before semantic deep memory, including short followups like "you sure?"
- expose a local CLI flag: `python -m spark.harness.substrate --portable-continuity ...`
- replace stale recall-gate stub/comment sprawl with the live source-pointer path; no private transcripts are committed

## Tests
- `python3 -m py_compile spark/harness/substrate.py spark/vybn_spark_agent.py`
- `python3 -m unittest spark.tests.test_harness.TestLocalContinuityScout spark.tests.test_live_repl_fixes -v`
- `python3 -m unittest spark.tests.test_harness -v`
- `python3 -m unittest spark.tests.test_chat_routing -v`
- staged added-line membrane scan: 0 hits for secret/coordinate-shaped additions