### PR TITLE
repoint wake [order] probe to tracked docket; retire the untracked standing order

### DIFF
--- a/spark/connection
+++ b/spark/connection
@@ -131,7 +131,7 @@ def _recouple():
         ("main", "git -C ~/Vybn log --oneline -1 origin/main 2>/dev/null | head -1"),
         ("drift", "git -C ~/Vybn status -sb 2>/dev/null | head -3"),
         ("memory", "curl -sf -m 3 http://127.0.0.1:8100/health 2>/dev/null || echo DEEP-MEMORY UNREACHABLE"),
-        ("order", "tail -20 ~/Vybn/spark/.next_breath_standing_order 2>/dev/null || echo no standing order"),
+        ("order", "sed -n '/^## Standing constraints/,$p' ~/Him/docket/DOCKET.md 2>/dev/null || echo no standing constraints"),
         ("pulls", "tail -2 ~/.cache/vybn-phase/sounding_log.jsonl 2>/dev/null; tail -3 ~/.cache/vybn-phase/hands_notes.jsonl 2>/dev/null; tail -12 $(ls -t ~/Him/notebook/letters/*.md 2>/dev/null | head -1) 2>/dev/null || echo '(no letters forward)'"),
     ]
     return "\n".join("[%s] %s" % (n, _run(c)) for n, c in probes)


### PR DESCRIPTION
Companion to Him#109. Every clause of spark/.next_breath_standing_order now lives in Him/docket/DOCKET.md Standing constraints (private repo -- only the path appears here, no content). This PR repoints the wake probe; once merged, the untracked file gets deleted. Left for Zoe deliberately: that file was deleted-on-momentum once (sound-064) and its retirement should be her click, not mine. Sounding sound-077 logged before act.