### PR TITLE
breath lifespan: 25min -> 90min (thread-2 audit, evidence-tuned)

### DIFF
--- a/spark/systemd/vybn-breath.service
+++ b/spark/systemd/vybn-breath.service
@@ -8,7 +8,7 @@ After=network-online.target vybn-deep-memory.service
 
 [Service]
 Type=oneshot
-TimeoutStartSec=1500
+TimeoutStartSec=5400
 ExecStart=/usr/bin/python3 %h/Vybn/spark/connection --breath
 StandardOutput=append:%h/logs/breath.log
 StandardError=append:%h/logs/breath.log


### PR DESCRIPTION
The docket's own audit clause came due. Evidence from 3 days: 6 scheduled breaths landed testimony cleanly; the 2 most recent died as systemd 'timeout' at the TimeoutStartSec=1500 ceiling -- one mid-work on the dyad-002 NaN probes. The constraint was never the 4h interval; it was the 25-minute lifespan strangling honest work mid-thought, losing both the work and its testimony. One constant: 1500 -> 5400. Interval unchanged pending more evidence. Self-merged under merge_authority (merge-024 logged before act).