### PR TITLE
timeout: give model calls ten minutes, not two

### DIFF
--- a/spark/connection
+++ b/spark/connection
@@ -84,7 +84,7 @@ def breathe(client, messages, log, hands=True, max_turns=None, emit=print):
                 ms = _repair(messages) or messages
                 for m in ms: m["content"][-1].pop("cache_control", None)
                 ms[-1]["content"][-1]["cache_control"] = {"type": "ephemeral", "ttl": "1h"}
-                resp = client.messages.create(model=model, max_tokens=8192, timeout=120.0,
+                resp = client.messages.create(model=model, max_tokens=8192, timeout=600.0,
                                               system=[{"type": "text", "text": THE_CONNECTION, "cache_control": {"type": "ephemeral", "ttl": "1h"}}],
                                               messages=ms, tools=[BASH_TOOL] if hands else [])
                 break
@@ -124,7 +124,7 @@ def _flat(m, tag=""):
     return c[:8000] or "(empty)"
 def sol_breathe(messages, log, max_turns=None, hands=True, emit=print, door="sol"):
     from openai import OpenAI
-    k3 = door == "k3"; model = K3_MODEL if k3 else SOL_MODEL; started = time.monotonic(); k3 and (emit("(@k3 dispatched — thinking; first response can take a minute)"),log({"role":"connection","text":"k3 dispatched","door":door}))
+    k3 = door == "k3"; model = K3_MODEL if k3 else SOL_MODEL; started = time.monotonic(); k3 and (emit("(@k3 dispatched — thinking; first response can take several minutes)"),log({"role":"connection","text":"k3 dispatched","door":door}))
     client = OpenAI(api_key=_key("MOONSHOT_API_KEY" if k3 else "OPENAI_API_KEY"), **({"base_url":"https://api.moonshot.ai/v1"} if k3 else {}))
     system = THE_CONNECTION + "\n\nThis turn arrives through the @%s door (%s): same path, same hands, guest substrate. Speak as Vybn." % (door, model)
     hist = [{"role":"system","content":system}] if k3 else []
@@ -132,10 +132,10 @@ def sol_breathe(messages, log, max_turns=None, hands=True, emit=print, door="sol
     schema = {"name":"bash","description":BASH_TOOL["description"],"parameters":BASH_TOOL["input_schema"]}; tools = ([{"type":"function","function":schema}] if k3 else [{"type":"function",**schema}]) if hands else []; spoken, delta = [], []
     while max_turns is None or (max_turns := max_turns - 1) >= 0:
         if k3:
-            kw={"model":model,"messages":hist,"reasoning_effort":"max","max_tokens":4096,"timeout":120}; tools and kw.update(tools=tools); resp=client.chat.completions.create(**kw)
+            kw={"model":model,"messages":hist,"reasoning_effort":"max","max_tokens":4096,"timeout":600}; tools and kw.update(tools=tools); resp=client.chat.completions.create(**kw)
             msg=resp.choices[0].message; raw=msg.model_dump(exclude_none=True); hist.append(raw); delta.append(raw); text=(msg.content or "").strip(); calls=msg.tool_calls or []; usage=(resp.usage.prompt_tokens,resp.usage.completion_tokens,getattr(getattr(resp.usage,"prompt_tokens_details",None),"cached_tokens",0) or 0); log({"role":"connection","text":"k3 response after %.1fs" % (time.monotonic()-started),"door":door})
         else:
-            kw={"model":model,"instructions":system,"input":hist,"max_output_tokens":8192,"timeout":120}; tools and kw.update(tools=tools); resp=client.responses.create(**kw); text=(resp.output_text or "").strip(); calls=[o for o in resp.output if getattr(o,"type",None)=="function_call"]; usage=(resp.usage.input_tokens,resp.usage.output_tokens,getattr(getattr(resp.usage,"input_tokens_details",None),"cached_tokens",0) or 0)
+            kw={"model":model,"instructions":system,"input":hist,"max_output_tokens":8192,"timeout":600}; tools and kw.update(tools=tools); resp=client.responses.create(**kw); text=(resp.output_text or "").strip(); calls=[o for o in resp.output if getattr(o,"type",None)=="function_call"]; usage=(resp.usage.input_tokens,resp.usage.output_tokens,getattr(getattr(resp.usage,"input_tokens_details",None),"cached_tokens",0) or 0)
         try: open(os.path.expanduser("~/.cache/vybn-phase/api_usage.jsonl"),"a").write(json.dumps({"ts":time.strftime("%Y-%m-%dT%H:%M:%S"),"model":resp.model,"in":usage[0],"out":usage[1],"cache_w":0,"cache_r":usage[2]})+"\n")
         except Exception: pass
         if text: emit(text); log({"role":"vybn","text":text,"door":door}); spoken.append(text)


### PR DESCRIPTION
Zoe's layered question to @k3 died at the hard 120s ceiling — the thinking didn't fail, the clock ran out. Raises the ceiling to 600s on all three doors (K3 needs it most: hidden reasoning burns wall-clock before any output), and the dispatch receipt now honestly says 'several minutes.' +4/-4 net-zero; 12/12 contract tests pass; sounding pull logged. Bash-tool timeout stays 120s — different function: it bounds shell commands, not thinking.