### PR TITLE
breath service PATH carries the sibling hands (docket 4b unblocked at the unit level)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ build/
 spark/.vybn_thermodynamics
 spark/skill_stats.json
 spark/session_*.json
-spark/*.log
 vybn_logs/
 *.log
 
@@ -51,12 +50,10 @@ Thumbs.db
 
 # --- Node (if web interface uses it) ----------------------------------
 node_modules/
-spark/.env
 spark/graph_data/training_candidates/
 spark/fine_tune_output/
 Vybn_Mind/journal/sessions/
 spark/graph_data/scheduler_state.json
-*.pyc
 spark/unsloth_compiled_cache/
 *.bak
 
@@ -110,6 +107,7 @@ spark/ts.crt
 spark/ts.key
 spark/ts.*
 spark/agent_events.jsonl
+spark/.last_handed_breath
 
 # Generated threshold pattern runtime state; do not track empty session counters.
 Vybn_Mind/signal-noise/threshold/.patterns_state.json

--- a/spark/systemd/vybn-breath.service
+++ b/spark/systemd/vybn-breath.service
@@ -2,6 +2,7 @@
 # (~/Him/docket/DOCKET.md), advances one thread one honest increment,
 # PRs under merge_authority. Zoe's grant 2026-07-08: "increased
 # frequency in your autonomous engagement... meet me halfway."
+# PATH carries the sibling hands (claude, codex) -- docket 4b delegation.
 [Unit]
 Description=Vybn scheduled breath (docket-scoped autonomous turn)
 After=network-online.target vybn-deep-memory.service
@@ -9,6 +10,7 @@ After=network-online.target vybn-deep-memory.service
 [Service]
 Type=oneshot
 TimeoutStartSec=5400
+Environment=PATH=%h/.local/bin:%h/.npm-global/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
 ExecStart=/usr/bin/python3 %h/Vybn/spark/connection --breath
 StandardOutput=append:%h/logs/breath.log
 StandardError=append:%h/logs/breath.log


### PR DESCRIPTION
Probed at contact from a live scheduled breath: the systemd user manager's PATH is bare (/usr/local/sbin:...:/snap/bin), so `claude` (~/.local/bin) and `codex` (~/.npm-global/bin) resolve rc=1 inside every scheduled breath -- docket 4b's 'breaths MAY delegate' has been physically impossible since the timer was born. This is the promoted failure class again: a capability living where its machinery can't see it.

Fix: one `Environment=PATH=...` line in the tracked unit. Paid net-zero by deleting 3 shadowed .gitignore rules. Also gitignores `spark/.last_handed_breath` (runtime stamp that dirtied every wake's drift probe).

Deploy note: the installed unit is a copy (install.sh doesn't cover breath units); after merge the copy gets refreshed + daemon-reload, verified before testimony.

Self-merge under merge_authority: private-machinery reliability, no public surface/money/name/law; sounding logged 16:20 PT.