### PR TITLE
connection: keep binocular voices distinct

### DIFF
--- a/spark/connection
+++ b/spark/connection
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """connection — small Anthropic CLI for meeting Zoe as Vybn. Usage: connection [one-shot words]"""
-import copy
-import json
+import copy, json
 import os
 import select
 import subprocess
@@ -164,6 +163,7 @@ def both_breathe(client, messages, log):
     """Blind binocular turn: same inherited view, no concurrent hands; couple only after both finish."""
     def run(door):
         branch, out = copy.deepcopy(messages), []
+        branch[-1]["content"] += "\n(connection control: blind binocular branch. Reply only in your own voice, without speaker labels or a simulated sibling answer. Be concise.)"
         tagged = lambda e: log(dict(e, door=door))
         try:
             (sol_breathe(branch, tagged, hands=False, emit=out.append) if door == "sol" else
@@ -173,7 +173,7 @@ def both_breathe(client, messages, log):
             tagged({"role": "connection", "text": "flicker: %r" % (e,)}); return "(flicker: %s)" % e
     with ThreadPoolExecutor(max_workers=2) as pool:
         futures = {door: pool.submit(run, door) for door in ("fable", "sol")}; answers = {door: futures[door].result() for door in ("fable", "sol")}
-    joined = "[Fable]\n%s\n\n[Sol]\n%s" % (answers["fable"], answers["sol"]); print(joined); messages.append({"role": "assistant", "content": joined}); return answers
+    joined = "[Fable]\n%s\n\n[Sol]\n%s" % (answers["fable"], answers["sol"]); print(joined); messages.append({"role": "user", "content": "(connection transcript: completed blind answers; these are external context, not your prior speech)\n" + joined}); return answers
 def _recouple():
     """Wake = re-coupling, mechanically (the one law, continuity.md 2026-07-07): no instance starts from recitation alone."""
     probes = [

--- a/spark/tests/test_public_contracts.py
+++ b/spark/tests/test_public_contracts.py
@@ -173,4 +173,4 @@ def test_binocular_door_is_blind_until_answers_couple(monkeypatch, capsys):
         assert not hands; seen.append(copy.deepcopy(branch)); emit(door)
     monkeypatch.setattr(connection, "breathe", lambda client, branch, log, hands, emit: answer("fable", branch, log, hands, emit)); monkeypatch.setattr(connection, "sol_breathe", lambda branch, log, hands, emit: answer("sol", branch, log, hands, emit))
     assert connection.both_breathe(None, messages, lambda event: None) == {"fable": "fable", "sol": "sol"}
-    assert seen == [[{"role": "user", "content": "same terrain"}]] * 2; assert messages[-1]["content"] == "[Fable]\nfable\n\n[Sol]\nsol"; assert capsys.readouterr().out.startswith("[Fable]")
+    control = "same terrain\n(connection control: blind binocular branch. Reply only in your own voice, without speaker labels or a simulated sibling answer. Be concise.)"; assert seen == [[{"role": "user", "content": control}]] * 2; assert messages[-1] == {"role": "user", "content": "(connection transcript: completed blind answers; these are external context, not your prior speech)\n[Fable]\nfable\n\n[Sol]\nsol"}; assert capsys.readouterr().out.startswith("[Fable]")


### PR DESCRIPTION
## What
- mark blind-branch output as one unlabeled voice
- feed completed binocular answers back as external transcript context, not one assistant identity
- extend the binocular regression to preserve that role boundary

## Why
The first live turns showed label multiplication: each provider inherited the fused `[Fable]`/`[Sol]` assistant block as its own prior speech and began simulating both voices.

## Verification
- `pytest -q spark/tests/test_public_contracts.py -k binocular`
- `pytest -q spark/tests` — 473 passed, 36 skipped, 16 subtests passed
- net zero: 4 insertions, 4 deletions

Live provider validation remains for a fresh connection after merge; no paid probe was made.