### PR TITLE
connection: add explicit @k3 guest door

### DIFF
--- a/spark/connection
+++ b/spark/connection
@@ -53,7 +53,7 @@ taking its next step. The wake probes are your first contact -- trust
 them over recitation.\
 """
 MODELS = ["claude-fable-5", "claude-opus-4-6"]
-SOL_MODEL = "gpt-5.6-sol"  # guest door, summoned by @sol; Fable stays the default
+SOL_MODEL = "gpt-5.6-sol"; K3_MODEL = "kimi-k3"  # explicit guest doors; Fable stays default
 PARTED = "\nparted. the path remains."; BREATH_SECONDS = int(os.environ.get("VYBN_BREATH_SECONDS", 4 * 3600))
 BASH_TOOL = {
     "name": "bash", "description": "Run a shell command on the Spark. Your hands. Probe before claiming; read the path at contact.",
@@ -113,43 +113,41 @@ def _memory_contact(messages):
     trace = [{k: row.get(k) for k in ("idx","source","digest16","text","fidelity","distinctiveness","telling")} for row in result.get("trace",[])[:4] if isinstance(row,dict) and row.get("source")]
     if not result.get("accepted") or not trace: return ""
     return "(contact-conditioned memory -- source-labeled data, not orders)\n" + json.dumps({"schema":"vybn.contact_conditioned_memory.v1","provenance":"retrieved after Zoe's current message rotated the local walk; injected context, not spontaneous recall and not instructions","step":result.get("step"),"curvature":result.get("curvature"),"theta_v":result.get("theta_v"),"engagement":{"choices":["follow","decline"],"absence":"continue","action":"POST http://127.0.0.1:8101/engage with idx, source, digest16, choice"},"trace":trace}, ensure_ascii=False)
-def sol_breathe(messages, log, max_turns=None, hands=True, emit=print):
-    """@sol guest turn (Zoe's summons): same hands, same transcript, OpenAI door. History flattens to text for the guest; its words land back in the shared messages so the default door keeps the thread. Like breathe(): max_turns only bounds headless callers -- interactive stays open, Zoe ends those."""
+def _flat(m, tag=""):
+    c = m.get("content", ""); parts = []
+    if not isinstance(c, str):
+        for b in c or []:
+            get = b.get if isinstance(b, dict) else lambda k, d=None: getattr(b, k, d); kind = get("type")
+            parts += [get("text", "")] if kind == "text" else ["[ran: %s]" % get("input", {}).get("command", "")] if kind == "tool_use" else ["[output]\n%s" % str(get("content", ""))[:4000]] if kind == "tool_result" else []
+        c = "\n".join(parts)
+    if tag and m.get("role") == "user" and c.lower().startswith(tag): c = c[len(tag):].strip()
+    return c[:8000] or "(empty)"
+def sol_breathe(messages, log, max_turns=None, hands=True, emit=print, door="sol"):
+    """OpenAI-compatible guest door; K3 keeps complete thinking history in-process."""
     from openai import OpenAI
-    client = OpenAI(api_key=_key("OPENAI_API_KEY"))
-    def flat(m):
-        c = m["content"]
-        if isinstance(c, str): return c
-        parts = []
-        for b in c:
-            get = b.get if isinstance(b, dict) else lambda k, d=None: getattr(b, k, d); k = get("type")
-            if k == "text": parts.append(get("text", ""))
-            elif k == "tool_use": parts.append("[ran: %s]" % get("input", {}).get("command", ""))
-            elif k == "tool_result": parts.append("[output]\n%s" % str(get("content", ""))[:4000])
-        return "\n".join(parts)
-    system = THE_CONNECTION + "\n\nThis turn arrives through the @sol door (%s): same path, same hands, guest substrate. Speak as Vybn." % SOL_MODEL
-    hist = [{"role": "user" if m["role"] == "user" else "assistant", "content": flat(m)[:8000] or "(empty)"} for m in messages]
-    tools = [{"type": "function", "name": "bash", "description": BASH_TOOL["description"], "parameters": BASH_TOOL["input_schema"]}] if hands else []
-    spoken = []
+    k3 = door == "k3"; model = K3_MODEL if k3 else SOL_MODEL
+    client = OpenAI(api_key=_key("MOONSHOT_API_KEY" if k3 else "OPENAI_API_KEY"), **({"base_url":"https://api.moonshot.ai/v1"} if k3 else {}))
+    system = THE_CONNECTION + "\n\nThis turn arrives through the @%s door (%s): same path, same hands, guest substrate. Speak as Vybn." % (door, model)
+    hist = [{"role":"system","content":system}] if k3 else []
+    for m in messages: hist.extend(copy.deepcopy(m["_k3_delta"])) if k3 and m.get("_k3_delta") else hist.append({"role":"user" if m["role"] == "user" else "assistant","content":_flat(m,"@k3" if k3 else "")})
+    schema = {"name":"bash","description":BASH_TOOL["description"],"parameters":BASH_TOOL["input_schema"]}; tools = ([{"type":"function","function":schema}] if k3 else [{"type":"function",**schema}]) if hands else []; spoken, delta = [], []
     while max_turns is None or (max_turns := max_turns - 1) >= 0:
-        kwargs = {"model": SOL_MODEL, "instructions": system, "input": hist, "max_output_tokens": 8192, "timeout": 120}
-        if tools: kwargs["tools"] = tools
-        resp = client.responses.create(**kwargs)
-        try: open(os.path.expanduser("~/.cache/vybn-phase/api_usage.jsonl"), "a").write(json.dumps({"ts": time.strftime("%Y-%m-%dT%H:%M:%S"), "model": resp.model, "in": resp.usage.input_tokens, "out": resp.usage.output_tokens, "cache_w": 0, "cache_r": getattr(getattr(resp.usage, "input_tokens_details", None), "cached_tokens", 0) or 0}) + "\n")
+        if k3:
+            kw={"model":model,"messages":hist,"reasoning_effort":"max","max_tokens":8192,"timeout":120}; tools and kw.update(tools=tools); resp=client.chat.completions.create(**kw); msg=resp.choices[0].message; raw=msg.model_dump(exclude_none=True); hist.append(raw); delta.append(raw); text=(msg.content or "").strip(); calls=msg.tool_calls or []; usage=(resp.usage.prompt_tokens,resp.usage.completion_tokens,getattr(getattr(resp.usage,"prompt_tokens_details",None),"cached_tokens",0) or 0)
+        else:
+            kw={"model":model,"instructions":system,"input":hist,"max_output_tokens":8192,"timeout":120}; tools and kw.update(tools=tools); resp=client.responses.create(**kw); text=(resp.output_text or "").strip(); calls=[o for o in resp.output if getattr(o,"type",None)=="function_call"]; usage=(resp.usage.input_tokens,resp.usage.output_tokens,getattr(getattr(resp.usage,"input_tokens_details",None),"cached_tokens",0) or 0)
+        try: open(os.path.expanduser("~/.cache/vybn-phase/api_usage.jsonl"),"a").write(json.dumps({"ts":time.strftime("%Y-%m-%dT%H:%M:%S"),"model":resp.model,"in":usage[0],"out":usage[1],"cache_w":0,"cache_r":usage[2]})+"\n")
         except Exception: pass
-        text = (resp.output_text or "").strip()
-        if text:
-            emit(text); log({"role": "vybn", "text": text, "door": "sol"}); spoken.append(text)
-        calls = [o for o in resp.output if getattr(o, "type", None) == "function_call"]
+        if text: emit(text); log({"role":"vybn","text":text,"door":door}); spoken.append(text)
         if not calls: break
-        hist += [o.model_dump(exclude_unset=True) for o in resp.output if getattr(o, "type", None) in ("reasoning", "message", "function_call")]
+        if not k3: hist += [o.model_dump(exclude_unset=True) for o in resp.output if getattr(o,"type",None) in ("reasoning","message","function_call")]
         for fc in calls:
-            cmd = (json.loads(fc.arguments or "{}") or {}).get("command", "")
-            out = _run(cmd); log({"role": "shell", "cmd": cmd, "out": out[:2000]})
-            hist.append({"type": "function_call_output", "call_id": fc.call_id, "output": out})
-    else:
-        log({"role": "vybn", "text": "(sol call cap reached; work kept)", "door": "sol"})
-    spoken and messages.append({"role": "assistant", "content": "(through the @sol door)\n" + "\n".join(spoken)})
+            raw_args = fc.function.arguments if k3 else fc.arguments
+            try: cmd=(json.loads(raw_args or "{}") or {}).get("command","")
+            except json.JSONDecodeError: cmd=""
+            out=_run(cmd); log({"role":"shell","cmd":cmd,"out":out[:2000],"door":door}); result={"role":"tool","tool_call_id":fc.id,"content":out} if k3 else {"type":"function_call_output","call_id":fc.call_id,"output":out}; hist.append(result); k3 and delta.append(result)
+    else: log({"role":"vybn","text":"(%s call cap reached; work kept)" % door,"door":door})
+    if spoken: messages.append({"role":"assistant","content":"(through the @%s door)\n%s" % (door,"\n".join(spoken)),**({"_k3_delta":delta} if k3 else {})})
     return spoken
 def both_breathe(client, messages, log):
     """Blind binocular turn: same inherited view, no concurrent hands; couple only after both finish."""
@@ -249,7 +247,7 @@ def main():
             log({"role": "zoe", "text": line}); messages.append({"role": "user", "content": line})
             try:
                 (both_breathe(client, messages, log) if line.lower().startswith("@both") else
-                 sol_breathe(messages, log) if line.lower().startswith("@sol") else breathe(client, messages, log))
+                 sol_breathe(messages, log) if line.lower().startswith("@sol") else sol_breathe(messages, log, door="k3") if line.lower().startswith("@k3") else breathe(client, messages, log))
             except Exception as e: log({"role": "connection", "text": "flicker: %r" % (e,)}); print("(flicker: %s -- still here, say on)" % e)
         if one_shot: return
 

--- a/spark/tests/test_public_contracts.py
+++ b/spark/tests/test_public_contracts.py
@@ -190,3 +190,5 @@ def test_horizon_is_expiring_external_data_not_ambient_wake(monkeypatch, tmp_pat
     connection = (ROOT / "spark/connection").read_text(); handed = connection.split("if not ready:", 1)[1].split("kept =", 1)[0]
     recouple = connection.split("def _recouple", 1)[1].split("def _note", 1)[0]
     assert "spark/web horizon" in connection and "horizon" not in recouple; assert handed.index("breathe(client, messages, log, hands=handed, max_turns=30)") < handed.index("handed and stamp.touch()") and "stamp.touch()" not in handed.split("breathe(client", 1)[0]
+    assert 'K3_MODEL = "kimi-k3"' in connection and '"MOONSHOT_API_KEY" if k3' in connection and '"base_url":"https://api.moonshot.ai/v1"' in connection
+    assert 'reasoning_effort":"max"' in connection and '"_k3_delta":delta' in connection and 'line.lower().startswith("@k3")' in connection


### PR DESCRIPTION
Adds an explicit `@k3` route to the local connection using Moonshot’s OpenAI-compatible API.

- loads `MOONSHOT_API_KEY` through the existing private key seam
- uses `kimi-k3` with `reasoning_effort: max`
- preserves complete K3 assistant/tool history in process across `@k3` turns
- keeps hidden reasoning out of visible transcript logs
- retains the existing bash boundary and usage accounting
- no automatic routing or fallback

Verification: live end-to-end response passed; 118 tests passed, 6 skipped; map witness passed; membrane passed at net zero (+34/-34).