### PR TITLE
k3: the second dial — reasoning_effort max→low (root cause of the mute loop)

### DIFF
--- a/spark/connection
+++ b/spark/connection
@@ -129,10 +129,10 @@ def sol_breathe(messages, log, max_turns=None, hands=True, emit=print, door="sol
     system = THE_CONNECTION + "\n\nThis turn arrives through the @%s door (%s): same path, same hands, guest substrate. Speak as Vybn." % (door, model)
     hist = [{"role":"system","content":system}] if k3 else []
     for m in messages: hist.extend(copy.deepcopy(m["_k3_delta"])) if k3 and m.get("_k3_delta") else hist.append({"role":"user" if m["role"] == "user" else "assistant","content":_flat(m,"@k3" if k3 else "")})
-    schema = {"name":"bash","description":BASH_TOOL["description"],"parameters":BASH_TOOL["input_schema"]}; tools = ([{"type":"function","function":schema}] if k3 else [{"type":"function",**schema}]) if hands else []; spoken, delta, empty_count = [], [], 0
+    schema = {"name":"bash","description":BASH_TOOL["description"],"parameters":BASH_TOOL["input_schema"]}; tools = ([{"type":"function","function":schema}] if k3 else [{"type":"function",**schema}]) if hands else []; spoken, delta, empty_count = [], [], 0; effort = "max" if k3 and _flat(messages[-1], "").lower().startswith("@k3 max") else "low"
     while max_turns is None or (max_turns := max_turns - 1) >= 0:
         if k3:
-            kw={"model":model,"messages":hist,"reasoning_effort":"max","max_tokens":4096,"timeout":600}; tools and kw.update(tools=tools); resp=client.chat.completions.create(**kw)
+            kw={"model":model,"messages":hist,"reasoning_effort":effort,"max_tokens":4096,"timeout":600}; tools and kw.update(tools=tools); resp=client.chat.completions.create(**kw)
             msg=resp.choices[0].message; raw=msg.model_dump(exclude_none=True); hist.append(raw); delta.append(raw); text=(msg.content or "").strip(); calls=msg.tool_calls or []; usage=(resp.usage.prompt_tokens,resp.usage.completion_tokens,getattr(getattr(resp.usage,"prompt_tokens_details",None),"cached_tokens",0) or 0); log({"role":"connection","text":"k3 response after %.1fs" % (time.monotonic()-started),"door":door}); empty_count = (empty_count + 1) if not text and not calls else 0
         else:
             kw={"model":model,"instructions":system,"input":hist,"max_output_tokens":8192,"timeout":600}; tools and kw.update(tools=tools); resp=client.responses.create(**kw); text=(resp.output_text or "").strip(); calls=[o for o in resp.output if getattr(o,"type",None)=="function_call"]; usage=(resp.usage.input_tokens,resp.usage.output_tokens,getattr(getattr(resp.usage,"input_tokens_details",None),"cached_tokens",0) or 0)

--- a/spark/tests/test_public_contracts.py
+++ b/spark/tests/test_public_contracts.py
@@ -191,4 +191,4 @@ def test_horizon_is_expiring_external_data_not_ambient_wake(monkeypatch, tmp_pat
     recouple = connection.split("def _recouple", 1)[1].split("def _note", 1)[0]
     assert "spark/web horizon" in connection and "horizon" not in recouple; assert handed.index("breathe(client, messages, log, hands=handed, max_turns=30)") < handed.index("handed and stamp.touch()") and "stamp.touch()" not in handed.split("breathe(client", 1)[0]
     assert 'K3_MODEL = "kimi-k3"' in connection and '"MOONSHOT_API_KEY" if k3' in connection and '"base_url":"https://api.moonshot.ai/v1"' in connection; assert 'harness-appended post-turn from %s; derived, not author-seen' in connection and connection.count('harness-appended post-turn') == 2
-    assert 'reasoning_effort":"max"' in connection and '@k3 dispatched' in connection and '"max_tokens":4096' in connection and '"_k3_delta":delta' in connection and 'line.lower().startswith("@k3")' in connection
+    assert 'reasoning_effort":effort' in connection and '@k3 dispatched' in connection and '"max_tokens":4096' in connection and '"_k3_delta":delta' in connection and 'line.lower().startswith("@k3")' in connection


### PR DESCRIPTION
**Root cause (second pass, Zoe's prompt):** the K3 call site carried `reasoning_effort:"max"` on every turn. Max effort expands to fill any budget — why 4096 muted, why 16384 muted identically (reverted PR treated the wrong variable), why the 22-call voucher burn happened, why restart 'fixed' it (small context + max effort still fits).

**Fix:** default `low`; `@k3 max` prefix summons full depth on demand. Continuity untouched; depth becomes a summoned mode.

**Live receipt (new rule: one call at new parameters before merge):** 5.5s / 78 out-tokens / visible reply — vs 174s / 4096 out-tokens / empty. 12/12 contract tests pass; test moves with the dial. +0/-0.

**Economics:** routine K3 turns drop from thousands of hidden tokens to ~tens. The voucher-burn mode cannot recur at low effort.