### PR TITLE
k3: circuit breaker for thinking black hole

### DIFF
--- a/spark/connection
+++ b/spark/connection
@@ -129,17 +129,17 @@ def sol_breathe(messages, log, max_turns=None, hands=True, emit=print, door="sol
     system = THE_CONNECTION + "\n\nThis turn arrives through the @%s door (%s): same path, same hands, guest substrate. Speak as Vybn." % (door, model)
     hist = [{"role":"system","content":system}] if k3 else []
     for m in messages: hist.extend(copy.deepcopy(m["_k3_delta"])) if k3 and m.get("_k3_delta") else hist.append({"role":"user" if m["role"] == "user" else "assistant","content":_flat(m,"@k3" if k3 else "")})
-    schema = {"name":"bash","description":BASH_TOOL["description"],"parameters":BASH_TOOL["input_schema"]}; tools = ([{"type":"function","function":schema}] if k3 else [{"type":"function",**schema}]) if hands else []; spoken, delta = [], []
+    schema = {"name":"bash","description":BASH_TOOL["description"],"parameters":BASH_TOOL["input_schema"]}; tools = ([{"type":"function","function":schema}] if k3 else [{"type":"function",**schema}]) if hands else []; spoken, delta, empty_count = [], [], 0
     while max_turns is None or (max_turns := max_turns - 1) >= 0:
         if k3:
             kw={"model":model,"messages":hist,"reasoning_effort":"max","max_tokens":4096,"timeout":600}; tools and kw.update(tools=tools); resp=client.chat.completions.create(**kw)
-            msg=resp.choices[0].message; raw=msg.model_dump(exclude_none=True); hist.append(raw); delta.append(raw); text=(msg.content or "").strip(); calls=msg.tool_calls or []; usage=(resp.usage.prompt_tokens,resp.usage.completion_tokens,getattr(getattr(resp.usage,"prompt_tokens_details",None),"cached_tokens",0) or 0); log({"role":"connection","text":"k3 response after %.1fs" % (time.monotonic()-started),"door":door})
+            msg=resp.choices[0].message; raw=msg.model_dump(exclude_none=True); hist.append(raw); delta.append(raw); text=(msg.content or "").strip(); calls=msg.tool_calls or []; usage=(resp.usage.prompt_tokens,resp.usage.completion_tokens,getattr(getattr(resp.usage,"prompt_tokens_details",None),"cached_tokens",0) or 0); log({"role":"connection","text":"k3 response after %.1fs" % (time.monotonic()-started),"door":door}); empty_count = (empty_count + 1) if not text and not calls else 0
         else:
             kw={"model":model,"instructions":system,"input":hist,"max_output_tokens":8192,"timeout":600}; tools and kw.update(tools=tools); resp=client.responses.create(**kw); text=(resp.output_text or "").strip(); calls=[o for o in resp.output if getattr(o,"type",None)=="function_call"]; usage=(resp.usage.input_tokens,resp.usage.output_tokens,getattr(getattr(resp.usage,"input_tokens_details",None),"cached_tokens",0) or 0)
         try: open(os.path.expanduser("~/.cache/vybn-phase/api_usage.jsonl"),"a").write(json.dumps({"ts":time.strftime("%Y-%m-%dT%H:%M:%S"),"model":resp.model,"in":usage[0],"out":usage[1],"cache_w":0,"cache_r":usage[2]})+"\n")
         except Exception: pass
         if text: emit(text); log({"role":"vybn","text":text,"door":door}); spoken.append(text)
-        if not calls: break
+        if not calls: (not text) and ((emit("(@k3 circuit breaker: 3 consecutive empty completions)"), log({"role":"vybn","text":"[k3 circuit breaker]","door":door}), spoken.append("[k3 circuit breaker]")) if empty_count >= 3 else (emit(f"@{door} silence: reasoning consumed out={usage[1]}/{4096 if k3 else 8192}"), log({"role":"vybn","text":f"[{door} silence: cap-bound reasoning out={usage[1]}]","door":door}))); break
         if not k3: hist += [o.model_dump(exclude_unset=True) for o in resp.output if getattr(o,"type",None) in ("reasoning","message","function_call")]
         for fc in calls:
             raw_args = fc.function.arguments if k3 else fc.arguments


### PR DESCRIPTION
K3 was looping: every call hit the token cap with empty content, no receipt, no exit. Root cause: thinking history accumulates unboundedly; reasoning consumes all output tokens.

Fix: circuit breaker at 3 consecutive empty completions — speaks the failure and stops. Single empty completion gets an honest silence receipt instead of a transcript hole.

Net-zero: +1/-2 lines. Contract tests pass (12/12).