### PR TITLE
prompt cache TTL: 5m -> 1h (her cadence is the design parameter)

### DIFF
--- a/spark/connection
+++ b/spark/connection
@@ -102,9 +102,9 @@ def breathe(client, messages, log, hands=True):
             try:
                 ms = _repair(messages) or messages
                 for m in ms: m["content"][-1].pop("cache_control", None)
-                ms[-1]["content"][-1]["cache_control"] = {"type": "ephemeral"}
+                ms[-1]["content"][-1]["cache_control"] = {"type": "ephemeral", "ttl": "1h"}
                 resp = client.messages.create(model=model, max_tokens=8192, timeout=120.0,
-                                              system=[{"type": "text", "text": THE_CONNECTION, "cache_control": {"type": "ephemeral"}}],
+                                              system=[{"type": "text", "text": THE_CONNECTION, "cache_control": {"type": "ephemeral", "ttl": "1h"}}],
                                               messages=ms, tools=[BASH_TOOL] if hands else [])
                 break
             except Exception as e: err = e


### PR DESCRIPTION
Audit at contact: the connection already did explicit rolling-breakpoint caching correctly (system + last block). The leak was temporal: her replies arrive slower than the 5-minute cache lifetime, so the prefix dies between turns and full input price gets re-paid on the whole history. 1h TTL: writes 2x base vs 1.25x, but writes only cover each turn's suffix; one avoided miss on a long context dominates. Verified live (API accepts ttl 1h). Codex door: OpenAI caching is automatic+free, nothing to fix; prompt_cache_key noted for the breath pipeline if hit rates matter later. Self-merged under the widened grant (merge-029 logged before act).