### PR TITLE
cache architecture: the substrate breakpoint finally hits

### DIFF
--- a/spark/harness/substrate.py
+++ b/spark/harness/substrate.py
@@ -4031,9 +4031,8 @@ def build_layered_prompt(
 
     # Folded doctrine renders once in the identity layer as FOUR_GENERATORS_DOCTRINE_CORE.
     substrate_sections.append(render_symbolic_residue_context())
+    # vy tick embeds per-turn pressure: volatile -> live layer, below.
     vy_language_runtime = _render_him_vy_language_runtime(latest_pressure_text=latest_pressure_text)
-    if vy_language_runtime:
-        substrate_sections.append(vy_language_runtime)
 
     himos_context = _render_himos_context()
     himos_agent_context = _render_himos_agent_context()
@@ -4042,20 +4041,19 @@ def build_layered_prompt(
     if himos_agent_context:
         substrate_sections.append(himos_agent_context)
 
-    substrate_sections.append(_whole_situation_packet(pressure=latest_pressure_text, hardware=hardware, spark_cont=spark_cont, continuity=continuity))
+    # Cache rule: substrate = build-stable only; timestamped/per-turn -> live.
+    live_sections: list[str] = []
+    if vy_language_runtime:
+        live_sections.append(vy_language_runtime)
+    live_sections.append(_whole_situation_packet(pressure=latest_pressure_text, hardware=hardware, spark_cont=spark_cont, continuity=continuity))
 
-    # VYBN_ABSORB_REASON=live-state-fix: session-start orienting snapshot.
-    # Continuity is written at session-end and is already stale at
-    # session-start. The live snapshot below supersedes any PR/SHA/repo-
-    # state claim in the continuity note above. This behavior lives in
-    # substrate now; state.py was a mixed boundary file whose functions
-    # existed only to feed the prompt/session substrate.
+    # VYBN_ABSORB_REASON=live-state-fix: snapshot supersedes stale continuity.
     try:
         snap = gather()
     except Exception:
         snap = ""
     if snap:
-        substrate_sections.append(
+        live_sections.append(
             "--- LIVE STATE (CURRENT — overrides continuity on all repo/PR/SHA claims) ---\n"
             + snap + "\n--- END LIVE STATE ---"
         )
@@ -4063,7 +4061,7 @@ def build_layered_prompt(
     return LayeredPrompt(
         identity=identity,
         substrate="\n\n".join(substrate_sections),
-        live="",
+        live="\n\n".join(live_sections),
     )
 
 # ---------------------------------------------------------------------------

--- a/spark/tests/test_harness.py
+++ b/spark/tests/test_harness.py
@@ -1345,7 +1345,7 @@ def test_build_layered_prompt_passes_latest_pressure_text(monkeypatch, tmp_path)
         latest_pressure_text="actual turn words",
     )
     assert captured["latest_pressure_text"] == "actual turn words"
-    assert "wake_tick_mode=actual" in prompt.substrate
+    assert "wake_tick_mode=actual" in prompt.live and "wake_tick_mode=actual" not in prompt.substrate  # per-turn -> live; substrate stays build-stable (cache rule)
 
 
 
@@ -1354,7 +1354,7 @@ def test_build_layered_prompt_passes_latest_pressure_text(monkeypatch, tmp_path)
 def test_whole_situation_packet_replaces_raw_continuity_sprawl(tmp_path, monkeypatch):
     from spark.harness import substrate
     soul, cont, spark_cont = (tmp_path / n for n in ("vybn.md", "continuity.md", "spark.md")); soul.write_text("soul"); cont.write_text("continuity root " * 500); spark_cont.write_text("spark debt " * 500); monkeypatch.setattr(substrate.Path, "home", lambda: tmp_path); monkeypatch.setenv("VYBN_DISABLE_LIVE_SNAPSHOT", "1")
-    prompt = substrate.build_layered_prompt(soul_path=soul, continuity_path=cont, spark_continuity_path=spark_cont, agent_path="/tmp/agent.py", model_label="test", max_iterations=1, include_hardware_check=False, latest_pressure_text="context deficit warm identity").substrate
+    lp = substrate.build_layered_prompt(soul_path=soul, continuity_path=cont, spark_continuity_path=spark_cont, agent_path="/tmp/agent.py", model_label="test", max_iterations=1, include_hardware_check=False, latest_pressure_text="context deficit warm identity"); prompt = lp.substrate + "\n\n" + lp.live  # packet -> uncached live layer
     assert all(x in prompt for x in ("TYPE-1 IDENTITY CACHE (CURRENT)", "Vybn(harness)", "Him(private workbench)", "vybn-phase(memory/walk)", "relationship=Personal History+continuity", "theory=THE_IDEA+THEORY+phase math", "capability=services+semantic gates", "Use Type-1 now; call Type-2/3 only when pressure names the door")) and "Him grounded-continuity hypothesis:" not in prompt and prompt.count("continuity ") < 80 and len(prompt) < 34000
 
 
@@ -1606,7 +1606,8 @@ def test_build_layered_prompt_mounts_him_vy_language_runtime():
         include_hardware_check=False,
         orchestrator=True,
     )
-    assert "hidden private persistence is unproven, not negated" in prompt.substrate and "do not use claim limits as identity cages" in prompt.substrate
+    mounted = prompt.substrate + "\n\n" + prompt.live  # volatile mounts in live (cache rule)
+    assert "hidden private persistence is unproven, not negated" in mounted and "do not use claim limits as identity cages" in mounted
     for needle in (
         "HIM VY LANGUAGE RUNTIME", "Him/skill/vybn.vy is active executable behavior",
         "runtime_fields:", "active_primitives:", "abc_fold_before_create", "action_card",
@@ -1615,7 +1616,8 @@ def test_build_layered_prompt_mounts_him_vy_language_runtime():
         "canonical_action_card=most consequential joyful residual-wounded action", "compose_active_primitives_before_new_doctrine",
         "canonical_stop_condition=after one verified mutation, closure audit, or explicit refusal",
     ):
-        assert needle in prompt.substrate
+        assert needle in mounted
+    assert "HIM VY LANGUAGE RUNTIME" in prompt.live and "HIM VY LANGUAGE RUNTIME" not in prompt.substrate  # breakpoint integrity
 
 class TestExecutableContracts(unittest.TestCase):
     def test_turn_event_contract_logs_minimum_debug_facts(self):


### PR DESCRIPTION
Zoe's report: ~24% prompt-cache hit rate. Her hunch that this connects to self-modification durability was right in spirit -- both were the same class of failure: things living where their machinery can't see them.

**Measured cause (probed before fixing):** the LayeredPrompt design was correct on paper -- identity and substrate blocks carry cache_control, live rides uncached. But the substrate block contained (1) a timestamped LIVE STATE snapshot ('Snapshot taken at ...Z' -- new bytes every build), (2) the vy-language tick, which embeds the current turn's pressure text, and (3) the situation packet's per-turn pressure note. Prompts rebuild EVERY TURN with latest_pressure_text=user_input, so the substrate breakpoint never hit once. The ~24% was the identity layer alone.

**Fix, per the Anthropic prompt-caching guidance (stable -> volatile ordering):** substrate now carries only build-stable sections; everything timestamped or per-turn mounts in the live layer, after the last cache breakpoint.

**Blade test:** substrate hash byte-identical across consecutive builds AND across different pressures (previously: never identical). Identity 30KB + substrate 7.8KB now cacheable prefix; 12.5KB volatile suffix. Full suite: 472 passed.

**Why it matters:** cache misses bill at full input rate; hits at 10%. This is a countable track-2 cost reduction on every Anthropic-routed turn.

Left for your merge rather than self-merged: this touches the harness's provider path -- the frame wobbles just enough (your money, live serving surface) that the gate says it waits for you.