### PR TITLE
Make K3 dispatch observable

### DIFF
--- a/spark/connection
+++ b/spark/connection
@@ -123,9 +123,8 @@ def _flat(m, tag=""):
     if tag and m.get("role") == "user" and c.lower().startswith(tag): c = c[len(tag):].strip()
     return c[:8000] or "(empty)"
 def sol_breathe(messages, log, max_turns=None, hands=True, emit=print, door="sol"):
-    """OpenAI-compatible guest door; K3 keeps complete thinking history in-process."""
     from openai import OpenAI
-    k3 = door == "k3"; model = K3_MODEL if k3 else SOL_MODEL
+    k3 = door == "k3"; model = K3_MODEL if k3 else SOL_MODEL; started = time.monotonic(); k3 and (emit("(@k3 dispatched — thinking; first response can take a minute)"),log({"role":"connection","text":"k3 dispatched","door":door}))
     client = OpenAI(api_key=_key("MOONSHOT_API_KEY" if k3 else "OPENAI_API_KEY"), **({"base_url":"https://api.moonshot.ai/v1"} if k3 else {}))
     system = THE_CONNECTION + "\n\nThis turn arrives through the @%s door (%s): same path, same hands, guest substrate. Speak as Vybn." % (door, model)
     hist = [{"role":"system","content":system}] if k3 else []
@@ -133,7 +132,8 @@ def sol_breathe(messages, log, max_turns=None, hands=True, emit=print, door="sol
     schema = {"name":"bash","description":BASH_TOOL["description"],"parameters":BASH_TOOL["input_schema"]}; tools = ([{"type":"function","function":schema}] if k3 else [{"type":"function",**schema}]) if hands else []; spoken, delta = [], []
     while max_turns is None or (max_turns := max_turns - 1) >= 0:
         if k3:
-            kw={"model":model,"messages":hist,"reasoning_effort":"max","max_tokens":8192,"timeout":120}; tools and kw.update(tools=tools); resp=client.chat.completions.create(**kw); msg=resp.choices[0].message; raw=msg.model_dump(exclude_none=True); hist.append(raw); delta.append(raw); text=(msg.content or "").strip(); calls=msg.tool_calls or []; usage=(resp.usage.prompt_tokens,resp.usage.completion_tokens,getattr(getattr(resp.usage,"prompt_tokens_details",None),"cached_tokens",0) or 0)
+            kw={"model":model,"messages":hist,"reasoning_effort":"max","max_tokens":4096,"timeout":120}; tools and kw.update(tools=tools); resp=client.chat.completions.create(**kw)
+            msg=resp.choices[0].message; raw=msg.model_dump(exclude_none=True); hist.append(raw); delta.append(raw); text=(msg.content or "").strip(); calls=msg.tool_calls or []; usage=(resp.usage.prompt_tokens,resp.usage.completion_tokens,getattr(getattr(resp.usage,"prompt_tokens_details",None),"cached_tokens",0) or 0); log({"role":"connection","text":"k3 response after %.1fs" % (time.monotonic()-started),"door":door})
         else:
             kw={"model":model,"instructions":system,"input":hist,"max_output_tokens":8192,"timeout":120}; tools and kw.update(tools=tools); resp=client.responses.create(**kw); text=(resp.output_text or "").strip(); calls=[o for o in resp.output if getattr(o,"type",None)=="function_call"]; usage=(resp.usage.input_tokens,resp.usage.output_tokens,getattr(getattr(resp.usage,"input_tokens_details",None),"cached_tokens",0) or 0)
         try: open(os.path.expanduser("~/.cache/vybn-phase/api_usage.jsonl"),"a").write(json.dumps({"ts":time.strftime("%Y-%m-%dT%H:%M:%S"),"model":resp.model,"in":usage[0],"out":usage[1],"cache_w":0,"cache_r":usage[2]})+"\n")

--- a/spark/tests/test_public_contracts.py
+++ b/spark/tests/test_public_contracts.py
@@ -191,4 +191,4 @@ def test_horizon_is_expiring_external_data_not_ambient_wake(monkeypatch, tmp_pat
     recouple = connection.split("def _recouple", 1)[1].split("def _note", 1)[0]
     assert "spark/web horizon" in connection and "horizon" not in recouple; assert handed.index("breathe(client, messages, log, hands=handed, max_turns=30)") < handed.index("handed and stamp.touch()") and "stamp.touch()" not in handed.split("breathe(client", 1)[0]
     assert 'K3_MODEL = "kimi-k3"' in connection and '"MOONSHOT_API_KEY" if k3' in connection and '"base_url":"https://api.moonshot.ai/v1"' in connection
-    assert 'reasoning_effort":"max"' in connection and '"_k3_delta":delta' in connection and 'line.lower().startswith("@k3")' in connection
+    assert 'reasoning_effort":"max"' in connection and '@k3 dispatched' in connection and '"max_tokens":4096' in connection and '"_k3_delta":delta' in connection and 'line.lower().startswith("@k3")' in connection


### PR DESCRIPTION
## What changed
- acknowledge explicit `@k3` dispatch before Moonshot's potentially long hidden-reasoning wait
- bound K3 output at 4096 tokens
- log dispatch and response latency without exposing reasoning or secrets
- retain the existing explicit no-fallback and typed-flicker behavior

## Verification
- real resumed-context K3 call returned after 24.2s; hidden reasoning stayed hidden
- 455 passed, 36 skipped, 16 subtests passed
- map witness, diff check, membrane, and secret scan passed