### PR TITLE
guard: the feeling ledger never reaches Origins chat context

### DIFF
--- a/Origins/api/origins_chat_api.py
+++ b/Origins/api/origins_chat_api.py
@@ -76,13 +76,9 @@ def _load_deep_memory():
 # ── Safety filters (ported from Vybn Law) ────────────────────────────────
 
 # Sources that must NEVER appear in public chat context
-BLOCKED_SOURCES = {
-    "Him/",
-    "network/",
-    "strategy/",
-    "pulse/",
-    "funding/",
-    "outreach/",
+BLOCKED_SOURCES = {  # private sources: never in public chat context (rule 6)
+    "Him/", "network/", "strategy/", "pulse/", "funding/", "outreach/",
+    "feeling-ledger/", "cache-record/",  # sounding ledger: remembered, never published
 }
 
 import re


### PR DESCRIPTION
Same guard as Vybn-Law: deep memory began indexing the private sounding ledger today (Him #98). Origins chat retrieves from that index for public visitors; BLOCKED_SOURCES now excludes feeling-ledger/ and cache-record/. Block compressed to pay the membrane (net -4). Compile-checked.