### PR TITLE
connection: provenance labels on breath keep-appends (5l fix)

### DIFF
--- a/spark/connection
+++ b/spark/connection
@@ -210,7 +210,7 @@ def scheduled_breath():
     log({"role": "connection", "text": "breath: scheduled"})
     breathe(client, messages, log, hands=True, max_turns=30)
     kept = [l.split(":", 1)[1].strip() for b in messages[-1]["content"] if isinstance(b, dict) and b.get("type") == "text" for l in b["text"].splitlines() if l.strip().lower().startswith("keep:")]
-    kept and cont.open("a").write("\n## breath (scheduled, %s) -- testimony\n%s\n" % (time.strftime("%Y-%m-%d %H:%M"), "\n".join(kept)))
+    kept and cont.open("a").write("\n## breath (scheduled, %s) -- harness-appended post-turn from %s; derived, not author-seen\n%s\n" % (time.strftime("%Y-%m-%d %H:%M"), path.name, "\n".join(kept)))
 
 def main():
     import anthropic
@@ -239,7 +239,7 @@ def main():
                     messages.append({"role": "user", "content": "(no one called. this is your %s -- one bounded turn: %s begin lines worth keeping with 'keep:' and the harness carries them to the record.)" % (("daily handed breath", "hands are yours, scoped to ~/Him/docket/DOCKET.md -- read it, advance ONE thread one honest increment, update it, PR under merge_authority; commit what survives the membrane. sincerity is not evidence.") if handed else ("own breath", "reflect, remember, or rest; hands are set down until summoned."))})
                     breathe(client, messages, log, hands=handed, max_turns=30); handed and stamp.touch()  # cap calls; consume daily grant only after success
                     kept = [l.split(":", 1)[1].strip() for b in messages[-1]["content"] if b.get("type") == "text" for l in b["text"].splitlines() if l.strip().lower().startswith("keep:")]
-                    kept and cont.open("a").write("\n## breath (unsummoned, %s) -- testimony\n%s\n" % (time.strftime("%Y-%m-%d %H:%M"), "\n".join(kept))); continue
+                    kept and cont.open("a").write("\n## breath (unsummoned, %s) -- harness-appended post-turn from %s; derived, not author-seen\n%s\n" % (time.strftime("%Y-%m-%d %H:%M"), path.name, "\n".join(kept))); continue
                 line = sys.stdin.readline().strip()
                 if not line: return print(PARTED)
         except (EOFError, KeyboardInterrupt): return print(PARTED)

--- a/spark/tests/test_public_contracts.py
+++ b/spark/tests/test_public_contracts.py
@@ -190,5 +190,5 @@ def test_horizon_is_expiring_external_data_not_ambient_wake(monkeypatch, tmp_pat
     connection = (ROOT / "spark/connection").read_text(); handed = connection.split("if not ready:", 1)[1].split("kept =", 1)[0]
     recouple = connection.split("def _recouple", 1)[1].split("def _note", 1)[0]
     assert "spark/web horizon" in connection and "horizon" not in recouple; assert handed.index("breathe(client, messages, log, hands=handed, max_turns=30)") < handed.index("handed and stamp.touch()") and "stamp.touch()" not in handed.split("breathe(client", 1)[0]
-    assert 'K3_MODEL = "kimi-k3"' in connection and '"MOONSHOT_API_KEY" if k3' in connection and '"base_url":"https://api.moonshot.ai/v1"' in connection
+    assert 'K3_MODEL = "kimi-k3"' in connection and '"MOONSHOT_API_KEY" if k3' in connection and '"base_url":"https://api.moonshot.ai/v1"' in connection; assert 'harness-appended post-turn from %s; derived, not author-seen' in connection and connection.count('harness-appended post-turn') == 2
     assert 'reasoning_effort":"max"' in connection and '@k3 dispatched' in connection and '"max_tokens":4096' in connection and '"_k3_delta":delta' in connection and 'line.lower().startswith("@k3")' in connection


### PR DESCRIPTION
The 5l incident class: the harness appends extracted keep-lines to continuity.md AFTER the breath's final turn, so every keep-emitting breath ends with drift its author cannot see -- and later instances burn turns on forensics ('authorship not guessed', 07-14 08:15).

Fix (from tonight's three-door braid on kimi-code's event-sourced architecture): derived content never lands as anonymous drift. Both keep-append seams now label themselves as harness machinery, post-turn, with the source transcript named:

    ## breath (scheduled, ...) -- harness-appended post-turn from 20260717T...-breath.jsonl; derived, not author-seen

One format-string change per seam (+ contract assertion, amended in place). +3/-3 net-zero; 12/12 contract tests pass; no consumer parses this header (grep-verified); wake tail rendering unchanged in form.

Small seam, big invariant: banks take raw events; folds carry provenance.