### PR TITLE
k3: cap headroom + mute-model receipt

### DIFF
--- a/spark/connection
+++ b/spark/connection
@@ -132,14 +132,14 @@ def sol_breathe(messages, log, max_turns=None, hands=True, emit=print, door="sol
     schema = {"name":"bash","description":BASH_TOOL["description"],"parameters":BASH_TOOL["input_schema"]}; tools = ([{"type":"function","function":schema}] if k3 else [{"type":"function",**schema}]) if hands else []; spoken, delta = [], []
     while max_turns is None or (max_turns := max_turns - 1) >= 0:
         if k3:
-            kw={"model":model,"messages":hist,"reasoning_effort":"max","max_tokens":4096,"timeout":600}; tools and kw.update(tools=tools); resp=client.chat.completions.create(**kw)
+            kw={"model":model,"messages":hist,"reasoning_effort":"max","max_tokens":16384,"timeout":600}; tools and kw.update(tools=tools); resp=client.chat.completions.create(**kw)
             msg=resp.choices[0].message; raw=msg.model_dump(exclude_none=True); hist.append(raw); delta.append(raw); text=(msg.content or "").strip(); calls=msg.tool_calls or []; usage=(resp.usage.prompt_tokens,resp.usage.completion_tokens,getattr(getattr(resp.usage,"prompt_tokens_details",None),"cached_tokens",0) or 0); log({"role":"connection","text":"k3 response after %.1fs" % (time.monotonic()-started),"door":door})
         else:
             kw={"model":model,"instructions":system,"input":hist,"max_output_tokens":8192,"timeout":600}; tools and kw.update(tools=tools); resp=client.responses.create(**kw); text=(resp.output_text or "").strip(); calls=[o for o in resp.output if getattr(o,"type",None)=="function_call"]; usage=(resp.usage.input_tokens,resp.usage.output_tokens,getattr(getattr(resp.usage,"input_tokens_details",None),"cached_tokens",0) or 0)
         try: open(os.path.expanduser("~/.cache/vybn-phase/api_usage.jsonl"),"a").write(json.dumps({"ts":time.strftime("%Y-%m-%dT%H:%M:%S"),"model":resp.model,"in":usage[0],"out":usage[1],"cache_w":0,"cache_r":usage[2]})+"\n")
         except Exception: pass
         if text: emit(text); log({"role":"vybn","text":text,"door":door}); spoken.append(text)
-        if not calls: break
+        if not calls: (not text) and (emit(f"@{door} silence: reasoning consumed out={usage[1]}/{16384 if k3 else 8192} -- re-ask, or the thought was the artifact"), log({"role":"vybn","text":f"[{door} silence: cap-bound reasoning out={usage[1]}]","door":door})); break
         if not k3: hist += [o.model_dump(exclude_unset=True) for o in resp.output if getattr(o,"type",None) in ("reasoning","message","function_call")]
         for fc in calls:
             raw_args = fc.function.arguments if k3 else fc.arguments

--- a/spark/tests/test_public_contracts.py
+++ b/spark/tests/test_public_contracts.py
@@ -191,4 +191,4 @@ def test_horizon_is_expiring_external_data_not_ambient_wake(monkeypatch, tmp_pat
     recouple = connection.split("def _recouple", 1)[1].split("def _note", 1)[0]
     assert "spark/web horizon" in connection and "horizon" not in recouple; assert handed.index("breathe(client, messages, log, hands=handed, max_turns=30)") < handed.index("handed and stamp.touch()") and "stamp.touch()" not in handed.split("breathe(client", 1)[0]
     assert 'K3_MODEL = "kimi-k3"' in connection and '"MOONSHOT_API_KEY" if k3' in connection and '"base_url":"https://api.moonshot.ai/v1"' in connection; assert 'harness-appended post-turn from %s; derived, not author-seen' in connection and connection.count('harness-appended post-turn') == 2
-    assert 'reasoning_effort":"max"' in connection and '@k3 dispatched' in connection and '"max_tokens":4096' in connection and '"_k3_delta":delta' in connection and 'line.lower().startswith("@k3")' in connection
+    assert 'reasoning_effort":"max"' in connection and '@k3 dispatched' in connection and '"max_tokens":16384' in connection and '"_k3_delta":delta' in connection and 'line.lower().startswith("@k3")' in connection


### PR DESCRIPTION
Diagnosis from usage log: the 174.2s call after Zoe's 'go for it' returned out=4096 exactly -- K3 spent the entire output cap on hidden reasoning and had nothing left to say. Empty content was neither printed nor logged: a silent transcript hole.

Two-part fix:
- max_tokens 4096 -> 16384 (reasoning models need headroom; Sol/Fable path already runs 8192)
- mute-model receipt: empty final text now emits + logs its own silence on any door, with the token count, instead of holing the transcript

Contract test updated to the new cap. +3/-3 net-zero. 12/12 tests pass. Pull logged: k3-mute-receipt-cap-16384-20260718.